### PR TITLE
[Enhancement] OpenApp ScreenShot feature

### DIFF
--- a/envs/openapp_env/pyproject.toml
+++ b/envs/openapp_env/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     # BrowserGym dependencies
     "browsergym>=0.13.3",
     "playwright>=1.40.0",
+    # Image processing for screenshots
+    "Pillow>=10.0.0",
     # Additional dependencies for web app interaction
     "python-multipart>=0.0.20",
 ]

--- a/envs/openapp_env/server/Dockerfile
+++ b/envs/openapp_env/server/Dockerfile
@@ -83,12 +83,18 @@ RUN python -c "import open_apps; print('✓ OpenApps installed')"
 
 # Install openenv-core from GitHub with --no-deps to avoid openai>=2.7.2 conflict
 # Then install only the server dependencies (no openai needed for server)
+# Note: fastmcp is required by openenv-core for MCP support
 RUN pip install --no-cache-dir --no-deps "openenv-core @ git+https://github.com/meta-pytorch/OpenEnv.git" && \
-    pip install --no-cache-dir fastapi pydantic uvicorn requests websockets
+    pip install --no-cache-dir fastmcp fastapi pydantic uvicorn requests websockets
 
 # Install openapp_env and remaining dependencies
 WORKDIR /app/env
 RUN pip install --no-cache-dir -e .
+
+# IMPORTANT: Force-reinstall beartype AFTER all other pip installs
+# py-key-value-aio uses beartype_this_package which was renamed to beartype_package in 0.18
+# browsergym or other deps may install incompatible beartype versions
+RUN pip install --no-cache-dir --force-reinstall "beartype>=0.15,<0.18"
 
 # Verify installation
 RUN python -c "import openapp_env; print('✓ openapp_env installed')" && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "websockets>=15.0.1",
     # MCP support
     "fastmcp>=2.0.0",
+    # Pin beartype for py-key-value-aio compatibility (beartype_this_package was renamed in 0.18)
+    "beartype>=0.15,<0.18",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
This PR adds screenshot capture functionality to the OpenApp environment and fixes dependency issues that were causing import errors.

### Key Changes

- **Screenshot Feature**: Environment now captures and returns base64-encoded PNG screenshots after each action (`reset()` and `step()`)
- **Dependency Fixes**: Resolved `beartype` version conflicts and added missing `fastmcp` dependency to Dockerfile
- **Documentation**: Added troubleshooting guide and screenshot usage instructions to README

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Documentation

##  Changes

### Screenshot Implementation (`envs/openapp_env/server/openapp_environment.py`)

- Added `_current_screenshot` instance variable to track screenshot state
- Added `_extract_screenshot()` helper method to convert BrowserGym numpy arrays to base64 PNG
- Updated `reset()` and `step()` to extract and return screenshots
- Updated all `_execute_*` methods (click, fill, goto, scroll, send_keys) to capture screenshots
- Updated `_update_observation_from_page()` to capture screenshots from Playwright

### Dockerfile Fixes (`envs/openapp_env/server/Dockerfile`)

- Added `fastmcp` dependency (required by openenv-core for MCP support)
- Added beartype force-reinstall step after all pip installs to fix version conflicts
- beartype is pinned to `>=0.15,<0.18` for py-key-value-aio compatibility

### Dependencies (`envs/openapp_env/pyproject.toml`)

- Added `Pillow>=10.0.0` for screenshot image processing

### Example Script (`examples/openapp_example.py`)

- Added `--test-screenshots` flag to verify screenshot functionality
- Screenshots saved to `examples/screenshot_output/` with descriptive names
- Works with both local and docker modes

### Documentation (`envs/openapp_env/README.md`)

- Added "Screenshots" section with usage examples and test instructions
- Added troubleshooting section for `beartype_this_package` import errors
- Added `PYTHONNOUSERSITE` fix for conda/virtualenv users

### Other

- Added beartype pin to main `pyproject.toml` for local development

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)

## Test Plan

### Local Mode
```bash
# Terminal 1: Start OpenApps server
cd /path/to/OpenApps
uv run launch.py

# Terminal 2: Test screenshots
export OPENAPPS_URL=http://localhost:5001
export PYTHONNOUSERSITE=1
python examples/openapp_example.py --mode local --test-screenshots
```

### Docker Mode
```bash
# Build the updated Docker image
cd envs/openapp_env
docker build -t openapp-env:latest -f server/Dockerfile .

# Test screenshots
export PYTHONNOUSERSITE=1
python examples/openapp_example.py --mode docker --test-screenshots
```

### Expected Output
- Screenshots saved to `examples/screenshot_output/`
- Files like `local_reset.png`, `local_step_1_goto.png`, etc.
- Each screenshot should be a valid PNG image of the browser state

## Claude Code Review

Alignment Review Report from Claude Code                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                  
  Automated Checks                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                  
  - Lint: ✅ PASS - 79 files already formatted                                                                                                                                                                                                                                                                    
  - Debug code: ✅ CLEAN - Print statements found are in docstrings/examples only (not actual debug code)                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                  
  Open RFCs Context                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                  
  - RFC 000 (Project Phases): Status: In Review                                                                                                                                                                                                                                                                   
  - RFC 001 (Abstractions): Status: In Review                                                                                                                                                                                                                                                                     
  - RFC 002 (Env Spec): Status: In Review                                                                                                                                                                                                                                                                         
  - RFC 003 (MCP Support): Status: In Review                                                                                                                                                                                                                                                                      
  - RFC 004 (Rubrics): Status: Not specified                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                  
  None of these RFCs directly conflict with the screenshot feature addition.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                  
  Tier 1: Fixes Required                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                  
  None identified. All mechanical issues are clean:                                                                                                                                                                                                                                                               
  - No lint failures                                                                                                                                                                                                                                                                                              
  - No debug code in production paths                                                                                                                                                                                                                                                                             
  - No uninitialized variables or type errors                                                                                                                                                                                                                                                                     
  - No security issues (no credentials exposed)                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                  
  Tier 2: Alignment Discussion                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                  
  Principle Conflicts                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                  
  None identified. The changes align with OpenEnv principles:                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                  
  1. ✅ Simple Gymnasium-style API: Screenshot is added to the existing Observation model without changing the reset()/step() signatures                                                                                                                                                                          
  2. ✅ Type safety: Screenshot field already existed in OpenAppObservation as Optional[str] - this PR just populates it                                                                                                                                                                                          
  3. ✅ Container isolation: No changes to container security model                                                                                                                                                                                                                                               
  4. ✅ Rewards in environment: No changes to reward computation                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                  
  RFC Conflicts                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                  
  None identified. The changes don't conflict with any open RFCs:                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                  
  - RFC 001 (Abstractions): Screenshot is part of the observation, not a new API                                                                                                                                                                                                                                  
  - RFC 002 (Env Spec): Observation fields are environment-specific, screenshot is valid                                                                                                                                                                                                                          
  - RFC 003 (MCP Support): Adding fastmcp dependency aligns with this RFC                                                                                                                                                                                                                                         
  - RFC 004 (Rubrics): No interaction with rubrics functionality                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                  
  Invariant Check                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                  
  All invariants preserved:                                                                                                                                                                                                                                                                                       
  - ✅ Gymnasium API signatures: reset() and step() signatures unchanged                                                                                                                                                                                                                                          
  - ✅ Generic type safety: OpenAppObservation already had the screenshot field typed                                                                                                                                                                                                                             
  - ✅ Pydantic serialization: Screenshot is base64 string, JSON-compatible                                                                                                                                                                                                                                       
  - ✅ Agent isolation: No simulation controls exposed                                                                                                                                                                                                                                                            
  - ✅ Client-server separation: Changes are server-side only (except README docs)                                                                                                                                                                                                                                
  - ✅ Rewards in environment: Unchanged                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                  
  Summary                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                  
  - 0 mechanical issues to fix                                                                                                                                                                                                                                                                                    
  - 0 alignment points for human review                                                                                                                                                                                                                                                                           
  - 0 RFC conflicts to discuss                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                  
  Recommendation: This PR is ready for merge. The changes are additive (populating an existing field), fix real dependency issues, and include good documentation.
