### PR TITLE
Fix TypeError: PythonCodeActEnv.step() missing 1 required positional argument: 'action'

### DIFF
--- a/src/openenv/core/env_server/web_interface.py
+++ b/src/openenv/core/env_server/web_interface.py
@@ -167,7 +167,13 @@ class WebInterfaceManager:
         observation_cls: Type[Observation],
         metadata: Optional[EnvironmentMetadata] = None,
     ):
-        self.env = env
+        import inspect
+
+        # If env is a class or factory function, instantiate it
+        if inspect.isclass(env) or inspect.isfunction(env):
+            self.env = env()
+        else:
+            self.env = env
         self.action_cls = action_cls
         self.observation_cls = observation_cls
         self.metadata = metadata or EnvironmentMetadata(


### PR DESCRIPTION
when using the coding_env, I got this error:
```
INFO:     10.16.12.39:24168 - "POST /web/step HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/app/env/.venv/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 416, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/env/.venv/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/env/.venv/lib/python3.11/site-packages/fastapi/applications.py", line 1135, in __call__
    await super().__call__(scope, receive, send)
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/applications.py", line 107, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/app/env/.venv/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/routing.py", line 716, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/routing.py", line 736, in app
    await route.handle(scope, receive, send)
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/routing.py", line 290, in handle
    await self.app(scope, receive, send)
  File "/app/env/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 115, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/app/env/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/app/env/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 101, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/app/env/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 355, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/env/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 243, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/env/.venv/lib/python3.11/site-packages/openenv/core/env_server/web_interface.py", line 376, in web_step
    return await web_manager.step_environment(action_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/env/.venv/lib/python3.11/site-packages/openenv/core/env_server/web_interface.py", line 262, in step_environment
    observation: Observation = await self._run_sync_in_thread_pool(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/env/.venv/lib/python3.11/site-packages/openenv/core/env_server/web_interface.py", line 194, in _run_sync_in_thread_pool
    return await loop.run_in_executor(self._executor, lambda: func(*args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/env/.venv/lib/python3.11/site-packages/openenv/core/env_server/web_interface.py", line 194, in <lambda>
    return await loop.run_in_executor(self._executor, lambda: func(*args, **kwargs))
                                                              ^^^^^^^^^^^^^^^^^^^^^
TypeError: PythonCodeActEnv.step() missing 1 required positional argument: 'action'
INFO:     connection closed
INFO:     10.16.12.39:58627 - "GET /web?logs=build HTTP/1.1" 200 OK
INFO:     10.16.43.133:45139 - "WebSocket /ws/ui" [accepted]
INFO:     connection open
```

**Root Cause**: The WebInterfaceManager.__init__ method was storing the env parameter directly without checking if it was a class/factory function vs an actual instance. When a class was passed (like PythonCodeActEnv), calling self.env.step(action) was calling an unbound method, which interpreted action as the self parameter.

**Fix**: Added logic in WebInterfaceManager.__init__ to detect if env is a class or factory function and instantiate it.