### PR TITLE
Fix coding_env: change CodingAction to CodeAction and add uvicorn[standard] package

### DIFF
--- a/src/envs/coding_env/openenv.yaml
+++ b/src/envs/coding_env/openenv.yaml
@@ -1,5 +1,5 @@
 name: coding_env
 version: "0.1.0"
 description: "Coding environment for OpenEnv"
-action: CodingAction
-observation: CodingObservation
+action: CodeAction
+observation: CodeObservation

--- a/src/envs/coding_env/pyproject.toml
+++ b/src/envs/coding_env/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "openenv-core>=0.1.0",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
-    "uvicorn>=0.24.0",
+    "uvicorn[standard]>=0.24.0",
     "requests>=2.31.0",
     "smolagents>=1.22.0,<2",
 ]


### PR DESCRIPTION
The coding_env space UI is not working due to missing packages, with uvicorn[standard] now UI is working fine, see my [test space](https://huggingface.co/spaces/wukaixingxp/coding-env-test). Also fixed the typos where `CodingAction` should be `CodeAction ..