### PR TITLE
Fix chess tests to skip when moonfish/python-chess not installed

### DIFF
--- a/tests/envs/test_chess_environment.py
+++ b/tests/envs/test_chess_environment.py
@@ -8,6 +8,10 @@
 
 import pytest
 
+# Skip entire module if chess dependencies are not installed
+pytest.importorskip("chess", reason="python-chess is not installed")
+pytest.importorskip("moonfish", reason="moonfish is not installed")
+
 from envs.chess_env import ChessAction, ChessObservation, ChessState
 from envs.chess_env.server.chess_environment import ChessEnvironment
 


### PR DESCRIPTION
## Summary

- Add `pytest.importorskip()` calls to `tests/envs/test_chess_environment.py` for `chess` and `moonfish` dependencies
- Tests now gracefully skip when these optional packages are missing instead of failing with import errors
- Follows established pattern used by other environment tests (e.g., `test_repl_env.py`, `test_browsergym_environment.py`)

Fixes #344

## Test plan

- [x] Verified tests skip gracefully when moonfish is not installed (shows `1 skipped`)
- [x] Verified full test suite passes (`344 passed, 46 skipped`)
- [x] Verified lint check passes