### PR TITLE
[textarena] flush on newline boundry

### DIFF
--- a/tests/envs/test_textarena_environment.py
+++ b/tests/envs/test_textarena_environment.py
@@ -21,3 +21,44 @@ def test_convert_messages_coalesces_consecutive_characters():
         TextArenaMessage(sender_id=1, content="AB", category="MESSAGE"),
         TextArenaMessage(sender_id=2, content="!", category="MESSAGE"),
     ]
+
+
+def test_convert_messages_splits_on_newlines():
+    env = object.__new__(TextArenaEnvironment)
+
+    raw_messages = [
+        "[",
+        "G",
+        "A",
+        "M",
+        "E",
+        "]",
+        "\n",
+        "[",
+        "N",
+        "E",
+        "X",
+        "T",
+        "]",
+    ]
+
+    converted = env._convert_messages(raw_messages)
+
+    assert converted == [
+        TextArenaMessage(sender_id=-1, content="[GAME]", category="MESSAGE"),
+        TextArenaMessage(sender_id=-1, content="[NEXT]", category="MESSAGE"),
+    ]
+
+
+def test_convert_messages_preserves_blank_lines():
+    env = object.__new__(TextArenaEnvironment)
+
+    raw_messages = ["A", "\n", "\n", "B"]
+
+    converted = env._convert_messages(raw_messages)
+
+    assert converted == [
+        TextArenaMessage(sender_id=-1, content="A", category="MESSAGE"),
+        TextArenaMessage(sender_id=-1, content="", category="MESSAGE"),
+        TextArenaMessage(sender_id=-1, content="B", category="MESSAGE"),
+    ]


### PR DESCRIPTION
the previous fix https://github.com/meta-pytorch/OpenEnv/pull/157 had an issue that we concatenated every character from the underlying env into a single `TextArenaMessage`,  so each prompt ballooned into one massive string containing the whole history. 

Now I flush on newline boundaries and treat each line as its own message.