### PR TITLE
Build docker images using github actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,112 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**/Dockerfile'
+      - 'src/**/*.py'
+      - '.github/workflows/docker-build.yml'
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository_owner }}/openenv
+
+jobs:
+  # Job 1: Build base image first
+  build-base:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for base image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-base
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: src/core/containers/images/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,mode=max,scope=base
+  # Job 2: Build environment images (depends on base)
+  build-envs:
+    runs-on: ubuntu-latest
+    needs: build-base  # Wait for base image to be built
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        image:
+          - name: echo-env
+            dockerfile: src/envs/echo_env/server/Dockerfile
+          - name: chat-env
+            dockerfile: src/envs/chat_env/server/Dockerfile
+          - name: coding-env
+            dockerfile: src/envs/coding_env/server/Dockerfile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ matrix.image.name }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Build and push environment image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-base:latest

--- a/src/core/containers/images/Dockerfile
+++ b/src/core/containers/images/Dockerfile
@@ -5,20 +5,20 @@
 # LICENSE file in the root directory of this source tree.
 
 #
-# EnvTorch Base Image
+# OpenEnv Base Image
 #
-# This is the standard base image for all EnvTorch environment servers.
+# This is the standard base image for all OpenEnv environment servers.
 # It includes the minimal dependencies needed to run HTTP environment servers.
 #
-# Build: docker build -t envtorch-base:latest -f src/core/containers/images/Dockerfile .
-# Tag:   docker tag envtorch-base:latest envtorch-base:0.1.0
+# Build: docker build -t openenv-base:latest -f src/core/containers/images/Dockerfile .
+# Tag:   docker tag openenv-base:latest openenv-base:0.1.0
 #
 
 FROM python:3.11-slim
 
 # Set metadata
-LABEL maintainer="EnvTorch Team"
-LABEL description="Base image for EnvTorch environment servers"
+LABEL maintainer="OpenEnv Team"
+LABEL description="Base image for OpenEnv based environment servers"
 LABEL version="0.1.0"
 
 # Install system dependencies

--- a/src/core/containers/images/README.md
+++ b/src/core/containers/images/README.md
@@ -1,20 +1,19 @@
-# EnvTorch Base Container Images
+# OpenEnv Base Image
 
-This directory contains base container image Dockerfiles used by all EnvTorch environment servers.
+Standard base image for all OpenEnv environment servers.
 
-## Why Base Images?
+## What's Included
 
-Using standardized base images prevents **image cardinality explosion** when multiple environments are created. Instead of each environment building its own complete image from scratch, they all share a common base.
+| Layer | Size | Contents |
+|-------|------|----------|
+| python:3.11-slim | 200 MB  | Base Python runtime |
+| + Dependencies   | 100 MB  | FastAPI, uvicorn, requests |
+| **Total**        | **~300 MB** | Ready for environment servers |
 
-### Benefits
+## Image Sizes
 
-✅ **Reduced build times** - Environments only copy their specific files
-✅ **Smaller total storage** - Base layers are shared across all environments
-✅ **Consistent dependencies** - All environments use the same FastAPI/uvicorn versions
-✅ **Easier maintenance** - Update dependencies in one place
-✅ **Faster deployments** - Base image can be pre-pulled on servers
-
-### Without Base Images (❌ Problem)
+```
+openenv-base:latest   300 MB  (python + fastapi + uvicorn)
 ```
 echo-env:latest        500 MB  (python + fastapi + uvicorn + app)
 coding-env:latest      520 MB  (python + fastapi + uvicorn + app + tools)
@@ -25,7 +24,7 @@ Total: 1.5 GB (with lots of duplication)
 
 ### With Base Images (✅ Solution)
 ```
-envtorch-base:latest   300 MB  (python + fastapi + uvicorn)
+openenv-base:latest    300 MB  (python + fastapi + uvicorn)
 echo-env:latest         50 MB  (app only, uses base)
 coding-env:latest       70 MB  (app + tools, uses base)
 another-env:latest      45 MB  (app only, uses base)
@@ -37,7 +36,7 @@ Total: 465 MB (base shared, minimal duplication)
 
 ```bash
 # From project root
-docker build -t envtorch-base:latest -f src/core/containers/images/Dockerfile .
+docker build -t openenv-base:latest -f src/core/containers/images/Dockerfile .
 ```
 
 ## Usage in Environment Dockerfiles
@@ -45,7 +44,7 @@ docker build -t envtorch-base:latest -f src/core/containers/images/Dockerfile .
 Each environment Dockerfile should start with:
 
 ```dockerfile
-FROM envtorch-base:latest
+FROM openenv-base:latest
 
 # Copy only environment-specific files
 COPY src/core/ /app/src/core/
@@ -67,7 +66,7 @@ CMD ["uvicorn", "envs.my_env.server.app:app", "--host", "0.0.0.0", "--port", "80
 
 ```bash
 # Step 1: Build base image (do this once)
-docker build -t envtorch-base:latest -f src/core/containers/images/Dockerfile .
+docker build -t openenv-base:latest -f src/core/containers/images/Dockerfile .
 
 # Step 2: Build echo environment (uses base)
 docker build -t echo-env:latest -f src/envs/echo_env/server/Dockerfile .
@@ -86,7 +85,7 @@ When dependencies need updating:
 
 ```bash
 # Update base
-docker build -t envtorch-base:latest -f src/core/containers/images/Dockerfile .
+docker build -t openenv-base:latest -f src/core/containers/images/Dockerfile .
 
 # Rebuild environments (they automatically use new base)
 docker build -t echo-env:latest -f src/envs/echo_env/server/Dockerfile .

--- a/src/envs/chat_env/server/Dockerfile
+++ b/src/envs/chat_env/server/Dockerfile
@@ -4,9 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Use the standard envtorch base image
-# Built from: docker build -t envtorch-base:latest -f src/core/containers/images/Dockerfile .
-FROM envtorch-base:latest
+# Use the standard openenv base image
+# Built from: docker build -t openenv-base:latest -f src/core/containers/images/Dockerfile .
+# In GitHub Actions, this is overridden to use the GHCR base image
+ARG BASE_IMAGE=openenv-base:latest
+FROM ${BASE_IMAGE}
 
 # Install additional dependencies for ChatEnvironment
 RUN pip install torch transformers

--- a/src/envs/coding_env/server/Dockerfile
+++ b/src/envs/coding_env/server/Dockerfile
@@ -4,9 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Use the standard envtorch base image
-# Built from: docker build -t envtorch-base:latest -f src/core/containers/images/Dockerfile .
-FROM envtorch-base:latest
+# Use the standard openenv base image
+# Built from: docker build -t openenv-base:latest -f src/core/containers/images/Dockerfile .
+# In GitHub Actions, this is overridden to use the GHCR base image
+ARG BASE_IMAGE=openenv-base:latest
+FROM ${BASE_IMAGE}
 
 # Install smolagents for code execution
 RUN pip install --no-cache-dir smolagents

--- a/src/envs/echo_env/server/Dockerfile
+++ b/src/envs/echo_env/server/Dockerfile
@@ -4,9 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Use the standard envtorch base image
-# Built from: docker build -t envtorch-base:latest -f src/core/containers/images/Dockerfile .
-FROM envtorch-base:latest
+# Use the standard openenv base image
+# Built from: docker build -t openenv-base:latest -f src/core/containers/images/Dockerfile .
+# In GitHub Actions, this is overridden to use the GHCR base image
+ARG BASE_IMAGE=openenv-base:latest
+FROM ${BASE_IMAGE}
 
 # Copy only what's needed for this environment
 COPY src/core/ /app/src/core/


### PR DESCRIPTION
This change enables git hub actions for building images and also renames env torch to openenv. 