### PR TITLE
Add TextArena and Connect4 rubric examples (RFC 004)

### DIFF
--- a/envs/connect4_env/rubrics.py
+++ b/envs/connect4_env/rubrics.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Trajectory-based rubrics for Connect4 environment.
+
+This module demonstrates the TrajectoryRubric pattern from RFC 004
+for terminal games where reward signals depend on game outcome.
+
+Connect4 is ideal for demonstrating trajectory rubrics because:
+- Win/loss is only known at game end
+- Clear semantics: 1.0 for win, 0.0 for loss, 0.5 for draw
+- Discounting can assign more credit to decisive late-game moves
+"""
+
+from typing import Any, Dict, List, Tuple
+
+from openenv.core.rubrics import ExponentialDiscountingTrajectoryRubric
+
+
+class Connect4WinLossRubric(ExponentialDiscountingTrajectoryRubric):
+    """Trajectory rubric that scores Connect4 games based on outcome.
+
+    Scores:
+    - 1.0 for win (player made 4 in a row)
+    - 0.0 for loss (opponent made 4 in a row, or player made invalid move)
+    - 0.5 for draw (board full, no winner)
+
+    With exponential discounting, later moves (closer to the decisive
+    outcome) receive higher rewards. This helps credit assignment:
+    the move that completes 4-in-a-row gets the most credit.
+
+    Usage:
+        rubric = Connect4WinLossRubric(gamma=0.95)
+        env = Connect4Environment(rubric=rubric)
+
+        obs = env.reset()
+        while not obs.done:
+            action = agent.act(obs)
+            obs = env.step(action)
+
+        # Get per-step rewards for training
+        step_rewards = rubric.compute_step_rewards()
+        # step_rewards[i] = gamma^(T-1-i) * final_score
+    """
+
+    def __init__(
+        self,
+        gamma: float = 0.95,
+        invalid_move_penalty: float = 0.0,
+        player_id: int = 1,
+    ):
+        """Initialize Connect4 trajectory rubric.
+
+        Args:
+            gamma: Discount factor for credit assignment. 0.95 gives
+                more credit to later (decisive) moves.
+            invalid_move_penalty: Score when player makes invalid move.
+                Default 0.0 (treat as loss).
+            player_id: Which player we're scoring for (1 or -1).
+        """
+        super().__init__(gamma=gamma, intermediate_reward=0.0)
+        self.invalid_move_penalty = invalid_move_penalty
+        self.player_id = player_id
+
+    def score_trajectory(self, trajectory: List[Tuple[Any, Any]]) -> float:
+        """Score based on game outcome.
+
+        Returns:
+            1.0 for win, 0.0 for loss, 0.5 for draw.
+        """
+        if not trajectory:
+            return 0.0
+
+        _, final_obs = trajectory[-1]
+
+        # Check for done observation
+        if not getattr(final_obs, "done", False):
+            return 0.0
+
+        # Get reward from observation
+        reward = getattr(final_obs, "reward", 0.0)
+        if reward is None:
+            reward = 0.0
+
+        # Interpret reward:
+        # -1 = invalid move (loss)
+        # 1.0 = win
+        # 0.0 with done = draw
+        if reward == -1:
+            return self.invalid_move_penalty
+        elif reward == 1.0:
+            return 1.0
+        elif reward == 0.0:
+            # Draw (board full, no winner)
+            return 0.5
+        else:
+            # Unexpected value, treat as loss
+            return 0.0
+
+    def state_dict(self) -> Dict[str, Any]:
+        """Serialize configuration."""
+        state = super().state_dict()
+        state["invalid_move_penalty"] = self.invalid_move_penalty
+        state["player_id"] = self.player_id
+        return state
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        """Load configuration from checkpoint."""
+        super().load_state_dict(state)
+        if "invalid_move_penalty" in state:
+            self.invalid_move_penalty = state["invalid_move_penalty"]
+        if "player_id" in state:
+            self.player_id = state["player_id"]
+
+
+__all__ = [
+    "Connect4WinLossRubric",
+]

--- a/envs/textarena_env/rubrics.py
+++ b/envs/textarena_env/rubrics.py
@@ -1,0 +1,243 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Rubrics for TextArena environments.
+
+This module provides Rubric implementations for TextArena games,
+migrated from the legacy RewardProvider interface to the new
+Rubric abstraction (RFC 004).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Tuple
+
+from openenv.core.rubrics import Rubric, RubricDict
+
+try:
+    from textarena_env.models import TextArenaAction, TextArenaObservation
+except ImportError:
+    from models import TextArenaAction, TextArenaObservation
+
+
+_WORDLE_GUESS_PATTERN = re.compile(r"\[[A-Za-z]{5}\]")
+
+
+def extract_guess(text: str) -> str:
+    """Normalize a Wordle guess string from arbitrary text."""
+    match = _WORDLE_GUESS_PATTERN.search(text)
+    if match:
+        return match.group(0).lower()
+
+    cleaned = re.sub(r"[^a-z]", "", text.lower())
+    if len(cleaned) >= 5:
+        return f"[{cleaned[:5]}]"
+    return "[dunno]"
+
+
+def extract_wordle_feedback(observation: TextArenaObservation) -> str:
+    """Pull the latest feedback text from a Wordle observation."""
+    for message in reversed(observation.messages):
+        content = message.content.strip()
+        if "Feedback:" in content:
+            return content.split("Feedback:", 1)[-1].strip()
+    return ""
+
+
+def extract_feedback_counts(feedback: str) -> Tuple[int, int]:
+    """Return counts of green (G) and yellow (Y) markers from feedback."""
+    if not feedback:
+        return (0, 0)
+
+    lines = [line.strip() for line in feedback.split("\n") if line.strip()]
+    if len(lines) < 2:
+        return (0, 0)
+
+    for line in reversed(lines):
+        normalized = line.replace(" ", "")
+        if normalized and all(c in "GYX" for c in normalized):
+            green = normalized.count("G")
+            yellow = normalized.count("Y")
+            return (green, yellow)
+
+    return (0, 0)
+
+
+class WordleGreensRubric(Rubric):
+    """Rubric that scores based on green (correct position) letters in Wordle.
+
+    Returns a score from 0.0 to 1.0 based on how many letters are in
+    the correct position (green count / 5).
+    """
+
+    def forward(self, action: Any, observation: Any) -> float:
+        if not isinstance(observation, TextArenaObservation):
+            return 0.0
+        feedback = extract_wordle_feedback(observation)
+        if not feedback:
+            return 0.0
+        green_count, _ = extract_feedback_counts(feedback)
+        return green_count / 5.0
+
+
+class WordleYellowsRubric(Rubric):
+    """Rubric that scores based on yellow (correct letter, wrong position) in Wordle.
+
+    Returns a score from 0.0 to 1.0 based on how many letters are in
+    the word but wrong position (yellow count / 5).
+    """
+
+    def forward(self, action: Any, observation: Any) -> float:
+        if not isinstance(observation, TextArenaObservation):
+            return 0.0
+        feedback = extract_wordle_feedback(observation)
+        if not feedback:
+            return 0.0
+        _, yellow_count = extract_feedback_counts(feedback)
+        return yellow_count / 5.0
+
+
+class WordleRepetitionsRubric(Rubric):
+    """Rubric that penalizes repeated guesses in Wordle.
+
+    Returns 1.0 for first occurrence of a guess, decreasing by 1.0
+    for each repetition (can go negative for heavily repeated guesses).
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._guess_history: Dict[str, int] = {}
+
+    def forward(self, action: Any, observation: Any) -> float:
+        if not isinstance(action, TextArenaAction):
+            return 0.0
+
+        guess = extract_guess(action.message)
+        normalized_guess = guess if guess and guess != "[dunno]" else ""
+
+        if not normalized_guess:
+            return 0.0
+
+        previous_occurrences = self._guess_history.get(normalized_guess, 0)
+        self._guess_history[normalized_guess] = previous_occurrences + 1
+
+        return 1.0 - previous_occurrences
+
+    def reset(self) -> None:
+        """Clear guess history for new episode."""
+        self._guess_history.clear()
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {"guess_history": dict(self._guess_history)}
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        if "guess_history" in state:
+            self._guess_history = dict(state["guess_history"])
+
+
+class WordleCorrectRubric(Rubric):
+    """Rubric that returns the game's correct/win reward from observation.
+
+    Simply passes through the reward from the underlying TextArena game.
+    """
+
+    def forward(self, action: Any, observation: Any) -> float:
+        if not isinstance(observation, TextArenaObservation):
+            return 0.0
+        return float(observation.reward or 0.0)
+
+
+class WordleRubric(Rubric):
+    """Composite rubric for Wordle that combines multiple scoring signals.
+
+    Provides the same signals as the legacy _WordleRewardProvider:
+    - greens: Score based on correct position letters
+    - yellows: Score based on correct letters in wrong position
+    - repetitions: Penalty for repeated guesses
+    - correct: Pass-through of game win/loss reward
+
+    Usage:
+        rubric = WordleRubric()
+        reward = rubric(action, observation)
+
+        # Access individual component scores
+        print(f"Greens: {rubric.greens.last_score}")
+        print(f"Yellows: {rubric.yellows.last_score}")
+    """
+
+    SIGNAL_MAP = {
+        "greens": "wordle.greens",
+        "yellows": "wordle.yellows",
+        "repetitions": "wordle.repetitions",
+        "correct": "wordle.correct",
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.greens = WordleGreensRubric()
+        self.yellows = WordleYellowsRubric()
+        self.repetitions = WordleRepetitionsRubric()
+        self.correct = WordleCorrectRubric()
+
+    def forward(self, action: Any, observation: Any) -> float:
+        """Evaluate all sub-rubrics and return the correct (win) score."""
+        # Evaluate all components - their scores are tracked via last_score
+        self.greens(action, observation)
+        self.yellows(action, observation)
+        self.repetitions(action, observation)
+        correct_score = self.correct(action, observation)
+
+        # Return the game's win/loss reward as the primary signal
+        return correct_score
+
+    def reset(self) -> None:
+        """Reset all child rubrics."""
+        self.greens.reset()
+        self.yellows.reset()
+        self.repetitions.reset()
+        self.correct.reset()
+
+    def get_reward_signals(self) -> Dict[str, float]:
+        """Get all reward signals in the legacy format.
+
+        Returns a dict mapping signal names to scores, compatible with
+        the legacy RewardProvider interface.
+        """
+        return {
+            self.SIGNAL_MAP["greens"]: self.greens.last_score or 0.0,
+            self.SIGNAL_MAP["yellows"]: self.yellows.last_score or 0.0,
+            self.SIGNAL_MAP["repetitions"]: self.repetitions.last_score or 0.0,
+            self.SIGNAL_MAP["correct"]: self.correct.last_score or 0.0,
+        }
+
+
+def build_rubric(env_id: str) -> Rubric | None:
+    """Instantiate the appropriate rubric for the given environment.
+
+    Args:
+        env_id: The TextArena environment ID (e.g., "Wordle-v0").
+
+    Returns:
+        A Rubric instance for the environment, or None if no specific
+        rubric is defined.
+    """
+    if env_id == "Wordle-v0":
+        return WordleRubric()
+    return None
+
+
+__all__ = [
+    "WordleRubric",
+    "WordleGreensRubric",
+    "WordleYellowsRubric",
+    "WordleRepetitionsRubric",
+    "WordleCorrectRubric",
+    "build_rubric",
+    "extract_guess",
+    "extract_wordle_feedback",
+    "extract_feedback_counts",
+]

--- a/tests/envs/test_connect4_rubrics.py
+++ b/tests/envs/test_connect4_rubrics.py
@@ -1,0 +1,192 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for Connect4 trajectory rubrics."""
+
+import pytest
+from dataclasses import dataclass
+from typing import Any, List
+
+from connect4_env.rubrics import Connect4WinLossRubric
+
+
+@dataclass
+class MockObservation:
+    """Mock observation for testing."""
+
+    done: bool = False
+    reward: float = 0.0
+
+
+@dataclass
+class MockAction:
+    """Mock action for testing."""
+
+    column: int = 0
+
+
+class TestConnect4WinLossRubric:
+    """Test Connect4 trajectory rubric."""
+
+    def test_returns_intermediate_until_done(self):
+        """Returns 0.0 for non-terminal steps."""
+        rubric = Connect4WinLossRubric(gamma=0.95)
+
+        action = MockAction(column=3)
+        obs = MockObservation(done=False, reward=0.0)
+
+        reward = rubric(action, obs)
+        assert reward == 0.0
+
+    def test_win_returns_one(self):
+        """Returns 1.0 when player wins."""
+        rubric = Connect4WinLossRubric(gamma=0.95)
+
+        # Simulate 3 moves leading to win
+        rubric(MockAction(column=0), MockObservation(done=False))
+        rubric(MockAction(column=1), MockObservation(done=False))
+        reward = rubric(MockAction(column=2), MockObservation(done=True, reward=1.0))
+
+        assert reward == 1.0
+
+    def test_loss_returns_zero(self):
+        """Returns 0.0 when player loses (invalid move)."""
+        rubric = Connect4WinLossRubric(gamma=0.95)
+
+        reward = rubric(MockAction(column=0), MockObservation(done=True, reward=-1))
+
+        assert reward == 0.0  # default invalid_move_penalty
+
+    def test_draw_returns_half(self):
+        """Returns 0.5 for draw (board full, no winner)."""
+        rubric = Connect4WinLossRubric(gamma=0.95)
+
+        reward = rubric(MockAction(column=0), MockObservation(done=True, reward=0.0))
+
+        assert reward == 0.5
+
+    def test_discounting_with_gamma_one(self):
+        """With gamma=1.0, all steps get equal credit."""
+        rubric = Connect4WinLossRubric(gamma=1.0)
+
+        # 5-step episode with win
+        for _ in range(4):
+            rubric(MockAction(column=0), MockObservation(done=False))
+        rubric(MockAction(column=0), MockObservation(done=True, reward=1.0))
+
+        step_rewards = rubric.compute_step_rewards()
+
+        assert len(step_rewards) == 5
+        assert all(r == 1.0 for r in step_rewards)
+
+    def test_discounting_with_gamma_095(self):
+        """With gamma=0.95, later steps get more credit."""
+        rubric = Connect4WinLossRubric(gamma=0.95)
+
+        # 3-step episode with win
+        rubric(MockAction(column=0), MockObservation(done=False))
+        rubric(MockAction(column=1), MockObservation(done=False))
+        rubric(MockAction(column=2), MockObservation(done=True, reward=1.0))
+
+        step_rewards = rubric.compute_step_rewards()
+
+        # r_t = gamma^(T-1-t) * final_score
+        # t=0: 0.95^2 = 0.9025
+        # t=1: 0.95^1 = 0.95
+        # t=2: 0.95^0 = 1.0
+        assert step_rewards[0] == pytest.approx(0.9025)
+        assert step_rewards[1] == pytest.approx(0.95)
+        assert step_rewards[2] == pytest.approx(1.0)
+
+    def test_reset_clears_trajectory(self):
+        """Reset clears accumulated trajectory."""
+        rubric = Connect4WinLossRubric(gamma=0.95)
+
+        rubric(MockAction(column=0), MockObservation(done=False))
+        rubric(MockAction(column=1), MockObservation(done=False))
+
+        assert len(rubric._trajectory) == 2
+
+        rubric.reset()
+
+        assert len(rubric._trajectory) == 0
+
+    def test_custom_invalid_move_penalty(self):
+        """Can customize penalty for invalid moves."""
+        rubric = Connect4WinLossRubric(gamma=0.95, invalid_move_penalty=-1.0)
+
+        reward = rubric(MockAction(column=0), MockObservation(done=True, reward=-1))
+
+        assert reward == -1.0
+
+    def test_state_dict_serialization(self):
+        """State dict includes custom parameters."""
+        rubric = Connect4WinLossRubric(
+            gamma=0.9,
+            invalid_move_penalty=0.1,
+            player_id=-1,
+        )
+
+        state = rubric.state_dict()
+
+        assert state["gamma"] == 0.9
+        assert state["invalid_move_penalty"] == 0.1
+        assert state["player_id"] == -1
+
+    def test_load_state_dict(self):
+        """Can load configuration from state dict."""
+        rubric = Connect4WinLossRubric(gamma=0.95)
+
+        rubric.load_state_dict(
+            {
+                "gamma": 0.8,
+                "invalid_move_penalty": 0.5,
+                "player_id": -1,
+            }
+        )
+
+        assert rubric.gamma == 0.8
+        assert rubric.invalid_move_penalty == 0.5
+        assert rubric.player_id == -1
+
+
+class TestConnect4RubricIntegration:
+    """Integration tests with Connect4 environment patterns."""
+
+    def test_multiple_episodes(self):
+        """Handles multiple episodes correctly."""
+        rubric = Connect4WinLossRubric(gamma=0.95)
+
+        # Episode 1: Win
+        rubric(MockAction(column=0), MockObservation(done=False))
+        rubric(MockAction(column=0), MockObservation(done=True, reward=1.0))
+        ep1_rewards = rubric.compute_step_rewards()
+
+        rubric.reset()
+
+        # Episode 2: Loss
+        rubric(MockAction(column=0), MockObservation(done=True, reward=-1))
+        ep2_rewards = rubric.compute_step_rewards()
+
+        assert ep1_rewards[-1] == 1.0  # Win
+        assert ep2_rewards[0] == 0.0  # Loss (invalid move penalty)
+
+    def test_long_game(self):
+        """Handles longer games correctly."""
+        rubric = Connect4WinLossRubric(gamma=0.99)
+
+        # Simulate a 20-move game ending in win
+        for _ in range(19):
+            rubric(MockAction(column=0), MockObservation(done=False))
+        rubric(MockAction(column=0), MockObservation(done=True, reward=1.0))
+
+        step_rewards = rubric.compute_step_rewards()
+
+        assert len(step_rewards) == 20
+        # First move should have gamma^19 reward
+        assert step_rewards[0] == pytest.approx(0.99**19)
+        # Last move gets full reward
+        assert step_rewards[-1] == 1.0

--- a/tests/envs/test_textarena_rubrics.py
+++ b/tests/envs/test_textarena_rubrics.py
@@ -1,0 +1,220 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for TextArena rubrics."""
+
+import pytest
+from typing import Any, Dict, List
+
+from textarena_env.models import TextArenaAction, TextArenaMessage, TextArenaObservation
+from textarena_env.rubrics import (
+    WordleRubric,
+    WordleGreensRubric,
+    WordleYellowsRubric,
+    WordleRepetitionsRubric,
+    WordleCorrectRubric,
+    build_rubric,
+    extract_guess,
+    extract_wordle_feedback,
+    extract_feedback_counts,
+)
+
+
+def make_wordle_observation(
+    feedback_text: str = "",
+    reward: float = 0.0,
+    done: bool = False,
+) -> TextArenaObservation:
+    """Create a mock Wordle observation."""
+    messages = []
+    if feedback_text:
+        messages.append(
+            TextArenaMessage(
+                sender_id=-1,
+                content=f"Feedback: {feedback_text}",
+                category="MESSAGE",
+            )
+        )
+    return TextArenaObservation(
+        prompt="Guess the word",
+        messages=messages,
+        current_player_id=0,
+        legal_players=[0],
+        info={},
+        reward=reward,
+        done=done,
+    )
+
+
+class TestExtractGuess:
+    """Test guess extraction from action text."""
+
+    def test_bracketed_guess(self):
+        assert extract_guess("[hello]") == "[hello]"
+        assert extract_guess("[WORLD]") == "[world]"
+
+    def test_unbracketed_guess(self):
+        assert extract_guess("hello") == "[hello]"
+        assert extract_guess("helloworld") == "[hello]"
+
+    def test_short_text(self):
+        assert extract_guess("hi") == "[dunno]"
+
+    def test_mixed_text(self):
+        assert extract_guess("My guess is [crane]") == "[crane]"
+
+
+class TestExtractFeedbackCounts:
+    """Test feedback parsing."""
+
+    def test_standard_feedback(self):
+        feedback = """crane
+G Y X X G"""
+        green, yellow = extract_feedback_counts(feedback)
+        assert green == 2
+        assert yellow == 1
+
+    def test_all_green(self):
+        feedback = """crane
+G G G G G"""
+        green, yellow = extract_feedback_counts(feedback)
+        assert green == 5
+        assert yellow == 0
+
+    def test_no_feedback(self):
+        green, yellow = extract_feedback_counts("")
+        assert green == 0
+        assert yellow == 0
+
+
+class TestWordleGreensRubric:
+    """Test green letter scoring."""
+
+    def test_scores_greens(self):
+        rubric = WordleGreensRubric()
+        action = TextArenaAction(message="[crane]")
+        obs = make_wordle_observation(feedback_text="crane\nG G X X X")
+
+        score = rubric(action, obs)
+        assert score == pytest.approx(0.4)  # 2 greens = 2/5
+
+    def test_all_greens(self):
+        rubric = WordleGreensRubric()
+        action = TextArenaAction(message="[hello]")
+        obs = make_wordle_observation(feedback_text="hello\nG G G G G")
+
+        score = rubric(action, obs)
+        assert score == pytest.approx(1.0)
+
+    def test_no_feedback(self):
+        rubric = WordleGreensRubric()
+        action = TextArenaAction(message="[hello]")
+        obs = make_wordle_observation()
+
+        score = rubric(action, obs)
+        assert score == 0.0
+
+
+class TestWordleRepetitionsRubric:
+    """Test repetition penalty."""
+
+    def test_first_guess_full_score(self):
+        rubric = WordleRepetitionsRubric()
+        action = TextArenaAction(message="[crane]")
+        obs = make_wordle_observation()
+
+        score = rubric(action, obs)
+        assert score == 1.0
+
+    def test_repeated_guess_penalty(self):
+        rubric = WordleRepetitionsRubric()
+        action = TextArenaAction(message="[crane]")
+        obs = make_wordle_observation()
+
+        rubric(action, obs)  # First time: 1.0
+        score = rubric(action, obs)  # Second time: 0.0
+        assert score == 0.0
+
+        score = rubric(action, obs)  # Third time: -1.0
+        assert score == -1.0
+
+    def test_reset_clears_history(self):
+        rubric = WordleRepetitionsRubric()
+        action = TextArenaAction(message="[crane]")
+        obs = make_wordle_observation()
+
+        rubric(action, obs)  # First time
+        rubric(action, obs)  # Second time
+
+        rubric.reset()
+
+        score = rubric(action, obs)  # First time after reset
+        assert score == 1.0
+
+
+class TestWordleRubric:
+    """Test composite Wordle rubric."""
+
+    def test_evaluates_all_components(self):
+        rubric = WordleRubric()
+        action = TextArenaAction(message="[crane]")
+        obs = make_wordle_observation(
+            feedback_text="crane\nG Y X X X",
+            reward=0.0,
+        )
+
+        reward = rubric(action, obs)
+
+        # Check all component scores are tracked
+        assert rubric.greens.last_score == pytest.approx(0.2)  # 1 green
+        assert rubric.yellows.last_score == pytest.approx(0.2)  # 1 yellow
+        assert rubric.repetitions.last_score == 1.0  # first guess
+        assert rubric.correct.last_score == 0.0  # not won yet
+
+    def test_get_reward_signals(self):
+        rubric = WordleRubric()
+        action = TextArenaAction(message="[crane]")
+        obs = make_wordle_observation(
+            feedback_text="crane\nG G G G G",
+            reward=1.0,  # win
+        )
+
+        rubric(action, obs)
+        signals = rubric.get_reward_signals()
+
+        assert "wordle.greens" in signals
+        assert "wordle.yellows" in signals
+        assert "wordle.repetitions" in signals
+        assert "wordle.correct" in signals
+
+        assert signals["wordle.greens"] == pytest.approx(1.0)
+        assert signals["wordle.correct"] == pytest.approx(1.0)
+
+    def test_reset_clears_all(self):
+        rubric = WordleRubric()
+        action = TextArenaAction(message="[crane]")
+        obs = make_wordle_observation()
+
+        rubric(action, obs)
+        rubric(action, obs)  # Repeat
+
+        rubric.reset()
+
+        # Repetitions should be fresh
+        rubric(action, obs)
+        assert rubric.repetitions.last_score == 1.0
+
+
+class TestBuildRubric:
+    """Test rubric factory."""
+
+    def test_wordle_rubric(self):
+        rubric = build_rubric("Wordle-v0")
+        assert isinstance(rubric, WordleRubric)
+
+    def test_unknown_env_returns_none(self):
+        rubric = build_rubric("Unknown-v0")
+        assert rubric is None


### PR DESCRIPTION
## Summary

Demonstrates rubric integration patterns with two environments per RFC 004:

### TextArena (Wordle)
- `WordleRubric` composite rubric with greens, yellows, repetitions, correct sub-rubrics
- Migrates from legacy `RewardProvider` to `Rubric` pattern
- Full backwards compatibility via `get_reward_signals()`

### Connect4
- `Connect4WinLossRubric` trajectory rubric for terminal games
- Demonstrates exponential discounting for credit assignment
- Shows `reset()` integration with environment lifecycle

## Changes

### New files
- `envs/textarena_env/rubrics.py` - Wordle rubric implementation
- `envs/connect4_env/rubrics.py` - Connect4 trajectory rubric
- `tests/envs/test_textarena_rubrics.py` - 18 tests
- `tests/envs/test_connect4_rubrics.py` - 12 tests

### Modified files
- `envs/textarena_env/server/environment.py` - Use rubric instead of RewardProvider
- `envs/connect4_env/server/connect4_environment.py` - Add optional rubric support

## Test plan

- [x] All 30 environment rubric tests pass
- [x] All 116 total rubric tests pass
- [x] Code formatted with ruff

## Dependencies

This PR depends on #340 (Rubric base system).