### PR TITLE
Update feedback count func

### DIFF
--- a/src/envs/textarena_env/rewards.py
+++ b/src/envs/textarena_env/rewards.py
@@ -61,18 +61,18 @@ def extract_feedback_counts(feedback: str) -> Tuple[int, int]:
     if not feedback:
         return (0, 0)
 
-    segments = [
-        segment.strip() for segment in feedback.split("\n") if segment.strip()
-    ]
-    if len(segments) < 2:
+    lines = [line.strip() for line in feedback.split("\n") if line.strip()]
+    if len(lines) < 2:
         return (0, 0)
 
-    marker_line = segments[1]
+    for line in lines:
+        normalized = line.replace(" ", "")
+        if normalized and all(c in "GYX" for c in normalized):
+            green = normalized.count("G")
+            yellow = normalized.count("Y")
+            return (green, yellow)
 
-    green_count = marker_line.count("G")
-    yellow_count = marker_line.count("Y")
-
-    return (green_count, yellow_count)
+    return (0, 0)
 
 
 class _WordleRewardProvider:


### PR DESCRIPTION
The current `extract_feedback_counts` function may return numbers that are incorrect for the number of green and yellow positions. This is what how the feedback looks like for this case:

```
A P P L E
Y Y X X G

A P P L E
Y Y X X G

A P P L E
Y Y X X G

B E R R Y
X Y X X X

G R E E N
X X Y X X

B A R E D
X G X Y X

You have 0 guesses left.
```

Updating it to reflect this.

@burtenshaw 
