### PR TITLE
Fix some issues in docs

### DIFF
--- a/docs/environments/openapp.md
+++ b/docs/environments/openapp.md
@@ -1,0 +1,2 @@
+--8<-- "../../envs/openapp_env/README.md"
+

--- a/docs/environments/unity.md
+++ b/docs/environments/unity.md
@@ -1,0 +1,2 @@
+--8<-- "../../envs/unity_env/README.md"
+

--- a/envs/textarena_env/README.md
+++ b/envs/textarena_env/README.md
@@ -127,11 +127,14 @@ The deployed space includes:
 ## Environment Details
 
 ### Action
+
 **TextArenaAction**: Contains a single field
 - `message` (str) - The message/action to send to the game
 
 ### Observation
+
 **TextArenaObservation**: Contains the game state and response
+
 - `prompt` (str) - Game instructions and context
 - `messages` (List[TextArenaMessage]) - Conversation history with the game
 - `current_player_id` (int) - ID of the current player
@@ -141,13 +144,17 @@ The deployed space includes:
 - `done` (bool) - Whether the episode has ended (inherited from Observation)
 
 ### TextArenaMessage
+
 Each message in the conversation has:
+
 - `sender_id` (int) - ID of the message sender
 - `content` (str) - The message content
 - `category` (str) - Message type (e.g., "PROMPT", "MESSAGE")
 
 ### State
+
 **TextArenaState**: Server-side state snapshot
+
 - `episode_id` (str) - Unique identifier for the current episode
 - `step_count` (int) - Number of steps taken in the current episode
 - `env_id` (str) - The TextArena environment ID (e.g., "Wordle-v0")
@@ -159,6 +166,7 @@ Each message in the conversation has:
 - `raw_state` (Dict) - Raw TextArena state snapshot
 
 ### Reward
+
 Rewards are determined by the underlying TextArena game. For example:
 - **Wordle-v0**: Positive reward for winning, includes reward signals for green/yellow letter matches
 


### PR DESCRIPTION
Fixing a problem in TextArena's docs rendering and adding missing envs.

<img width="1090" height="752" alt="Screenshot 2026-01-16 at 15 37 00" src="https://github.com/user-attachments/assets/77637c82-6371-4198-bde7-666c91338654" />
