### PR TITLE
Update EchoEnv hub reference in quickstart guide

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,7 +49,7 @@ You can also use environments from Hugging Face. To do this, you can use the `fr
 ```python
 from echo_env import EchoEnv
 
-client = EchoEnv.from_hub("meta-pytorch/echo_env")
+client = EchoEnv.from_hub("openenv/echo_env")
 ```
 
 In the background, the environment will be pulled from Hugging Face and a container will be started on your local machine.


### PR DESCRIPTION
## Summary
Found an typo with the code in the documentation
```
from echo_env import EchoEnv
client = EchoEnv.from_hub("meta-pytorch/echo_env")
```
should be
```
from echo_env import EchoEnv
client = EchoEnv.from_hub("openenv/echo_env")
```
see [openenv/echo_env](https://huggingface.co/spaces/openenv/echo_env).
Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
<!-- How can reviewers verify this works? -->

## Claude Code Review
"N/A"
