### PR TITLE
[CLI/CI] Add improved cli integration to CI

### DIFF
--- a/.github/workflows/pr-new-env.yml
+++ b/.github/workflows/pr-new-env.yml
@@ -255,11 +255,21 @@ jobs:
               '',
               summary,
               '',
-              '- `openenv push ' + envName + ' --repo-id ' + repoId + '`',
-            ].join('\n');
+              '- `openenv push ' + envName + ' --repo-id <your-username>/' + envName + '`',
+            ];
 
             const {owner, repo} = context.repo;
             const issue_number = context.payload.pull_request.number;
+            const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+            const runUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            if (status !== 'success') {
+              body.push(`- Failed run: ${runUrl}`);
+            } else {
+              body.push(`- Success run: ${runUrl}`);
+            }
+
+            const bodyText = body.join('\n');
 
             const existing = await github.paginate(
               github.rest.issues.listComments,


### PR DESCRIPTION
This PR integrates the new CLI into the repo CI and therefore follows #128.

It does this:
- uses the CLI instead of shell script
- comments with the CLI
- links to the successful github action run
- cleans up the space on hf on completion
- updated comments instead of re-creating.
