### PR TITLE
[RFC] Add RFC 004: Rubrics

### DIFF
--- a/.claude/docs/PRINCIPLES.md
+++ b/.claude/docs/PRINCIPLES.md
@@ -33,6 +33,9 @@ These decisions are documented in RFCs and should not be changed without a new R
 | **MCP as universal standard** | All agent-environment tool interaction via MCP | 003 |
 | **WebSocket for step loop** | Lower latency than HTTP per-step | 002 |
 | **Two-interface model** | WebSocket for orchestration, MCP for agent tools | 001 |
+| **One env = one trajectory** | Batching via environment stacking, not multiplexing | 004 |
+
+**One env = one trajectory**: Environments do not support multiplexed trajectories. To generate batches, stack multiple environment instances. Helpers like `EnvPool` orchestrate batch collection across the stack. Multiplexing is left to future work.
 
 ## When to Revisit These Principles
 


### PR DESCRIPTION
## Summary

Introduces RFC 004: Rubric System—a composable, nn.Module-inspired abstraction for computing rewards in OpenEnv environments.

Key design decisions:
  - Environment authors implement __init__ and forward(action, observation) -> float
  - Child rubrics auto-register when assigned as attributes
  - Sync forward() + async evaluate() for batch parallelism (no async knowledge required from authors)
  - Hooks for observability without polluting the base class

What's included:
  - Rubric base class with PyTorch-like API
  - Container rubrics: Sequential, Gate, WeightedSum, RubricList, LLMJudge
  - evaluate_batch() helper for parallel evaluation in training loops

Design informed by:
  - RLTF (hierarchical gating)
  - Rubicon (multi-dimensional rubrics)
  - AdvancedIF (all-or-nothing aggregation)
  - OpenRubrics (gatekeeper mechanism)

Test plan

  - Review RFC for clarity and completeness
  - Gather feedback on API design
  - Validate against existing environment implementations