### PR TITLE
Add Python-based PR review bot with time-based filtering

### DIFF
--- a/scripts/PR_REVIEW_BOT.md
+++ b/scripts/PR_REVIEW_BOT.md
@@ -1,0 +1,113 @@
+# PR Review Bot
+
+Automated PR review system using Claude Code. Runs as a cron job to review open PRs.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Cron (every 6 hours)                     │
+│                pr-review-cron-wrapper.sh                    │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                      Claude Code                            │
+│  1. Calls pr_tracker.py --list --since 6h                   │
+│  2. Spawns alignment-reviewer subagent for each PR          │
+│  3. Posts reviews via pr_tracker.post_review()              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Key insight**: Claude handles orchestration. The only code needed is `pr_tracker.py` for GitHub API access.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `pr_tracker.py` | GitHub API wrapper (PyGithub) - fetches PRs, posts reviews |
+| `pr-review-cron-wrapper.sh` | Cron entry point - invokes Claude |
+
+## Quick Start
+
+### 1. Install PyGithub
+
+```bash
+pip install PyGithub
+```
+
+### 2. Test the Tracker
+
+```bash
+# List PRs updated in last 6 hours
+python3 scripts/pr_tracker.py --list --since 6h
+
+# List PRs updated in last day
+python3 scripts/pr_tracker.py --list --since 1d
+
+# Get details for a specific PR
+python3 scripts/pr_tracker.py --details 123
+```
+
+### 3. Test a Review (manually)
+
+```bash
+claude "Review PR #123 using the alignment-reviewer agent.
+Use scripts/pr_tracker.py to get PR details and post the review."
+```
+
+### 4. Set Up Cron
+
+```bash
+crontab -e
+
+# Add this line
+0 */6 * * * /home/davidet/OpenEnv/scripts/pr-review-cron-wrapper.sh >> ~/.openenv-review-cron.log 2>&1
+```
+
+## pr_tracker.py API
+
+```python
+from scripts.pr_tracker import (
+    get_prs_needing_review,
+    get_pr_details,
+    post_review,
+    parse_since,
+)
+
+# Get PRs updated in last 6 hours
+since = parse_since("6h")
+prs = get_prs_needing_review(since=since)
+# Returns: [{"number": 123, "title": "...", "updated_at": "...", ...}]
+
+# Get detailed info about a PR
+details = get_pr_details(123)
+# Returns: {"number": 123, "files": [...], "body": "...", ...}
+
+# Post a review
+post_review(pr_number=123, verdict="approve", body="LGTM!")
+```
+
+## Filtering
+
+PRs are filtered by update time using `--since`:
+- `6h` - last 6 hours
+- `1d` - last day
+- `2w` - last 2 weeks
+- `2024-01-13T00:00:00Z` - since specific timestamp
+
+The cron job runs every 6 hours with `--since 6h`, so it reviews any PR that was updated since the last run.
+
+## Review Model
+
+| Issues Found | Verdict |
+|--------------|---------|
+| Tier 1 issues (bugs, lint, security) | `request_changes` |
+| Only Tier 2 flags (alignment concerns) | `comment` |
+| No issues | `approve` |
+
+## Logs
+
+```bash
+tail -50 ~/.openenv-review-cron.log
+```

--- a/scripts/pr-review-cron-wrapper.sh
+++ b/scripts/pr-review-cron-wrapper.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Cron wrapper for PR review bot
+# Invokes Claude to review open PRs
+#
+# Crontab entry (every 6 hours):
+#   0 */6 * * * /path/to/OpenEnv/scripts/pr-review-cron-wrapper.sh >> ~/.openenv-review-cron.log 2>&1
+
+set -euo pipefail
+
+# Source user's shell profile for PATH
+if [ -f "$HOME/.bashrc" ]; then
+    source "$HOME/.bashrc" 2>/dev/null || true
+elif [ -f "$HOME/.profile" ]; then
+    source "$HOME/.profile" 2>/dev/null || true
+fi
+
+export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+
+# Get repo directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_DIR"
+
+# Acquire lock to prevent concurrent runs
+LOCK_FILE="/tmp/openenv-pr-review.lock"
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Another instance is running. Exiting."
+    exit 0
+fi
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Starting PR review..."
+
+# Invoke Claude to handle the reviews
+exec claude --print --dangerously-skip-permissions --max-budget-usd 100.00 "
+Review PRs updated in the last 6 hours.
+
+1. Run: python3 scripts/pr_tracker.py --list --since 6h
+   This returns JSON with open PRs updated in the last 6 hours.
+
+2. For each PR, spawn a subagent (alignment-reviewer) to review it.
+   The subagent should:
+   - Read the diff and changed files
+   - Apply the two-tier review model (Tier 1: bugs/lint, Tier 2: alignment)
+   - Determine verdict: approve, comment, or request_changes
+
+3. After each review, use pr_tracker.post_review() to post the GitHub review.
+
+Run subagent reviews in parallel when possible.
+"

--- a/scripts/pr_tracker.py
+++ b/scripts/pr_tracker.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+PR Tracker - Fetches PRs that need review using GitHub API.
+
+This module provides data about open PRs. Claude handles orchestration,
+review logic, and posting reviews.
+
+Usage:
+    # Get PRs updated in the last 6 hours
+    python3 scripts/pr_tracker.py --list --since 6h
+
+    # Get PRs updated since a specific time
+    python3 scripts/pr_tracker.py --list --since 2024-01-13T00:00:00Z
+
+    # Get details for a specific PR
+    python3 scripts/pr_tracker.py --details 123
+"""
+
+import json
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+from github import Github, Auth
+
+# Configuration
+DEFAULT_REPO = "meta-pytorch/OpenEnv"
+DEFAULT_STATE_FILE = Path.home() / ".openenv-review-state.json"
+
+
+def _get_github_client() -> Github:
+    """Get authenticated GitHub client."""
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        return Github(auth=Auth.Token(token))
+
+    # Try gh CLI token
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        token = result.stdout.strip()
+        return Github(auth=Auth.Token(token))
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    raise RuntimeError(
+        "No GitHub token found. Set GITHUB_TOKEN env var or authenticate with 'gh auth login'"
+    )
+
+
+def parse_since(since_str: str) -> datetime:
+    """
+    Parse a 'since' argument into a datetime.
+
+    Accepts:
+    - Duration: "6h", "1d", "30m", "2w"
+    - ISO timestamp: "2024-01-13T00:00:00Z"
+    """
+    # Try duration format first (e.g., "6h", "1d", "30m")
+    duration_match = re.match(r"^(\d+)([mhdw])$", since_str.lower())
+    if duration_match:
+        value = int(duration_match.group(1))
+        unit = duration_match.group(2)
+        unit_map = {
+            "m": timedelta(minutes=value),
+            "h": timedelta(hours=value),
+            "d": timedelta(days=value),
+            "w": timedelta(weeks=value),
+        }
+        return datetime.now(timezone.utc) - unit_map[unit]
+
+    # Try ISO format
+    try:
+        # Handle various ISO formats
+        if since_str.endswith("Z"):
+            since_str = since_str[:-1] + "+00:00"
+        return datetime.fromisoformat(since_str)
+    except ValueError:
+        pass
+
+    raise ValueError(
+        f"Invalid 'since' format: {since_str}. "
+        "Use duration (6h, 1d, 30m, 2w) or ISO timestamp (2024-01-13T00:00:00Z)"
+    )
+
+
+def get_prs_needing_review(
+    repo: str = DEFAULT_REPO,
+    since: Optional[datetime] = None,
+    state_file: Optional[Path] = None,
+) -> list[dict]:
+    """
+    Get list of PRs that need review.
+
+    Args:
+        repo: Repository name (owner/repo)
+        since: Only return PRs updated after this time
+        state_file: Optional state file for SHA-based tracking (legacy)
+
+    Returns:
+        List of dicts with PR info:
+        - number: PR number
+        - title: PR title
+        - author: Author username
+        - url: PR URL
+        - head_sha: Current commit SHA
+        - updated_at: Last update time (ISO format)
+    """
+    gh = _get_github_client()
+    repo_obj = gh.get_repo(repo)
+
+    # Load state for SHA tracking if provided
+    repo_state = {}
+    if state_file and state_file.exists():
+        try:
+            state = json.loads(state_file.read_text())
+            repo_state = state.get(repo, {})
+        except json.JSONDecodeError:
+            pass
+
+    prs = []
+    for pr in repo_obj.get_pulls(state="open"):
+        if pr.draft:
+            continue
+
+        # Filter by update time if 'since' provided
+        if since and pr.updated_at < since:
+            continue
+
+        # If using state file, skip already-reviewed commits
+        if state_file:
+            pr_state = repo_state.get(str(pr.number), {})
+            if pr_state.get("last_reviewed_sha") == pr.head.sha:
+                continue
+
+        prs.append(
+            {
+                "number": pr.number,
+                "title": pr.title,
+                "author": pr.user.login,
+                "url": pr.html_url,
+                "head_sha": pr.head.sha,
+                "updated_at": pr.updated_at.isoformat(),
+            }
+        )
+
+    return prs
+
+
+def get_pr_details(pr_number: int, repo: str = DEFAULT_REPO) -> dict:
+    """Get detailed information about a specific PR."""
+    gh = _get_github_client()
+    repo_obj = gh.get_repo(repo)
+    pr = repo_obj.get_pull(pr_number)
+
+    return {
+        "number": pr.number,
+        "title": pr.title,
+        "author": pr.user.login,
+        "url": pr.html_url,
+        "head_sha": pr.head.sha,
+        "updated_at": pr.updated_at.isoformat(),
+        "body": pr.body or "",
+        "files": [f.filename for f in pr.get_files()],
+        "diff_url": pr.diff_url,
+        "additions": pr.additions,
+        "deletions": pr.deletions,
+        "changed_files": pr.changed_files,
+    }
+
+
+def record_review(
+    pr_number: int,
+    commit_sha: str,
+    verdict: str,
+    repo: str = DEFAULT_REPO,
+    state_file: Path = DEFAULT_STATE_FILE,
+):
+    """Record that a PR was reviewed (for SHA-based tracking)."""
+    state = {}
+    if state_file.exists():
+        try:
+            state = json.loads(state_file.read_text())
+        except json.JSONDecodeError:
+            pass
+
+    if repo not in state:
+        state[repo] = {}
+
+    state[repo][str(pr_number)] = {
+        "last_reviewed_sha": commit_sha,
+        "review_timestamp": datetime.now(timezone.utc).isoformat(),
+        "verdict": verdict,
+    }
+
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps(state, indent=2))
+    state_file.chmod(0o600)
+
+
+def post_review(
+    pr_number: int,
+    verdict: str,
+    body: str,
+    repo: str = DEFAULT_REPO,
+):
+    """
+    Post a review to a PR.
+
+    Args:
+        pr_number: PR number
+        verdict: One of "approve", "comment", "request_changes"
+        body: Review body (markdown)
+    """
+    gh = _get_github_client()
+    repo_obj = gh.get_repo(repo)
+    pr = repo_obj.get_pull(pr_number)
+
+    event_map = {
+        "approve": "APPROVE",
+        "comment": "COMMENT",
+        "request_changes": "REQUEST_CHANGES",
+    }
+    event = event_map.get(verdict, "COMMENT")
+
+    # Can't approve own PR
+    current_user = gh.get_user().login
+    if event == "APPROVE" and pr.user.login == current_user:
+        pr.create_issue_comment(body)
+        return
+
+    formatted_body = f"""> **Note**: This is an automated review by **Claude Code**, not a human review.
+
+---
+
+{body}
+
+---
+*Automated review by Claude Code | [Learn more](https://github.com/meta-pytorch/OpenEnv/blob/main/CLAUDE.md)*"""
+
+    pr.create_review(body=formatted_body, event=event)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="PR Tracker - Fetch PRs needing review",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # PRs updated in last 6 hours
+  python3 pr_tracker.py --list --since 6h
+
+  # PRs updated in last day
+  python3 pr_tracker.py --list --since 1d
+
+  # PRs updated since specific time
+  python3 pr_tracker.py --list --since 2024-01-13T00:00:00Z
+
+  # Get details for PR #123
+  python3 pr_tracker.py --details 123
+""",
+    )
+    parser.add_argument("--list", action="store_true", help="List PRs needing review")
+    parser.add_argument(
+        "--details", type=int, metavar="PR", help="Get details for specific PR"
+    )
+    parser.add_argument(
+        "--since",
+        type=str,
+        help="Only PRs updated since (e.g., 6h, 1d, 2024-01-13T00:00:00Z)",
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, help="Repository (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--use-state", action="store_true", help="Also filter by SHA state file"
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        since = parse_since(args.since) if args.since else None
+        state_file = DEFAULT_STATE_FILE if args.use_state else None
+        prs = get_prs_needing_review(repo=args.repo, since=since, state_file=state_file)
+        print(json.dumps(prs, indent=2))
+    elif args.details:
+        details = get_pr_details(args.details, repo=args.repo)
+        print(json.dumps(details, indent=2))
+    else:
+        parser.print_help()


### PR DESCRIPTION
## Summary

Replaces the broken bash-based PR review bot with a clean Python implementation.

**Key changes:**
- `scripts/pr_tracker.py` - PyGithub wrapper with `--since` argument for time-based filtering
- `scripts/pr-review-cron-wrapper.sh` - Simple wrapper that invokes Claude with a prompt
- Claude handles orchestration and spawns alignment-reviewer subagents

**Architecture:**
```
Cron (every 6h) → Claude → subagents → pr_tracker.post_review()
```

**Why this is better:**
- Claude returns the verdict directly (no regex parsing)
- Time-based filtering (`--since 6h`) instead of brittle state file tracking
- Clean Python code instead of fragile bash

**Fixes:**
- Blank approvals (header/footer only)
- Spurious approvals (approved PRs with blocking issues)

## Test plan
- [x] Tested `pr_tracker.py --list --since 6h` 
- [x] Dismissed 10 spurious/blank approvals from old system
- [ ] Run full cron job after merge