### PR TITLE
Import ..models instead of models in templates

### DIFF
--- a/src/openenv_cli/templates/openenv_env/server/__ENV_NAME___environment.py
+++ b/src/openenv_cli/templates/openenv_env/server/__ENV_NAME___environment.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 from openenv_core.env_server.interfaces import Environment
 from openenv_core.env_server.types import State
 
-from models import __ENV_CLASS_NAME__Action, __ENV_CLASS_NAME__Observation
+from ..models import __ENV_CLASS_NAME__Action, __ENV_CLASS_NAME__Observation
 
 
 class __ENV_CLASS_NAME__Environment(Environment):

--- a/src/openenv_cli/templates/openenv_env/server/app.py
+++ b/src/openenv_cli/templates/openenv_env/server/app.py
@@ -27,7 +27,7 @@ except Exception as e:  # pragma: no cover
     raise ImportError("openenv_core is required for the web interface. Install dependencies with '\n    uv sync\n'") from e
 
 from .__ENV_NAME___environment import __ENV_CLASS_NAME__Environment
-from models import __ENV_CLASS_NAME__Action, __ENV_CLASS_NAME__Observation
+from ..models import __ENV_CLASS_NAME__Action, __ENV_CLASS_NAME__Observation
 
 # Create the environment instance
 env = __ENV_CLASS_NAME__Environment()


### PR DESCRIPTION
Solves issue #258

For files in the `server` directory of the template, imports `..models` instead of `models` to fix a module not found error.
 