### PR TITLE
Fix tomli compatibility issue for older Python version

### DIFF
--- a/src/openenv/cli/_validation.py
+++ b/src/openenv/cli/_validation.py
@@ -12,8 +12,12 @@ configured for multi-mode deployment (Docker, direct Python, notebooks, clusters
 """
 
 import subprocess
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 
 def validate_multi_mode_deployment(env_path: Path) -> tuple[bool, list[str]]:


### PR DESCRIPTION
This PR addressing this issue: [issue284](https://github.com/meta-pytorch/OpenEnv/issues/284)

## Summary

Fixes a `ModuleNotFoundError` when running OpenEnv CLI commands on Python 3.10 and older by adding a fallback import for the `tomli` package.

## Problem

The `tomllib` module is only available in Python 3.11+. When running on Python 3.10 and older, the following error occurs:

```
$ openenv push
Traceback (most recent call last):
  ...
  File "/src/openenv/cli/_validation.py", line 15, in <module>
    import tomllib
ModuleNotFoundError: No module named 'tomllib'
```

## Solution

Add a try/except import that falls back to `tomli` (the third-party backport) when `tomllib` is not available:

```python
try:
    import tomllib
except ModuleNotFoundError:
    import tomli as tomllib
```

## Changes

- `src/openenv/cli/_validation.py`: Updated import to support Python 3.10 and older