### PR TITLE
Fix template client missing StateT generic parameter

### DIFF
--- a/src/openenv/cli/templates/openenv_env/client.py
+++ b/src/openenv/cli/templates/openenv_env/client.py
@@ -16,7 +16,7 @@ from .models import __ENV_CLASS_NAME__Action, __ENV_CLASS_NAME__Observation
 
 
 class __ENV_CLASS_NAME__Env(
-    EnvClient[__ENV_CLASS_NAME__Action, __ENV_CLASS_NAME__Observation]
+    EnvClient[__ENV_CLASS_NAME__Action, __ENV_CLASS_NAME__Observation, State]
 ):
     """
     Client for the __ENV_TITLE_NAME__ Environment.

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -454,3 +454,20 @@ def test_init_handles_file_path_collision(tmp_path: Path) -> None:
     ), (
         f"Expected BadParameter error about file collision. Exit code: {result.exit_code}, Output: {result.output}"
     )
+
+
+def test_init_client_uses_three_generics(tmp_path: Path) -> None:
+    """Test that generated client.py uses EnvClient with 3 generic parameters."""
+    env_name = "test_env"
+    env_dir = tmp_path / env_name
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(str(tmp_path))
+        result = runner.invoke(app, ["init", env_name], input="\n")
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == 0
+    client_content = (env_dir / "client.py").read_text()
+    assert "EnvClient[TestAction, TestObservation, State]" in client_content


### PR DESCRIPTION
## Summary

- Fixed CLI template generating clients with only 2 generic parameters instead of required 3
- The template now correctly uses `EnvClient[ActT, ObsT, State]` matching the invariant
- Added regression test to prevent future breakage

## Test plan

- [x] All CLI tests pass (44/44)
- [x] Manual verification: `openenv init test_env` generates correct signature
- [x] Lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)