### PR TITLE
Fix example notebook for all themes

### DIFF
--- a/examples/OpenEnv_Tutorial.ipynb
+++ b/examples/OpenEnv_Tutorial.ipynb
@@ -638,7 +638,7 @@
    "source": [
     "### How the Client Works\n",
     "\n",
-    "<div style=\"background-color: #e7f3ff; padding: 15px; border-radius: 5px; margin: 20px 0;\">\n",
+    "<div style=\"background-color: rgba(128, 128, 128, 0.1); padding: 20px; border-radius: 10px; margin: 20px 0; border: 1px solid rgba(128, 128, 128, 0.2);\">\n",
     "\n",
     "The client **inherits from HTTPEnvClient** and implements 3 methods:\n",
     "\n",
@@ -719,7 +719,7 @@
     "</tr>\n",
     "</table>\n",
     "\n",
-    "<div style=\"background-color: #d4edda; padding: 15px; border-left: 5px solid #28a745; margin: 20px 0;\">\n",
+    "<div style=\"background-color: rgba(128, 128, 128, 0.1); padding: 20px; border-radius: 10px; margin: 20px 0; border: 1px solid rgba(128, 128, 128, 0.2);\">\n",
     "\n",
     "**🎯 Why Catch?**\n",
     "- Simple rules (easy to understand)\n",


### PR DESCRIPTION
Hi. I was reading the tutorial and noticed that some of the styling makes it unreadable with dark themes due to coloring. This fixes it with a simple opacity change. 

# Before

<img width="1039" height="363" alt="image" src="https://github.com/user-attachments/assets/918ad5d7-c929-43f7-a84b-e8883a1cdd1a" />

# After

<img width="1048" height="515" alt="image" src="https://github.com/user-attachments/assets/6bd079e5-33d5-4819-b0da-da0cdc33bd66" />

