### PR TITLE
feat(ci): automatically sync RFC PRs to roadmap project

### DIFF
--- a/.github/workflows/rfc-to-roadmap.yml
+++ b/.github/workflows/rfc-to-roadmap.yml
@@ -1,0 +1,149 @@
+name: RFC → Project Roadmap
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, reopened, closed, ready_for_review, converted_to_draft, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  projects: write
+
+jobs:
+  update-project:
+    if: >
+      github.event.pull_request && 
+      (
+        contains(github.event.pull_request.title, 'RFC') ||
+        contains(join(github.event.pull_request.labels.*.name, ','), 'rfc') ||
+        startsWith(github.event.pull_request.head.ref, 'rfc/')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to Project
+        uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/orgs/meta-pytorch/projects/9
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Fetch IDs we need (project, item, Status field + option IDs)
+      - name: Resolve Project + Field IDs
+        id: ids
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const projectUrl = 'https://github.com/orgs/meta-pytorch/projects/9';
+            const projectNumber = 9;
+            const org = 'meta-pytorch';
+
+            // 1) Get project ID + fields (including Status and its options)
+            const projResp = await github.graphql(`
+              query($org: String!, $number: Int!) {
+                organization(login: $org) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 50) {
+                      nodes {
+                        ... on ProjectV2FieldCommon { id name }
+                        ... on ProjectV2SingleSelectField {
+                          id name
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { org, number: projectNumber });
+
+            const project = projResp.organization.projectV2;
+            const projectId = project.id;
+
+            // Find Status field and option IDs
+            const statusField = project.fields.nodes.find(f => f.name === 'Status');
+            if (!statusField) throw new Error('Status field not found on project');
+
+            const unprioritized = statusField.options.find(o => o.name.toLowerCase() === 'unprioritized');
+            const planned = statusField.options.find(o => o.name.toLowerCase() === 'planned' || o.name.toLowerCase() === 'committed');
+
+            core.setOutput('projectId', projectId);
+            core.setOutput('statusFieldId', statusField.id);
+            core.setOutput('unprioritizedId', unprioritized ? unprioritized.id : '');
+            core.setOutput('plannedId', planned ? planned.id : '');
+
+            // 2) Get the PR node ID and ensure there is a project item for it
+            const prNodeId = context.payload.pull_request.node_id;
+
+            const addItemResp = await github.graphql(`
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item { id }
+                }
+              }
+            `, { projectId, contentId: prNodeId }).catch(e => {
+              // If it already exists, that's fine; we'll look it up below
+              return null;
+            });
+
+            // Look up the project item for this PR
+            const itemQuery = await github.graphql(`
+              query($org: String!, $number: Int!, $prId: ID!) {
+                organization(login: $org) {
+                  projectV2(number: $number) {
+                    items(first: 50, query: "") {
+                      nodes {
+                        id
+                        content { ... on PullRequest { id } }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { org, number: projectNumber, prId: prNodeId });
+
+            const item = itemQuery.organization.projectV2.items.nodes.find(n => n.content && n.content.id === prNodeId);
+            if (!item) throw new Error('Project item not found or could not be created');
+
+            core.setOutput('itemId', item.id);
+
+      - name: Set Status based on PR state
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const itemId = "${{ steps.ids.outputs.itemId }}";
+            const projectId = "${{ steps.ids.outputs.projectId }}";
+            const statusFieldId = "${{ steps.ids.outputs.statusFieldId }}";
+            const unprioritizedId = "${{ steps.ids.outputs.unprioritizedId }}";
+            const plannedId = "${{ steps.ids.outputs.plannedId }}";
+
+            const pr = context.payload.pull_request;
+
+            // Decide target option
+            let optionId = null;
+            if (pr.merged) {
+              optionId = plannedId || unprioritizedId;
+            } else {
+              // On open/label/reopen/etc. → Unprioritized
+              optionId = unprioritizedId || plannedId;
+            }
+
+            if (!optionId) {
+              core.warning('Could not find matching Status option; skipping update');
+              return;
+            }
+
+            await github.graphql(`
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $projectId,
+                  itemId: $itemId,
+                  fieldId: $fieldId,
+                  value: { singleSelectOptionId: $optionId }
+                }) { projectV2Item { id } }
+              }
+            `, { projectId, itemId, fieldId: statusFieldId, optionId });
+


### PR DESCRIPTION
Adds a GitHub Actions workflow that keeps the project roadmap in sync with RFC pull requests:
- When an RFC PR is opened, it’s added to the “Unprioritized” section of the roadmap.
- When the RFC PR is merged, its status is updated to “Planned.”

Uses `actions/add-to-project` and GraphQL mutations to manage ProjectV2 items and status updates.