### PR TITLE
Add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.worktrees/
 
 # PyInstaller
 *.manifest


### PR DESCRIPTION
Ignore git worktree directories to keep the repository clean when using `git worktree` for parallel development.