### PR TITLE
[CI] PR action for new Env contributions

### DIFF
--- a/.github/workflows/pr-new-env.yml
+++ b/.github/workflows/pr-new-env.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x scripts/deploy_to_hf.sh
-          ./scripts/deploy_to_hf.sh --env "${{ matrix.environment }}" --space-suffix "${SPACE_SUFFIX}"
+          ./scripts/deploy_to_hf.sh --env "${{ matrix.environment }}" --space-suffix "${SPACE_SUFFIX}" --hub-tag "openenv-pr"
 
       - name: Wait for deployment to stabilize
         shell: bash

--- a/scripts/deploy_to_hf.sh
+++ b/scripts/deploy_to_hf.sh
@@ -75,6 +75,10 @@ while [[ $# -gt 0 ]]; do
             ENV_NAME="$2"
             shift 2
             ;;
+        --hub-tag)
+            HUB_TAG="$2"
+            shift 2
+            ;;
         --base-sha|--base-image-sha)
             BASE_IMAGE_SHA="$2"
             shift 2
@@ -126,6 +130,10 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [ -z "$HUB_TAG" ]; then
+    HUB_TAG="openenv"
+fi
 
 if [ -z "$ENV_NAME" ]; then
     echo "Error: Environment name is required" >&2
@@ -364,6 +372,8 @@ sdk: docker
 pinned: false
 app_port: 8000
 base_path: /web
+tags:
+  - ${HUB_TAG}
 ---
 
 # ${env_title} Environment Server


### PR DESCRIPTION
This PR introduces a new action that deploys any contributions in `src/envs` to a hub testing org (openenv-testing) and comments a link and instructions on the PR. 

I think this will save us time reviewing, get people deploying their own envs, show people the cli when it's ready.

I tested this on a fork, on this [pr](https://github.com/burtenshaw/OpenEnv/pull/3) and this [action](https://github.com/burtenshaw/OpenEnv/actions/runs/18997671629/job/54259799775).

<img width="1012" height="329" alt="image" src="https://github.com/user-attachments/assets/d4a88144-4536-48d9-954e-524b68b6e77f" />
