### PR TITLE
Add meta extension to prevent yaml from rendering in docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -61,6 +61,7 @@ markdown_extensions:
         - name: important
         - name: warning
         - name: caution
+  - meta
 
 watch:
   - ../src/core


### PR DESCRIPTION
In current docs, some internal details that are not needed are rendered. Adding an extension to prevent rendering

<img width="1345" height="437" alt="Screenshot 2025-11-19 at 10 46 58" src="https://github.com/user-attachments/assets/9241e357-d66f-4d0c-8952-0d7243fab25c" />
