### PR TITLE
[browsergym] fixes

### DIFF
--- a/src/envs/browsergym_env/server/requirements.txt
+++ b/src/envs/browsergym_env/server/requirements.txt
@@ -5,3 +5,5 @@ browsergym-webarena>=0.2.0
 gymnasium>=0.29.0
 playwright>=1.40.0
 Pillow>=10.0.0
+fastapi>=0.104.0
+uvicorn>=0.24.0

--- a/src/envs/browsergym_env/server/start.sh
+++ b/src/envs/browsergym_env/server/start.sh
@@ -25,5 +25,5 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
-exec uvicorn envs.browsergym_env.server.app:app --host 0.0.0.0 --port "${BROWSERGYM_PORT}"
+exec python -m uvicorn envs.browsergym_env.server.app:app --host 0.0.0.0 --port "${BROWSERGYM_PORT}"
 


### PR DESCRIPTION
1. Thread Pool Execution
      - Added `ThreadPoolExecutor` to run synchronous environment operations in separate threads
      - Prevents Playwright's blocking sync API from freezing the asyncio event loop
      - Required because BrowserGym uses `playwright.sync_api`, which cannot be called directly from async endpoints
1. NumPy Array Serialization
      - Added recursive NumPy-to-list conversion in observation serialization
1. Flexible Action Format
     -  Support both `{"action": {...}}` and direct `{...}` action formats
1.  Missing Dependencies
      - Added `fastapi>=0.104.0` and `uvicorn>=0.24.0` to requirements
1. Server Startup
      - Changed to`python -m uvicorn` for more reliable module loading