### PR TITLE
Update to relative import in `browsergym_env`

### DIFF
--- a/src/envs/browsergym_env/client.py
+++ b/src/envs/browsergym_env/client.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict
 
 from openenv_core.http_env_client import HTTPEnvClient, StepResult
-from browsergym_env.models import (
+from .models import (
     BrowserGymAction,
     BrowserGymObservation,
     BrowserGymState,


### PR DESCRIPTION
The current approach generates:

```
OpenEnv/src/envs/browsergym_env/client.py", line 6, in <module>
    from browsergym_env.models import (
ModuleNotFoundError: No module named 'browsergym_env'
```

when imported the env when installed via pip

cc @Paulescu