### PR TITLE
cleanup the hf deploy and docker logic

### DIFF
--- a/scripts/prepare_hf_deployment.sh
+++ b/scripts/prepare_hf_deployment.sh
@@ -5,6 +5,18 @@
 
 set -e
 
+# Cross-platform sed in-place editing
+# BSD sed (macOS) requires -i '', GNU sed (Linux) requires -i
+sed_inplace() {
+    if sed --version >/dev/null 2>&1; then
+        # GNU sed
+        sed -i "$@"
+    else
+        # BSD sed
+        sed -i '' "$@"
+    fi
+}
+
 ENV_NAME="$1"
 BASE_IMAGE_SHA="$2"
 STAGING_DIR="hf-staging"
@@ -41,288 +53,118 @@ echo "Copied core files"
 cp -r src/envs/$ENV_NAME/* $CURRENT_STAGING_DIR/src/envs/$ENV_NAME/
 echo "Copied $ENV_NAME environment files"
 
-# Create environment-specific multi-stage Dockerfile
+# Copy and modify the static Dockerfile from the environment
 create_environment_dockerfile() {
     local env_name=$1
-    
-    # Create base Dockerfile
-    cat > $CURRENT_STAGING_DIR/Dockerfile << DOCKERFILE_EOF
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+    local dockerfile_path="src/envs/$env_name/server/Dockerfile"
+    local prepare_script="src/envs/$env_name/server/prepare_hf.sh"
 
-# Use the specified openenv-base image
-FROM $BASE_IMAGE_REF
-DOCKERFILE_EOF
+    if [ ! -f "$dockerfile_path" ]; then
+        echo "Error: Dockerfile not found at $dockerfile_path"
+        exit 1
+    fi
 
-    # Add environment-specific dependencies
-    case $env_name in
-        "echo_env")
-            # Echo environment needs no additional dependencies
-            ;;
-        "coding_env")
-            cat >> $CURRENT_STAGING_DIR/Dockerfile << 'DOCKERFILE_EOF'
-# Install smolagents for code execution
-RUN pip install --no-cache-dir smolagents
-DOCKERFILE_EOF
-            ;;
-        "chat_env")
-            cat >> $CURRENT_STAGING_DIR/Dockerfile << 'DOCKERFILE_EOF'
-# Install additional dependencies for ChatEnvironment
-RUN pip install --no-cache-dir torch transformers
+    # Copy the static Dockerfile
+    cp "$dockerfile_path" "$CURRENT_STAGING_DIR/Dockerfile"
+    echo "Copied static Dockerfile from $dockerfile_path"
 
-# Set up cache directory for Hugging Face models
-RUN mkdir -p /.cache && chmod 777 /.cache
-ENV HF_HOME=/.cache
-ENV TRANSFORMERS_CACHE=/.cache
+    # Check if environment has custom HF preparation script
+    if [ -f "$prepare_script" ]; then
+        echo "Found custom HF preparation script, executing..."
+        chmod +x "$prepare_script"
+        "$prepare_script" "$CURRENT_STAGING_DIR/Dockerfile" "$BASE_IMAGE_REF"
+    else
+        # Standard Dockerfile modification: replace ARG BASE_IMAGE with FROM
+        sed_inplace "s|ARG BASE_IMAGE=.*||g" "$CURRENT_STAGING_DIR/Dockerfile"
+        sed_inplace "s|FROM \${BASE_IMAGE}|FROM $BASE_IMAGE_REF|g" "$CURRENT_STAGING_DIR/Dockerfile"
+        echo "Modified Dockerfile with base image: $BASE_IMAGE_REF"
+    fi
 
-# Pre-download the GPT-2 model to avoid permission issues during runtime
-RUN python -c "from transformers import GPT2Tokenizer; GPT2Tokenizer.from_pretrained('gpt2')"
-DOCKERFILE_EOF
-            ;;
-        "atari_env")
-            cat >> $CURRENT_STAGING_DIR/Dockerfile << 'DOCKERFILE_EOF'
-# Install ALE-specific dependencies
-RUN pip install --no-cache-dir \
-    gymnasium>=0.29.0 \
-    ale-py>=0.8.0 \
-    numpy>=1.24.0
-DOCKERFILE_EOF
-            ;;
-        "openspiel_env")
-            # OpenSpiel requires special C++ build process - replace entire Dockerfile
-            cat > $CURRENT_STAGING_DIR/Dockerfile << DOCKERFILE_EOF
-# OpenSpiel environment using pre-built OpenSpiel base image
-ARG OPENSPIEL_BASE_IMAGE=ghcr.io/meta-pytorch/openenv-openspiel-base:sha-e622c7e
-FROM \${OPENSPIEL_BASE_IMAGE}
-
-# Copy OpenEnv core (base image already set WORKDIR=/app)
-WORKDIR /app
-COPY src/core/ /app/src/core/
-
-# Copy OpenSpiel environment
-COPY src/envs/openspiel_env/ /app/src/envs/openspiel_env/
-
-# Copy README for web interface documentation
-COPY src/envs/openspiel_env/README.md /app/README.md
-
-# Extend Python path for OpenEnv (base image set PYTHONPATH=/app/src)
-# We prepend OpenSpiel paths
-ENV PYTHONPATH=/repo:/repo/build/python:/app/src
-
-# OpenSpiel-specific environment variables (can be overridden at runtime)
-ENV OPENSPIEL_GAME=catch
-ENV OPENSPIEL_AGENT_PLAYER=0
-ENV OPENSPIEL_OPPONENT_POLICY=random
-
-# Health check (curl is provided by openenv-base)
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
-
-# Note: EXPOSE 8000 already set by openenv-base
-
-# Run the FastAPI server (uvicorn installed by openenv-base)
-CMD ["uvicorn", "envs.openspiel_env.server.app:app", "--host", "0.0.0.0", "--port", "8000"]
-DOCKERFILE_EOF
-            echo "Created special OpenSpiel Dockerfile with C++ build process"
-            echo "OpenSpiel builds can take 10-15 minutes due to C++ compilation"
-            return  # Skip the common parts since OpenSpiel has its own complete Dockerfile
-            ;;
-    esac
-
-    # Add common parts
-    cat >> $CURRENT_STAGING_DIR/Dockerfile << 'DOCKERFILE_EOF'
-
-# Copy only what's needed for this environment
-COPY src/core/ /app/src/core/
-COPY src/envs/ENV_NAME_PLACEHOLDER/ /app/src/envs/ENV_NAME_PLACEHOLDER/
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
-
-# Run the FastAPI server
-CMD ["uvicorn", "envs.ENV_NAME_PLACEHOLDER.server.app:app", "--host", "0.0.0.0", "--port", "8000"]
-DOCKERFILE_EOF
-
-    # Replace placeholder with actual environment name
-    sed -i "s/ENV_NAME_PLACEHOLDER/$env_name/g" $CURRENT_STAGING_DIR/Dockerfile
+    # Add web interface support before the final CMD
+    # Use awk for cross-platform compatibility
+    awk '/^CMD \[/{print "ENV ENABLE_WEB_INTERFACE=true\n"; print; next} 1' "$CURRENT_STAGING_DIR/Dockerfile" > "$CURRENT_STAGING_DIR/Dockerfile.tmp"
+    mv "$CURRENT_STAGING_DIR/Dockerfile.tmp" "$CURRENT_STAGING_DIR/Dockerfile"
+    echo "Enabled web interface"
 }
 
 create_environment_dockerfile $ENV_NAME
 
-# Add web interface support
-echo "ENV ENABLE_WEB_INTERFACE=true" >> $CURRENT_STAGING_DIR/Dockerfile
-echo "Added web interface support"
-
-# Create environment-specific README
+# Copy and prepend HF-specific intro to README
 create_readme() {
     local env_name=$1
-    
-    # Capitalize first letter of environment name
-    env_title=$(echo "$env_name" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
-    
-    # Set environment-specific colors and emoji
+    local readme_source="src/envs/$env_name/README.md"
+
+    if [ ! -f "$readme_source" ]; then
+        echo "Error: README not found at $readme_source"
+        exit 1
+    fi
+
+    # Check if README already has HF front matter
+    if head -n 1 "$readme_source" | grep -q "^---$"; then
+        echo "README has HF front matter, inserting HF deployment section after it"
+
+        # Find the line number of the closing --- (second occurrence)
+        local closing_line=$(grep -n "^---$" "$readme_source" | sed -n '2p' | cut -d: -f1)
+
+        if [ -z "$closing_line" ]; then
+            echo "Error: Could not find closing --- in front matter"
+            exit 1
+        fi
+
+        # Split the README: front matter + rest
+        head -n "$closing_line" "$readme_source" > "$CURRENT_STAGING_DIR/README.md"
+
+        # Add HF-specific deployment info right after front matter
+        cat >> $CURRENT_STAGING_DIR/README.md << 'README_EOF'
+
+## 🚀 Hugging Face Space Deployment
+
+This is a Hugging Face Space deployment of the OpenEnv environment. It includes:
+
+- **Web Interface** at `/web` - Interactive UI for exploring the environment
+- **API Documentation** at `/docs` - Full OpenAPI/Swagger interface
+- **Health Check** at `/health` - Container health monitoring
+
+### Connecting from Code
+
+```python
+from envs.ENV_NAME_PLACEHOLDER import ENV_CLASS_PLACEHOLDER
+
+# Connect to this HF Space
+env = ENV_CLASS_PLACEHOLDER(base_url="https://huggingface.co/spaces/openenv/ENV_NAME_PLACEHOLDER")
+
+# Use the environment
+result = env.reset()
+result = env.step(action)
+```
+
+For full documentation, see the [OpenEnv repository](https://github.com/meta-pytorch/OpenEnv).
+
+README_EOF
+
+        # Append the rest of the original README (skip front matter)
+        tail -n "+$((closing_line + 1))" "$readme_source" >> "$CURRENT_STAGING_DIR/README.md"
+    else
+        echo "Error: README missing HF front matter at $readme_source"
+        echo "Please add YAML front matter to the environment README"
+        exit 1
+    fi
+
+    # Set environment-specific class name
     case $env_name in
-        "atari_env")
-            EMOJI="🕹️"
-            COLOR_FROM="#FF6200"
-            COLOR_TO="#D4151B"
-            ;;
-        "coding_env")
-            EMOJI="💻"
-            COLOR_FROM="#007ACC"
-            COLOR_TO="#1E1E1E"
-            ;;
-        "openspiel_env")
-            EMOJI="🎮"
-            COLOR_FROM="#9146FF"
-            COLOR_TO="#00FFA3"
-            ;;
-        "echo_env")
-            EMOJI="🔊"
-            COLOR_FROM="#00C9FF"
-            COLOR_TO="#1B2845"
-            ;;
-        "chat_env")
-            EMOJI="💬"
-            COLOR_FROM="#0084FF"
-            COLOR_TO="#25D366"
-            ;;
-        *)
-            EMOJI="🐳"
-            COLOR_FROM="blue"
-            COLOR_TO="green"
-            ;;
+        "echo_env") ENV_CLASS="EchoEnv" ;;
+        "coding_env") ENV_CLASS="CodingEnv" ;;
+        "chat_env") ENV_CLASS="ChatEnv" ;;
+        "atari_env") ENV_CLASS="AtariEnv" ;;
+        "openspiel_env") ENV_CLASS="OpenSpielEnv" ;;
+        *) ENV_CLASS="Env" ;;
     esac
 
-    cat > $CURRENT_STAGING_DIR/README.md << README_EOF
----
-title: ${env_title} Environment Server
-emoji: ${EMOJI}
-colorFrom: ${COLOR_FROM}
-colorTo: ${COLOR_TO}
-sdk: docker
-pinned: false
-app_port: 8000
-base_path: /web
----
-
-# ${env_title} Environment Server
-
-FastAPI server for ${env_name} environment powered by Meta's OpenEnv.
-
-## About
-
-This Space provides a containerized environment for ${env_name} interactions.
-Built with FastAPI and OpenEnv framework.
-
-## Web Interface
-
-This deployment includes an interactive web interface for exploring the environment:
-- **HumanAgent Interface**: Interact with the environment using a web form
-- **State Observer**: Real-time view of environment state and action history
-- **Live Updates**: WebSocket-based real-time updates
-
-Access the web interface at: \`/web\`
-
-README_EOF
-
-    # Add environment-specific information
-    case $env_name in
-        "echo_env")
-            cat >> $CURRENT_STAGING_DIR/README.md << 'README_EOF'
-## Echo Environment
-
-Simple test environment that echoes back messages. Perfect for testing the OpenEnv APIs.
-
-### Usage
-Send a POST request to `/step` with:
-```json
-{
-  "message": "Hello World"
-}
-```
-README_EOF
-            ;;
-        "coding_env")
-            cat >> $CURRENT_STAGING_DIR/README.md << 'README_EOF'
-## Coding Environment
-
-Executes Python code in a sandboxed environment with safety checks.
-
-### Usage
-Send a POST request to `/step` with:
-```json
-{
-  "code": "print('Hello World')"
-}
-```
-README_EOF
-            ;;
-        "chat_env")
-            cat >> $CURRENT_STAGING_DIR/README.md << 'README_EOF'
-## Chat Environment
-
-Provides a chat-based interface for LLMs with tokenization support.
-
-### Usage
-Send a POST request to `/step` with tokenized input:
-```json
-{
-  "tokens": [1, 2, 3, 4, 5]
-}
-```
-README_EOF
-            ;;
-        "atari_env")
-            cat >> $CURRENT_STAGING_DIR/README.md << 'README_EOF'
-## Atari Environment
-
-Provides Atari 2600 games via the Arcade Learning Environment (ALE).
-
-### Usage
-Send a POST request to `/step` with:
-```json
-{
-  "action_id": 0,
-  "game_name": "pong"
-}
-```
-README_EOF
-            ;;
-        "openspiel_env")
-            cat >> $CURRENT_STAGING_DIR/README.md << 'README_EOF'
-## OpenSpiel Environment
-
-Provides access to OpenSpiel games for multi-agent reinforcement learning.
-
-### Usage
-Send a POST request to `/step` with:
-```json
-{
-  "action": {
-    "action_id": 1
-  }
-}
-README_EOF
-            ;;
-    esac
-
-    cat >> $CURRENT_STAGING_DIR/README.md << 'README_EOF'
-
-## API Documentation
-
-Visit `/docs` for interactive API documentation.
-
-## Health Check
-
-The environment provides a health check endpoint at `/health`.
-README_EOF
+    # Replace placeholders (cross-platform)
+    sed_inplace "s/ENV_NAME_PLACEHOLDER/$env_name/g" "$CURRENT_STAGING_DIR/README.md"
+    sed_inplace "s/ENV_CLASS_PLACEHOLDER/$ENV_CLASS/g" "$CURRENT_STAGING_DIR/README.md"
 }
 
 create_readme $ENV_NAME
-echo "Created README for HF Space"
+echo "Copied and enhanced README for HF Space"
 echo "Completed preparation for $ENV_NAME environment"

--- a/src/envs/atari_env/README.md
+++ b/src/envs/atari_env/README.md
@@ -1,3 +1,14 @@
+---
+title: Atari Environment Server
+emoji: 🕹️
+colorFrom: '#FF6200'
+colorTo: '#D4151B'
+sdk: docker
+pinned: false
+app_port: 8000
+base_path: /web
+---
+
 # Atari Environment
 
 Integration of Atari 2600 games with the OpenEnv framework via the Arcade Learning Environment (ALE). ALE provides access to 100+ classic Atari games for RL research.

--- a/src/envs/atari_env/server/Dockerfile
+++ b/src/envs/atari_env/server/Dockerfile
@@ -12,12 +12,9 @@
 ARG BASE_IMAGE=openenv-base:latest
 FROM ${BASE_IMAGE}
 
-# Install ALE-specific dependencies
-# ale-py includes all Atari ROMs by default and requires gymnasium
-RUN pip install --no-cache-dir \
-    gymnasium>=0.29.0 \
-    ale-py>=0.8.0 \
-    numpy>=1.24.0
+# Install dependencies
+COPY src/envs/atari_env/server/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 # Copy OpenEnv core (base image already set WORKDIR=/app)
 COPY src/core/ /app/src/core/

--- a/src/envs/atari_env/server/requirements.txt
+++ b/src/envs/atari_env/server/requirements.txt
@@ -1,0 +1,3 @@
+gymnasium>=0.29.0
+ale-py>=0.8.0
+numpy>=1.24.0

--- a/src/envs/chat_env/README.md
+++ b/src/envs/chat_env/README.md
@@ -1,3 +1,14 @@
+---
+title: Chat Environment Server
+emoji: 💬
+colorFrom: '#0084FF'
+colorTo: '#25D366'
+sdk: docker
+pinned: false
+app_port: 8000
+base_path: /web
+---
+
 # Chat Environment
 
 A chat-based environment for LLMs with built-in tokenization and message history management. This environment is designed to work directly with language models and provides a minimal, flexible foundation for conversation-based RL training.

--- a/src/envs/chat_env/server/Dockerfile
+++ b/src/envs/chat_env/server/Dockerfile
@@ -10,8 +10,20 @@
 ARG BASE_IMAGE=openenv-base:latest
 FROM ${BASE_IMAGE}
 
-# Install additional dependencies for ChatEnvironment
-RUN pip install torch transformers
+# Install dependencies and run setup
+COPY src/envs/chat_env/server/requirements.txt /tmp/requirements.txt
+COPY src/envs/chat_env/server/install_deps.sh /tmp/install_deps.sh
+RUN chmod +x /tmp/install_deps.sh && \
+    /tmp/install_deps.sh && \
+    rm /tmp/install_deps.sh /tmp/requirements.txt
+
+# Set environment variables
+ENV HF_HOME=/.cache
+ENV TRANSFORMERS_CACHE=/.cache
+
+# Environment variables that can be overridden at runtime
+ENV TOKENIZER_NAME=gpt2
+ENV SYSTEM_PROMPT="You are a helpful AI assistant."
 
 # Copy only what's needed for this environment
 COPY src/core/ /app/src/core/
@@ -19,10 +31,6 @@ COPY src/envs/chat_env/ /app/src/envs/chat_env/
 
 # Copy README for web interface documentation
 COPY src/envs/chat_env/README.md /app/README.md
-
-# Environment variables that can be overridden at runtime
-ENV TOKENIZER_NAME=gpt2
-ENV SYSTEM_PROMPT="You are a helpful AI assistant."
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \

--- a/src/envs/chat_env/server/install_deps.sh
+++ b/src/envs/chat_env/server/install_deps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Additional setup for chat_env
+set -e
+
+# Install Python dependencies
+pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Set up cache directory for Hugging Face models
+mkdir -p /.cache && chmod 777 /.cache
+
+# Pre-download the GPT-2 model to avoid permission issues during runtime
+python -c "from transformers import GPT2Tokenizer; GPT2Tokenizer.from_pretrained('gpt2')"

--- a/src/envs/chat_env/server/requirements.txt
+++ b/src/envs/chat_env/server/requirements.txt
@@ -1,0 +1,2 @@
+torch
+transformers

--- a/src/envs/coding_env/README.md
+++ b/src/envs/coding_env/README.md
@@ -1,3 +1,14 @@
+---
+title: Coding Environment Server
+emoji: 💻
+colorFrom: '#007ACC'
+colorTo: '#1E1E1E'
+sdk: docker
+pinned: false
+app_port: 8000
+base_path: /web
+---
+
 # Coding Environment
 
 A Python code execution environment that runs arbitrary Python code and returns results. Perfect for testing code execution infrastructure and demonstrating environment usage patterns.

--- a/src/envs/coding_env/server/Dockerfile
+++ b/src/envs/coding_env/server/Dockerfile
@@ -10,8 +10,9 @@
 ARG BASE_IMAGE=openenv-base:latest
 FROM ${BASE_IMAGE}
 
-# Install smolagents for code execution
-RUN pip install --no-cache-dir smolagents
+# Install dependencies
+COPY src/envs/coding_env/server/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 # Copy only what's needed for this environment
 COPY src/core/ /app/src/core/

--- a/src/envs/coding_env/server/requirements.txt
+++ b/src/envs/coding_env/server/requirements.txt
@@ -1,0 +1,1 @@
+smolagents

--- a/src/envs/echo_env/README.md
+++ b/src/envs/echo_env/README.md
@@ -1,3 +1,14 @@
+---
+title: Echo Environment Server
+emoji: 🔊
+colorFrom: '#00C9FF'
+colorTo: '#1B2845'
+sdk: docker
+pinned: false
+app_port: 8000
+base_path: /web
+---
+
 # Echo Environment
 
 A simple test environment that echoes back messages. Perfect for testing the env APIs as well as demonstrating environment usage patterns.

--- a/src/envs/openspiel_env/README.md
+++ b/src/envs/openspiel_env/README.md
@@ -1,3 +1,14 @@
+---
+title: OpenSpiel Environment Server
+emoji: 🎮
+colorFrom: '#9146FF'
+colorTo: '#00FFA3'
+sdk: docker
+pinned: false
+app_port: 8000
+base_path: /web
+---
+
 # OpenSpiel Environment
 
 Integration of OpenSpiel games with the OpenEnv framework. OpenSpiel (https://github.com/google-deepmind/open_spiel) is DeepMind's collection of 70+ game environments for RL research.

--- a/src/envs/openspiel_env/server/prepare_hf.sh
+++ b/src/envs/openspiel_env/server/prepare_hf.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Custom HF deployment script for openspiel_env
+# OpenSpiel uses a different base image with C++ compilation
+
+set -e
+
+DOCKERFILE_PATH="$1"
+BASE_IMAGE_REF="$2"
+
+echo "OpenSpiel: Using custom Dockerfile preparation"
+
+# Cross-platform sed in-place editing
+sed_inplace() {
+    if sed --version >/dev/null 2>&1; then
+        # GNU sed (Linux)
+        sed -i "$@"
+    else
+        # BSD sed (macOS)
+        sed -i '' "$@"
+    fi
+}
+
+# Replace ARG with hardcoded FROM using the special OpenSpiel base
+sed_inplace 's|ARG OPENSPIEL_BASE_IMAGE=.*|FROM ghcr.io/meta-pytorch/openenv-openspiel-base:sha-e622c7e|g' "$DOCKERFILE_PATH"
+sed_inplace '/^FROM \${OPENSPIEL_BASE_IMAGE}/d' "$DOCKERFILE_PATH"
+
+echo "OpenSpiel: Modified Dockerfile to use GHCR OpenSpiel base image"
+echo "OpenSpiel builds can take 10-15 minutes due to C++ compilation"


### PR DESCRIPTION
Refactored the OpenEnv Docker deployment architecture to eliminate code duplication between GHCR and Hugging Face Spaces deployments. Introduced standard Python dependency management patterns and fully collocated environment configuration.

## Problem

Previously, dependencies and deployment configuration were duplicated across:
1. Static Dockerfiles (for GHCR deployment)
2. HF deployment script with hardcoded case statements
3. Dynamic Dockerfile generation for HF Spaces

This created:
- **Maintenance burden**: Changes required updating multiple files
- **Drift risk**: Dependencies could get out of sync between deployment methods
- **Poor scalability**: Adding new environments required modifying central deployment script
- **Unclear ownership**: Configuration scattered across codebase

## Solution

### 1. Introduced Standard Dependency Files

Each environment now uses familiar Python patterns:

**`requirements.txt`** - Standard Python dependencies (most common)
```bash
src/envs/coding_env/server/requirements.txt
src/envs/atari_env/server/requirements.txt
src/envs/chat_env/server/requirements.txt
```

**`install_deps.sh`** - Optional bash script for complex setup beyond pip
```bash
src/envs/chat_env/server/install_deps.sh
```

**`prepare_hf.sh`** - Optional custom HF Dockerfile modification
```bash
src/envs/openspiel_env/server/prepare_hf.sh
```

### 2. Updated Static Dockerfiles

All environment Dockerfiles now follow the standard pattern:

```dockerfile
# Install dependencies from requirements.txt
COPY src/envs/my_env/server/requirements.txt /tmp/requirements.txt
RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt

# For complex setup, use install_deps.sh
COPY src/envs/my_env/server/install_deps.sh /tmp/install_deps.sh
RUN chmod +x /tmp/install_deps.sh && \
    /tmp/install_deps.sh && \
    rm /tmp/install_deps.sh
```

### 3. Enhanced Environment READMEs

Added HF Space YAML front matter to each environment's README:

```yaml
---
title: Echo Environment Server
emoji: 🔊
colorFrom: '#00C9FF'
colorTo: '#1B2845'
sdk: docker
pinned: false
app_port: 8000
base_path: /web
---
```

### 4. Simplified HF Deployment Script

Reduced `scripts/prepare_hf_deployment.sh` from **~329 lines to ~180 lines**:
- ❌ Removed all hardcoded case statements for dependencies
- ❌ Removed dynamic Dockerfile generation
- ✅ Now copies and minimally modifies static Dockerfiles
- ✅ Reuses existing environment READMEs
- ✅ Executes optional environment-specific preparation scripts
- ✅ Cross-platform compatible (macOS BSD sed + Linux GNU sed)


## Testing

Generate the readmes and dockers for the envs and check the generated files.
