### PR TITLE
Fix atari example script

### DIFF
--- a/examples/atari_simple.py
+++ b/examples/atari_simple.py
@@ -24,7 +24,7 @@ def main():
     """Run a simple Atari episode."""
     # Connect to the Atari environment server
     print("Connecting to Atari environment...")
-    env = AtariEnv(base_url="http://localhost:8000")
+    env = AtariEnv.from_docker_image("ghcr.io/meta-pytorch/openenv-atari-env:latest")
 
     try:
         # Reset the environment


### PR DESCRIPTION
When testing `python examples/atari_simple.py` this `TypeError` was raised so I fixed it by casting the `action_id` to a JSON compatible `int`. 

```sh
  File "/admin/home/benjamin_burtenshaw/.local/share/uv/python/cpython-3.12.9-linux-x86_64-gnu/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type int64 is not JSON serializable
```

🙋 I could also see this being fixed in `AtariEnv` or `HTTPEnvClient` with a json serializer methods. If you're open to contributions there. 

