### PR TITLE
RFC 004: Add delayed rewards support for trajectory-based scoring

### DIFF
--- a/rfcs/004-rubrics.md
+++ b/rfcs/004-rubrics.md
@@ -293,6 +293,336 @@ The `evaluate_batch()` helper accepts an optional `max_workers` parameter to con
 
 ---
 
+## Delayed Rewards
+
+The per-step `Rubric.forward(action, observation) -> float` API handles immediate rewards well, but many environments require delayed rewards where the score depends on future events:
+
+- **Cursor Plan Mode**: Reward for writing a plan depends on later execution success
+- **Codenames**: Spymaster's clue quality depends on Operative's subsequent guesses
+- **Chess**: Win/loss only known at game end, needs discounting back to earlier moves
+
+### Self-Accumulating TrajectoryRubric
+
+Since OpenEnv doesn't batch (one env = one trajectory), the rubric itself can accumulate the trajectory internally. No separate trajectory buffer is needed.
+
+**The pattern**:
+1. `TrajectoryRubric.__call__(action, obs)` records step internally
+2. Returns `0.0` (or configurable intermediate reward) until `obs.done=True`
+3. On done, computes final score from accumulated trajectory
+4. `reset()` clears the internal buffer
+5. Composes naturally with `Sequential`, `RubricDict`, etc.
+
+### Memory Model: CPU-Only Trajectories
+
+**Constraint**: Trajectories must not consume GPU memory.
+
+**Design**: `TrajectoryRubric` stores observations in CPU memory only. Environments with GPU tensors in observations must detach/move to CPU before returning from `step()`.
+
+**Future extension**: If CPU memory becomes problematic at scale, a reference-based approach could store `(episode_id, step_index)` tuples referencing external replay buffers.
+
+### TrajectoryRubric Base Class
+
+```python
+from abc import abstractmethod
+from typing import List, Tuple, Any
+
+
+class TrajectoryRubric(Rubric):
+    """Abstract base for rubrics that score based on full trajectories.
+
+    Subclasses implement:
+    - score_trajectory(): Compute final score from trajectory
+    - compute_step_rewards(): Define credit assignment strategy
+
+    The __call__ method accumulates steps and returns rewards according
+    to the subclass's implementation.
+
+    IMPORTANT: Trajectories are stored in CPU memory to avoid GPU pressure.
+    Environments with GPU tensors in observations must move them to CPU
+    before returning from step().
+
+    Known limitation: Very long episodes (thousands of steps) may consume
+    significant CPU memory. For such cases, consider streaming rubrics.
+    """
+
+    def __init__(self, intermediate_reward: float = 0.0):
+        super().__init__()
+        self.intermediate_reward = intermediate_reward
+        self._trajectory: List[Tuple[Any, Observation]] = []
+
+    def __call__(self, action, observation) -> float:
+        """Accumulate step and return reward.
+
+        Returns intermediate_reward until done, then computes trajectory score.
+        """
+        self._trajectory.append((action, observation))
+
+        if getattr(observation, 'done', False):
+            return self.score_trajectory(self._trajectory)
+        else:
+            return self.intermediate_reward
+
+    @abstractmethod
+    def score_trajectory(self, trajectory: List[Tuple[Any, Observation]]) -> float:
+        """Score the complete trajectory. Return 0.0-1.0.
+
+        Called when observation.done=True.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def compute_step_rewards(self) -> List[float]:
+        """Compute per-step rewards from the accumulated trajectory.
+
+        Returns: List of rewards, one per step.
+        Define your credit assignment strategy here.
+        """
+        raise NotImplementedError
+
+    def reset(self):
+        """Clear accumulated trajectory. Call on env.reset()."""
+        self._trajectory = []
+
+    @property
+    def trajectory(self) -> List[Tuple[Any, Observation]]:
+        """Current trajectory (read-only copy)."""
+        return list(self._trajectory)
+```
+
+### ExponentialDiscountingTrajectoryRubric
+
+Concrete implementation with standard gamma-based discounting:
+
+```python
+class ExponentialDiscountingTrajectoryRubric(TrajectoryRubric):
+    """TrajectoryRubric with exponential discounting for credit assignment.
+
+    Per-step reward: r_t = gamma^(T-1-t) * R_final
+
+    With gamma=0.99, later steps get higher reward (they're "closer" to the outcome).
+    With gamma=1.0, all steps get equal reward.
+
+    Usage:
+        rubric = ChessWinLossRubric(gamma=0.99)
+        reward = rubric(action, obs)  # Returns 0.0 until done, then final score
+        step_rewards = rubric.compute_step_rewards()  # Get discounted per-step rewards
+    """
+
+    def __init__(self, gamma: float = 0.99, intermediate_reward: float = 0.0):
+        super().__init__(intermediate_reward=intermediate_reward)
+        self.gamma = gamma
+
+    def compute_step_rewards(self) -> List[float]:
+        """Apply exponential discounting from final reward."""
+        if not self._trajectory:
+            return []
+
+        final_score = self.score_trajectory(self._trajectory)
+        T = len(self._trajectory)
+        return [final_score * (self.gamma ** (T - 1 - t)) for t in range(T)]
+```
+
+### Composition with Existing Containers
+
+TrajectoryRubric extends Rubric, so it composes naturally:
+
+```python
+# Terminal game with format check first
+rubric = Sequential(
+    FormatRubric(),           # Per-step: check action format
+    ChessWinLossRubric(),     # Trajectory: score at game end
+)
+
+# Multi-game environment
+rubric = RubricDict({
+    "chess": ChessWinLossRubric(gamma=0.99),
+    "codenames": CodenamesRubric(gamma=0.95),
+})
+
+# Weighted combination of per-step and trajectory
+rubric = WeightedSum(
+    [ClueQualityRubric(), GameOutcomeRubric()],
+    weights=[0.3, 0.7],
+)
+```
+
+### Example: Chess with Discounting
+
+```python
+class ChessWinLossRubric(ExponentialDiscountingTrajectoryRubric):
+    """Score chess game based on outcome with temporal discounting."""
+
+    def __init__(self, gamma: float = 0.99):
+        super().__init__(gamma=gamma, intermediate_reward=0.0)
+
+    def score_trajectory(self, trajectory: List[Tuple[Any, Observation]]) -> float:
+        """Score based on game outcome."""
+        if not trajectory:
+            return 0.0
+
+        _, final_obs = trajectory[-1]  # Unpack (action, observation)
+        outcome = getattr(final_obs, 'metadata', {}).get('winner')
+
+        if outcome == 'agent':
+            return 1.0
+        elif outcome == 'opponent':
+            return 0.0
+        else:
+            return 0.5  # Draw
+```
+
+### Example: Cursor Plan Mode
+
+```python
+class PlanExecutionRubric(TrajectoryRubric):
+    """Score based on whether plan led to successful execution.
+
+    Custom credit assignment: full reward goes to the plan step,
+    zero to execution steps (since execution just follows the plan).
+    """
+
+    def __init__(self):
+        super().__init__(intermediate_reward=0.0)
+
+    def score_trajectory(self, trajectory: List[Tuple[Any, Observation]]) -> float:
+        """Score = execution success rate."""
+        if len(trajectory) < 2:
+            return 0.0
+
+        # Find execution steps after plan
+        plan_idx = None
+        for i, (action, obs) in enumerate(trajectory):
+            if getattr(action, 'metadata', {}).get('type') == 'plan':
+                plan_idx = i
+
+        if plan_idx is None:
+            return 0.0
+
+        # Score based on test results after plan
+        execution_steps = trajectory[plan_idx + 1:]
+        if not execution_steps:
+            return 0.0
+
+        _, final_obs = execution_steps[-1]
+        tests_passed = final_obs.metadata.get('tests_passed', 0)
+        tests_total = final_obs.metadata.get('tests_total', 1)
+
+        return tests_passed / tests_total if tests_total > 0 else 0.0
+
+    def compute_step_rewards(self) -> List[float]:
+        """Assign full reward to plan step, zero to execution."""
+        final_score = self.score_trajectory(self._trajectory)
+        rewards = [0.0] * len(self._trajectory)
+
+        for i, (action, obs) in enumerate(self._trajectory):
+            if getattr(action, 'metadata', {}).get('type') == 'plan':
+                rewards[i] = final_score
+
+        return rewards
+```
+
+### Example: Codenames (Mixed Per-Step + Trajectory)
+
+```python
+class CodenamesRubric(Rubric):
+    """Combine per-clue quality with game outcome."""
+
+    def __init__(self):
+        super().__init__()
+        self.clue_quality = ClueQualityRubric()    # Per-step
+        self.game_outcome = GameWinRubric()         # Trajectory
+        self.clue_scores: List[float] = []
+
+    def __call__(self, action, observation) -> float:
+        # Score clue quality per-step
+        if getattr(action, 'metadata', {}).get('type') == 'give_clue':
+            score = self.clue_quality(action, observation)
+            self.clue_scores.append(score)
+
+        # Delegate to trajectory rubric (it accumulates internally)
+        outcome_reward = self.game_outcome(action, observation)
+
+        if observation.done:
+            # Combine: 30% clue quality, 70% game outcome
+            clue_avg = sum(self.clue_scores) / len(self.clue_scores) if self.clue_scores else 0.0
+            return 0.3 * clue_avg + 0.7 * outcome_reward
+        else:
+            return 0.0
+
+    def reset(self):
+        self.clue_scores = []
+        self.game_outcome.reset()
+
+
+class GameWinRubric(ExponentialDiscountingTrajectoryRubric):
+    """Score based on win/loss outcome."""
+
+    def score_trajectory(self, trajectory: List[Tuple[Any, Observation]]) -> float:
+        if not trajectory:
+            return 0.0
+        _, final_obs = trajectory[-1]
+        if final_obs.metadata.get('outcome') == 'win':
+            return 1.0
+        elif final_obs.metadata.get('outcome') == 'loss':
+            return 0.0
+        return 0.5
+```
+
+### Environment Integration
+
+```python
+class ChessEnvironment(Environment[ChessAction, ChessObservation, ChessState]):
+    """Chess environment with trajectory-based scoring."""
+
+    def __init__(self):
+        super().__init__()
+        self.rubric = ChessWinLossRubric(gamma=0.99)
+
+    def reset(self, seed=None, episode_id=None, **kwargs) -> ChessObservation:
+        self._state = ChessState(episode_id=episode_id or str(uuid4()))
+        self.rubric.reset()  # Clear rubric's trajectory
+        return self._make_observation()
+
+    def step(self, action: ChessAction) -> ChessObservation:
+        obs = self._apply_move(action)
+
+        # Rubric handles trajectory accumulation internally
+        obs.reward = self.rubric(action, obs)
+
+        return obs
+```
+
+**Note**: The environment just calls `self.rubric(action, obs)` on every step. The rubric handles:
+- Accumulating trajectory internally
+- Returning 0.0 until done
+- Computing final reward when done
+
+### Training Loop: Retrieving Per-Step Rewards
+
+For training systems that need per-step rewards for credit assignment:
+
+```python
+obs = env.reset()
+while True:
+    action = agent.act(obs)
+    obs = env.step(action)
+
+    if obs.done:
+        # Get per-step rewards (discounting depends on rubric implementation)
+        step_rewards = env.rubric.compute_step_rewards()
+
+        # step_rewards[i] corresponds to trajectory step i
+        # For ExponentialDiscountingTrajectoryRubric with gamma=0.99:
+        # later moves get higher reward (closer to outcome)
+        for (action, obs), reward in zip(env.rubric.trajectory, step_rewards):
+            # Use for gradient computation...
+            pass
+
+        break
+```
+
+---
+
 ## Implementation Plan
 
 This RFC will be implemented in stacked PRs:
@@ -316,7 +646,18 @@ This RFC will be implemented in stacked PRs:
 - Migrate `textarena_env` from `RewardProvider` to `Rubric`
 - Update any other environments using custom reward patterns
 
-### PR 4: EnvPool (Future)
+### PR 4: Trajectory Rubrics
+
+- `TrajectoryRubric` base class in `src/openenv/core/rubrics/trajectory.py`
+- `ExponentialDiscountingTrajectoryRubric` concrete implementation
+- Unit tests for trajectory accumulation, discounting, and reset behavior
+
+### PR 5: Trajectory Rubric Examples
+
+- Add trajectory rubric to an existing game environment (e.g., `connect4_env` or `openspiel_env`)
+- Demonstrate integration with environment reset/step cycle
+
+### PR 6: EnvPool (Future)
 
 - Batch orchestration across stacked environments
 - `step_batch()` helper for parallel execution


### PR DESCRIPTION
## Summary

Extends RFC 004 to address Issue #107: the per-step `forward(action, obs)` API doesn't support delayed rewards where score depends on future events.

**Examples of delayed reward scenarios:**
- **Cursor Plan Mode**: Reward for writing a plan depends on later execution success
- **Codenames**: Spymaster's clue quality depends on Operative's subsequent guesses
- **Chess**: Win/loss only known at game end, needs discounting back to earlier moves

## Key Additions to RFC 004

### Self-Accumulating TrajectoryRubric
Since OpenEnv doesn't batch (one env = one trajectory), the rubric itself accumulates the trajectory internally:
1. `TrajectoryRubric.__call__(action, obs)` records step internally
2. Returns `0.0` (or configurable intermediate reward) until `obs.done=True`
3. On done, computes final score from accumulated trajectory
4. `reset()` clears the internal buffer
5. Composes naturally with `Sequential`, `RubricDict`, etc.

### ExponentialDiscountingTrajectoryRubric
Standard gamma-based discounting: `r_t = gamma^(T-1-t) * R_final`

### Memory Model
CPU-only trajectories to avoid GPU pressure. Environments with GPU tensors must move them to CPU before returning from `step()`.

### Examples
- Chess with win/loss and temporal discounting
- Cursor Plan Mode with custom credit assignment
- Codenames mixing per-step and trajectory rewards

## Test Plan

- [ ] Review RFC additions for clarity and completeness
- [ ] Verify examples are correct and representative
- [ ] Check consistency with existing RFC 004 content

Resolves: #107