### PR TITLE
fix: ensure Gen 8 Random Battles run correctly instead of Gen 9

### DIFF
--- a/src/envs/pokemon_env/server/Dockerfile
+++ b/src/envs/pokemon_env/server/Dockerfile
@@ -46,7 +46,7 @@ COPY src/envs/pokemon_env/ /app/src/envs/pokemon_env/
 COPY src/envs/pokemon_env/README.md /app/README.md
 
 # Pokemon environment variables
-ENV POKEMON_BATTLE_FORMAT=gen9randombattle
+ENV POKEMON_BATTLE_FORMAT=gen8randombattle
 ENV POKEMON_PLAYER_USERNAME=player
 ENV POKEMON_REWARD_MODE=sparse
 ENV POKEMON_MAX_TURNS=1000

--- a/src/envs/pokemon_env/server/app.py
+++ b/src/envs/pokemon_env/server/app.py
@@ -16,7 +16,7 @@ Usage:
     python -m envs.pokemon_env.server.app
 
 Environment variables:
-    POKEMON_BATTLE_FORMAT: Battle format (default: "gen9randombattle")
+    POKEMON_BATTLE_FORMAT: Battle format (default: "gen8randombattle")
     POKEMON_PLAYER_USERNAME: Player username (default: "player")
     POKEMON_REWARD_MODE: Reward mode - "sparse" or "dense" (default: "sparse")
     POKEMON_MAX_TURNS: Maximum turns per battle (default: "1000")
@@ -37,7 +37,7 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 
-battle_format = os.getenv("POKEMON_BATTLE_FORMAT", "gen9randombattle")
+battle_format = os.getenv("POKEMON_BATTLE_FORMAT", "gen8randombattle")
 player_username = os.getenv("POKEMON_PLAYER_USERNAME", "player")
 reward_mode = os.getenv("POKEMON_REWARD_MODE", "sparse")
 max_turns = int(os.getenv("POKEMON_MAX_TURNS", "1000"))

--- a/src/envs/pokemon_env/server/pokemon_environment.py
+++ b/src/envs/pokemon_env/server/pokemon_environment.py
@@ -234,7 +234,7 @@ class PokemonEnvironment(Environment):
 
     def __init__(
         self,
-        battle_format: str = "gen9randombattle",
+        battle_format: str = "gen8randombattle",
         player_username: Optional[str] = None,
         opponent: Optional[Player] = None,
         reward_mode: str = "sparse",
@@ -254,7 +254,7 @@ class PokemonEnvironment(Environment):
         self.player = OpenEnvPokemonPlayer(
             account_configuration=AccountConfiguration(self.player_username, None),
             server_configuration=LocalhostServerConfiguration,
-            battle_format=battle_format,
+            battle_format=self.battle_format,
             max_concurrent_battles=1,  # One battle at a time
         )
 
@@ -265,7 +265,7 @@ class PokemonEnvironment(Environment):
             self.opponent = RandomPlayer(
                 account_configuration=AccountConfiguration(opponent_username, None),
                 server_configuration=LocalhostServerConfiguration,
-                battle_format=battle_format,
+                battle_format=self.battle_format,
                 max_concurrent_battles=1,
             )
         else:
@@ -537,6 +537,7 @@ class PokemonEnvironment(Environment):
             # Start battle on POKE_LOOP
             async def start_battle():
                 """Start a single battle and return when it's initialized."""
+                logger.info(self.battle_format)
                 logger.info("Starting battle...")
 
                 # Use battle_against which returns when battle is complete


### PR DESCRIPTION
Previously, the Poke-Env setup was launching Gen 9 random battles due to incorrect environment variable configuration. 
This fix updates the environment setup to explicitly use Gen 8, ensuring that Pokémon Showdown runs the correct battle generation.
