### PR TITLE
add from_hub method to base EnvClient

### DIFF
--- a/src/core/http_env_client.py
+++ b/src/core/http_env_client.py
@@ -105,6 +105,24 @@ class HTTPEnvClient(ABC, Generic[ActT, ObsT]):
         # 3. Create and return client instance with provider reference
         return cls(base_url=base_url, provider=provider)
 
+    @classmethod
+    def from_hub(cls: Type[EnvClientT], repo_id: str, provider: Optional["ContainerProvider"] = None, **kwargs: Any) -> EnvClientT:
+        """
+        Create an environment client by pulling from a Hugging Face model hub.
+        """
+        
+        if provider is None:
+            provider = LocalDockerProvider()
+        
+        if "tag" in kwargs:
+            tag = kwargs["tag"]
+        else:
+            tag = "latest"
+        
+        base_url = f"registry.hf.space/{repo_id.replace('/', '-')}:{tag}"
+        
+        return cls.from_docker_image(image=base_url, provider=provider)
+
     @abstractmethod
     def _step_payload(self, action: ActT) -> dict:
         """Convert an Action object to the JSON body expected by the env server."""


### PR DESCRIPTION
This PR integrates with the hub's built in docker registry via a `from_hub` method, so you can do:

```
    env = TextArenaEnv.from_hub(
        "burtenshaw/textarena",
        env_vars={
            "TEXTARENA_ENV_ID": "GuessTheNumber-v0",
            "TEXTARENA_NUM_PLAYERS": "1",
        },
        ports={8000: 8000},
    )
```