### PR TITLE
Fix: TypeError in load_environment_metadata when env is a class or factory function

### DIFF
--- a/envs/coding_env/pyproject.toml
+++ b/envs/coding_env/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Coding Environment for OpenEnv"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core] @ git+https://github.com/meta-pytorch/OpenEnv.git@fix/web-interface-params",
+    "openenv-core[core]>=0.2.0",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.24.0",


### PR DESCRIPTION
### Problem: 
When starting the web interface with ENABLE_WEB_INTERFACE=true, the application crashes with:

`TypeError: Environment.get_metadata() missing 1 required positional argument: 'self'`

This occurs because load_environment_metadata() assumed the env parameter was always an instance, but create_app() accepts a Callable[[], Environment] — which can be:

- A class (e.g., PythonCodeActEnv, EchoEnvironment)

- A factory function (e.g., create_chat_environment, create_atari_environment)

- An instance (e.g., SnakeEnvironment())

When hasattr(env, "get_metadata") was called on a class, it returned True (because the class defines the method), but calling env.get_metadata() failed because instance methods require self.

### Solution:
Updated load_environment_metadata() to detect the type of env using inspect.isclass() and inspect.isfunction(), and only call instance methods when env is actually an instance.

### Changes:
Added detection for class vs factory function vs instance in load_environment_metadata()
Updated docstring to clarify the function accepts classes, factory functions, and instances
Correctly derive class name based on what type of env is passed
### Testing:
Verified that environments using all three patterns work correctly:

Class as factory: coding_env, echo_env, connect4_env
Factory function: chat_env, atari_env, git_env, etc.
Instance: snake_env