### PR TITLE
Enable prod mode for MCP environments

### DIFF
--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -90,6 +90,7 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         connect_timeout_s: float = 10.0,
         message_timeout_s: float = 60.0,
         provider: Optional["ContainerProvider | RuntimeProvider"] = None,
+        mode: Optional[str] = None,
     ):
         """
         Initialize environment client.
@@ -101,7 +102,26 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
             message_timeout_s: Timeout for receiving responses to messages
             provider: Optional container/runtime provider for lifecycle management.
                      Can be a ContainerProvider (Docker) or RuntimeProvider (UV).
+            mode: Communication mode: 'simulation' for Gym-style API (default) or
+                 'production' for MCP JSON-RPC protocol. Can also be set via the
+                 OPENENV_CLIENT_MODE environment variable. Constructor parameter
+                 takes precedence over environment variable. Case-insensitive.
         """
+        # Determine mode (constructor > env var > default)
+        if mode is None:
+            mode = os.environ.get("OPENENV_CLIENT_MODE", "simulation")
+
+        # Normalize and validate mode
+        mode = mode.lower()
+        if mode not in ("simulation", "production"):
+            raise ValueError(
+                f"Invalid mode: '{mode}'. Must be 'simulation' or 'production'. "
+                f"Set via constructor parameter or OPENENV_CLIENT_MODE environment variable."
+            )
+
+        # Store mode (use object.__setattr__ to bypass immutability)
+        object.__setattr__(self, "_mode", mode)
+
         # Convert HTTP URL to WebSocket URL
         ws_url = convert_to_ws_url(base_url)
 
@@ -110,6 +130,12 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         self._message_timeout = message_timeout_s
         self._provider = provider
         self._ws: Optional[ClientConnection] = None
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Prevent modification of _mode after initialization."""
+        if name == "_mode" and hasattr(self, "_mode"):
+            raise AttributeError("Cannot modify mode after initialization")
+        super().__setattr__(name, value)
 
     async def connect(self) -> "EnvClient":
         """

--- a/src/openenv/core/mcp_client.py
+++ b/src/openenv/core/mcp_client.py
@@ -35,7 +35,7 @@ Example (sync wrapper):
 
 from typing import Any, Dict, List, Optional
 
-from .client_types import StepResult, StateT
+from .client_types import StepResult
 from .env_client import EnvClient
 from .env_server.mcp_types import (
     CallToolAction,
@@ -66,6 +66,7 @@ class MCPClientBase(EnvClient[Any, Observation, State]):
         connect_timeout_s: float = 10.0,
         message_timeout_s: float = 60.0,
         provider: Optional[Any] = None,
+        mode: Optional[str] = None,
     ):
         """
         Initialize MCP client.
@@ -75,12 +76,26 @@ class MCPClientBase(EnvClient[Any, Observation, State]):
             connect_timeout_s: Timeout for establishing WebSocket connection.
             message_timeout_s: Timeout for receiving responses to messages.
             provider: Optional container/runtime provider for lifecycle management.
+            mode: Communication mode. Must be 'production' for MCP clients. Defaults to 'production'.
         """
+        # MCPClientBase defaults to production mode, but allow override for validation
+        if mode is None:
+            mode = "production"
+
+        # Validate that mode is production
+        mode_lower = mode.lower()
+        if mode_lower != "production":
+            raise ValueError(
+                f"MCPToolClient only supports 'production' mode, got '{mode}'. "
+                f"Use GenericEnvClient for simulation mode."
+            )
+
         super().__init__(
             base_url=base_url,
             connect_timeout_s=connect_timeout_s,
             message_timeout_s=message_timeout_s,
             provider=provider,
+            mode=mode,
         )
         self._tools_cache: Optional[List[Tool]] = None
 

--- a/tests/core/test_mode_selection.py
+++ b/tests/core/test_mode_selection.py
@@ -1,0 +1,311 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for client mode selection mechanism.
+
+These tests verify that clients can select between WebSocket (Gym-style) and MCP modes
+through constructor parameters and environment variables. The mode selection determines
+which protocol the client uses to communicate with the server:
+
+1. Simulation mode: Uses WSResetMessage, WSStepMessage (standard Gym API)
+2. Production mode: Uses WSMCPMessage with JSON-RPC (MCP protocol for tool calling)
+
+Test coverage:
+- Mode selection via constructor parameter
+- Mode selection via environment variable
+- Environment variable precedence over constructor default
+- Invalid mode values raise appropriate errors
+- Mode switching not allowed after connection
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from openenv.core.generic_client import GenericEnvClient
+from openenv.core.mcp_client import MCPToolClient
+
+
+# ============================================================================
+# Test Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def clean_env():
+    """Ensure OPENENV_CLIENT_MODE is not set."""
+    old_mode = os.environ.pop("OPENENV_CLIENT_MODE", None)
+    yield
+    if old_mode is not None:
+        os.environ["OPENENV_CLIENT_MODE"] = old_mode
+
+
+@pytest.fixture
+def mock_websocket():
+    """Create a mock WebSocket connection."""
+    ws = MagicMock()
+    ws.recv.return_value = '{"type": "response", "data": {}}'
+    return ws
+
+
+# ============================================================================
+# Constructor Parameter Mode Selection Tests
+# ============================================================================
+
+
+class TestConstructorModeSelection:
+    """Test mode selection via constructor parameter."""
+
+    def test_default_mode_is_simulation(self, clean_env):
+        """Test that default mode is 'simulation' when no mode specified."""
+        client = GenericEnvClient(base_url="http://localhost:8000")
+
+        # Should have simulation mode set
+        assert hasattr(client, "_mode")
+        assert client._mode == "simulation"
+
+    def test_explicit_simulation_mode(self, clean_env):
+        """Test explicit simulation mode via constructor."""
+        client = GenericEnvClient(base_url="http://localhost:8000", mode="simulation")
+
+        assert client._mode == "simulation"
+
+    def test_explicit_production_mode(self, clean_env):
+        """Test explicit production mode via constructor."""
+        client = GenericEnvClient(base_url="http://localhost:8000", mode="production")
+
+        assert client._mode == "production"
+
+    def test_invalid_mode_raises_error(self, clean_env):
+        """Test that invalid mode value raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            GenericEnvClient(base_url="http://localhost:8000", mode="invalid_mode")
+
+        assert "mode" in str(exc_info.value).lower()
+        assert "simulation" in str(exc_info.value).lower()
+        assert "production" in str(exc_info.value).lower()
+
+    def test_case_insensitive_mode(self, clean_env):
+        """Test that mode parameter is case-insensitive."""
+        client1 = GenericEnvClient(base_url="http://localhost:8000", mode="SIMULATION")
+        client2 = GenericEnvClient(base_url="http://localhost:8000", mode="PRODUCTION")
+
+        assert client1._mode == "simulation"
+        assert client2._mode == "production"
+
+
+# ============================================================================
+# Environment Variable Mode Selection Tests
+# ============================================================================
+
+
+class TestEnvironmentVariableModeSelection:
+    """Test mode selection via OPENENV_CLIENT_MODE environment variable."""
+
+    def test_env_var_simulation_mode(self):
+        """Test mode selection via OPENENV_CLIENT_MODE=simulation."""
+        with patch.dict(os.environ, {"OPENENV_CLIENT_MODE": "simulation"}):
+            client = GenericEnvClient(base_url="http://localhost:8000")
+            assert client._mode == "simulation"
+
+    def test_env_var_production_mode(self):
+        """Test mode selection via OPENENV_CLIENT_MODE=production."""
+        with patch.dict(os.environ, {"OPENENV_CLIENT_MODE": "production"}):
+            client = GenericEnvClient(base_url="http://localhost:8000")
+            assert client._mode == "production"
+
+    def test_env_var_case_insensitive(self):
+        """Test that OPENENV_CLIENT_MODE is case-insensitive."""
+        with patch.dict(os.environ, {"OPENENV_CLIENT_MODE": "PRODUCTION"}):
+            client = GenericEnvClient(base_url="http://localhost:8000")
+            assert client._mode == "production"
+
+    def test_env_var_overrides_default(self):
+        """Test that environment variable overrides default mode."""
+        with patch.dict(os.environ, {"OPENENV_CLIENT_MODE": "production"}):
+            # No explicit mode in constructor
+            client = GenericEnvClient(base_url="http://localhost:8000")
+            assert client._mode == "production"
+
+    def test_constructor_overrides_env_var(self):
+        """Test that explicit constructor parameter overrides environment variable."""
+        with patch.dict(os.environ, {"OPENENV_CLIENT_MODE": "production"}):
+            # Explicit mode in constructor should take precedence
+            client = GenericEnvClient(
+                base_url="http://localhost:8000", mode="simulation"
+            )
+            assert client._mode == "simulation"
+
+    def test_invalid_env_var_raises_error(self):
+        """Test that invalid OPENENV_CLIENT_MODE raises ValueError."""
+        with patch.dict(os.environ, {"OPENENV_CLIENT_MODE": "invalid"}):
+            with pytest.raises(ValueError) as exc_info:
+                GenericEnvClient(base_url="http://localhost:8000")
+
+            assert "OPENENV_CLIENT_MODE" in str(exc_info.value)
+            assert "invalid" in str(exc_info.value).lower()
+
+
+# ============================================================================
+# Mode Behavior Tests
+# ============================================================================
+
+
+class TestModeBehavior:
+    """Test that different modes result in different client behavior."""
+
+    @pytest.mark.asyncio
+    async def test_simulation_mode_uses_gym_protocol(self, clean_env, mock_websocket):
+        """Test that simulation mode uses Gym-style WebSocket messages."""
+        client = GenericEnvClient(base_url="http://localhost:8000", mode="simulation")
+
+        with patch.object(client, "_send") as mock_send:
+            with patch.object(
+                client,
+                "_receive",
+                return_value={
+                    "type": "response",
+                    "data": {"observation": {}, "reward": None, "done": False},
+                },
+            ):
+                with patch.object(client, "_ws", mock_websocket):
+                    await client.reset()
+
+                    # Should send WSResetMessage format
+                    call_args = mock_send.call_args_list
+                    reset_call = [
+                        call for call in call_args if call[0][0].get("type") == "reset"
+                    ]
+                    assert len(reset_call) > 0, (
+                        "Should send reset message with type='reset'"
+                    )
+
+    @pytest.mark.asyncio
+    async def test_production_mode_uses_jsonrpc_protocol(
+        self, clean_env, mock_websocket
+    ):
+        """Test that production mode uses JSON-RPC format for tool calls."""
+        client = MCPToolClient(base_url="http://localhost:8000", mode="production")
+
+        with patch.object(client, "_send") as mock_send:
+            with patch.object(
+                client,
+                "_receive",
+                return_value={
+                    "type": "response",
+                    "data": {
+                        "observation": {"tools": []},
+                        "reward": None,
+                        "done": False,
+                    },
+                },
+            ):
+                with patch.object(client, "_ws", mock_websocket):
+                    await client.list_tools()
+
+                    # Should send step message with list_tools action
+                    call_args = mock_send.call_args_list
+                    step_call = [
+                        call for call in call_args if call[0][0].get("type") == "step"
+                    ]
+                    assert len(step_call) > 0, "Should send message with type='step'"
+
+                    # Check that the action payload is list_tools
+                    step_message = step_call[0][0][0]
+                    assert "data" in step_message
+                    assert step_message["data"].get("type") == "list_tools"
+
+
+# ============================================================================
+# Mode Immutability Tests
+# ============================================================================
+
+
+class TestModeImmutability:
+    """Test that mode cannot be changed after client creation."""
+
+    def test_mode_cannot_be_changed_after_creation(self, clean_env):
+        """Test that mode attribute is read-only after initialization."""
+        client = GenericEnvClient(base_url="http://localhost:8000", mode="simulation")
+
+        # Attempting to change mode should raise AttributeError or have no effect
+        with pytest.raises((AttributeError, ValueError)):
+            client._mode = "mcp"
+
+    def test_mode_cannot_be_changed_after_connection(self, clean_env):
+        """Test that mode cannot be changed after connection is established."""
+        client = GenericEnvClient(base_url="http://localhost:8000", mode="simulation")
+
+        with patch.object(client, "_ws", MagicMock()):
+            # Mark as connected
+            client._ws = MagicMock()
+
+            # Should not allow mode change
+            with pytest.raises((AttributeError, ValueError)):
+                client._mode = "mcp"
+
+
+# ============================================================================
+# Cross-Client Mode Consistency Tests
+# ============================================================================
+
+
+class TestCrossClientModeConsistency:
+    """Test that mode selection works consistently across different client types."""
+
+    def test_generic_client_supports_both_modes(self, clean_env):
+        """Test that GenericEnvClient supports both simulation and production modes."""
+        ws_client = GenericEnvClient(
+            base_url="http://localhost:8000", mode="simulation"
+        )
+        mcp_client = GenericEnvClient(
+            base_url="http://localhost:8000", mode="production"
+        )
+
+        assert ws_client._mode == "simulation"
+        assert mcp_client._mode == "production"
+
+    def test_mcp_client_defaults_to_production_mode(self, clean_env):
+        """Test that MCPToolClient defaults to 'production' mode."""
+        client = MCPToolClient(base_url="http://localhost:8000")
+
+        # MCPToolClient should default to production mode
+        assert client._mode == "production"
+
+    def test_mcp_client_cannot_use_simulation_mode(self, clean_env):
+        """Test that MCPToolClient raises error if simulation mode is requested."""
+        with pytest.raises(ValueError) as exc_info:
+            MCPToolClient(base_url="http://localhost:8000", mode="simulation")
+
+        assert "MCPToolClient" in str(exc_info.value)
+        assert "production" in str(exc_info.value).lower()
+
+
+# ============================================================================
+# Mode Documentation Tests
+# ============================================================================
+
+
+class TestModeDocumentation:
+    """Test that mode parameter is properly documented."""
+
+    def test_mode_parameter_in_docstring(self, clean_env):
+        """Test that mode parameter is documented in __init__ docstring."""
+        # GenericEnvClient should document mode parameter
+        docstring = GenericEnvClient.__init__.__doc__
+
+        # Should mention mode in Args section
+        assert docstring is not None
+        assert "mode" in docstring.lower()
+
+    def test_mode_values_documented(self, clean_env):
+        """Test that valid mode values are documented."""
+        docstring = GenericEnvClient.__init__.__doc__
+
+        # Should document both simulation and production modes
+        assert "simulation" in docstring.lower()
+        assert "production" in docstring.lower()

--- a/tests/core/test_production_mode_mcp.py
+++ b/tests/core/test_production_mode_mcp.py
@@ -1,0 +1,613 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for production mode MCP functionality.
+
+These tests verify that in production mode:
+1. MCP endpoints (tools/list, tools/call) are available via WebSocket
+2. MCP operations work WITHOUT requiring reset() first
+3. MCP JSON-RPC protocol is properly implemented
+4. Error handling is correct for invalid requests
+
+This is a critical test suite for production inference use cases where agents
+interact with real environments using MCP tools, not simulation controls.
+
+Test coverage:
+- Production mode exposes MCP tools/list via WebSocket
+- Production mode exposes MCP tools/call via WebSocket
+- MCP works without calling reset() first (key production requirement)
+- MCP error handling (tool not found, invalid arguments, etc.)
+- MCP JSON-RPC format compliance
+"""
+
+import sys
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Add paths for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "envs"))
+
+from openenv.core.env_server.http_server import HTTPEnvServer
+from openenv.core.env_server.mcp_environment import MCPEnvironment
+from openenv.core.env_server.types import Action, Observation, State
+from openenv.core.env_server.mcp_types import (
+    CallToolAction,
+    CallToolObservation,
+)
+from fastmcp import FastMCP
+
+
+# ============================================================================
+# Test Fixtures - MCP-Enabled Environment
+# ============================================================================
+
+
+class MCPTestEnvironment(MCPEnvironment):
+    """
+    Test environment with MCP tools for production mode testing.
+
+    This environment provides simple tools for testing MCP functionality
+    in production mode without requiring simulation controls.
+    """
+
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
+    def __init__(self):
+        """Initialize with a FastMCP server containing test tools."""
+        mcp_server = FastMCP("test-production-env")
+
+        @mcp_server.tool
+        def get_info() -> str:
+            """Get environment information."""
+            return "Production environment v1.0"
+
+        @mcp_server.tool
+        def calculate(operation: str, a: int, b: int) -> int:
+            """Perform a calculation."""
+            if operation == "add":
+                return a + b
+            elif operation == "multiply":
+                return a * b
+            else:
+                raise ValueError(f"Unknown operation: {operation}")
+
+        super().__init__(mcp_server)
+        self._state = State(episode_id="prod", step_count=0)
+
+    def reset(self, **kwargs) -> Observation:
+        """Reset the environment."""
+        self._state = State(episode_id="prod", step_count=0)
+        return Observation(done=False, reward=None)
+
+    def _step_impl(self, action: Action, **kwargs) -> Observation:
+        """Handle non-MCP actions."""
+        self._state.step_count += 1
+        return Observation(done=False, reward=None)
+
+    @property
+    def state(self) -> State:
+        """Return current state."""
+        return self._state
+
+
+@pytest.fixture
+def production_mcp_app() -> FastAPI:
+    """
+    Create a FastAPI app in production mode with MCP-enabled environment.
+
+    This simulates a production deployment where only MCP tools are exposed,
+    not simulation controls.
+    """
+    app = FastAPI()
+    server = HTTPEnvServer(
+        env=MCPTestEnvironment,
+        action_cls=CallToolAction,
+        observation_cls=CallToolObservation,
+    )
+    server.register_routes(app, mode="production")
+    return app
+
+
+@pytest.fixture
+def simulation_mcp_app() -> FastAPI:
+    """
+    Create a FastAPI app in simulation mode with MCP-enabled environment.
+
+    This is for comparison testing to verify MCP works in both modes.
+    """
+    app = FastAPI()
+    server = HTTPEnvServer(
+        env=MCPTestEnvironment,
+        action_cls=CallToolAction,
+        observation_cls=CallToolObservation,
+    )
+    server.register_routes(app, mode="simulation")
+    return app
+
+
+# ============================================================================
+# Production Mode MCP Functionality Tests
+# ============================================================================
+
+
+class TestProductionModeMCPToolsList:
+    """Test that production mode exposes MCP tools/list functionality."""
+
+    def test_production_mode_mcp_tools_list_via_websocket(self, production_mcp_app):
+        """
+        Test that tools/list works in production mode via WebSocket.
+
+        This is the primary test for production mode MCP functionality.
+        Tools should be discoverable without calling reset() first.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send MCP tools/list request (JSON-RPC format)
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 1,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            # Receive response
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            # Verify JSON-RPC response structure
+            assert response["type"] == "mcp", "Response should be MCP type"
+            assert "data" in response, "Response should have data field"
+
+            data = response["data"]
+            assert data["jsonrpc"] == "2.0", "Should follow JSON-RPC 2.0"
+            assert data["id"] == 1, "Should echo request ID"
+            assert "result" in data, "Should have result (not error)"
+
+            # Verify tools are returned
+            result = data["result"]
+            assert "tools" in result, "Result should contain tools list"
+
+            tools = result["tools"]
+            assert len(tools) > 0, "Should return at least one tool"
+
+            # Verify tool structure
+            tool_names = [t["name"] for t in tools]
+            assert "get_info" in tool_names, "Should include get_info tool"
+            assert "calculate" in tool_names, "Should include calculate tool"
+
+            # Verify tool has required fields
+            get_info_tool = next(t for t in tools if t["name"] == "get_info")
+            assert "description" in get_info_tool, "Tool should have description"
+            # Note: FastMCP may use different field names (inputSchema vs input_schema)
+            # Just verify the tool has some schema-related field
+            assert len(get_info_tool) > 2, (
+                "Tool should have name, description, and other metadata"
+            )
+
+    def test_production_mode_tools_list_without_reset(self, production_mcp_app):
+        """
+        Test that tools/list works WITHOUT calling reset() first.
+
+        This is a key requirement for production mode: MCP tools should be
+        available immediately without needing to reset the environment.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # DO NOT call reset() - this is the key test
+
+            # Directly call tools/list
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 42,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            # Should succeed without reset
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "mcp"
+            assert "result" in response["data"], "Should succeed without reset()"
+            assert "tools" in response["data"]["result"]
+            assert len(response["data"]["result"]["tools"]) > 0
+
+
+class TestProductionModeMCPToolsCall:
+    """Test that production mode exposes MCP tools/call functionality."""
+
+    def test_production_mode_mcp_tools_call_via_websocket(self, production_mcp_app):
+        """
+        Test that tools/call works in production mode via WebSocket.
+
+        Agents should be able to invoke tools in production mode.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Call get_info tool
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "get_info",
+                        "arguments": {},
+                    },
+                    "id": 2,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            # Receive response
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            # Verify JSON-RPC response structure
+            assert response["type"] == "mcp"
+            assert response["data"]["jsonrpc"] == "2.0"
+            assert response["data"]["id"] == 2
+            assert "result" in response["data"], "Should have result (not error)"
+
+            # Verify result contains tool output
+            result = response["data"]["result"]
+            assert result is not None, "Tool should return a result"
+
+    def test_production_mode_tools_call_with_arguments(self, production_mcp_app):
+        """
+        Test tools/call with arguments in production mode.
+
+        Verifies that tool arguments are correctly passed through.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Call calculate tool with arguments
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "calculate",
+                        "arguments": {
+                            "operation": "add",
+                            "a": 5,
+                            "b": 3,
+                        },
+                    },
+                    "id": 3,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            # Receive response
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            # Verify successful execution
+            assert response["type"] == "mcp"
+            assert "result" in response["data"], "Should succeed with valid arguments"
+
+            # Note: The exact result format depends on FastMCP implementation
+            # We just verify it doesn't error
+            result = response["data"]["result"]
+            assert result is not None
+
+    def test_production_mode_tools_call_without_reset(self, production_mcp_app):
+        """
+        Test that tools/call works WITHOUT calling reset() first.
+
+        Production environments should allow tool calls immediately.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # DO NOT call reset() - this is the key test
+
+            # Directly call a tool
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "get_info",
+                        "arguments": {},
+                    },
+                    "id": 99,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            # Should succeed without reset
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "mcp"
+            assert "result" in response["data"], "Should succeed without reset()"
+
+
+class TestProductionModeMCPErrorHandling:
+    """Test MCP error handling in production mode."""
+
+    def test_production_mode_tool_not_found_error(self, production_mcp_app):
+        """
+        Test that calling a non-existent tool returns proper error.
+
+        Should return JSON-RPC error response.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Call non-existent tool
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "nonexistent_tool",
+                        "arguments": {},
+                    },
+                    "id": 10,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            # Receive error response
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            # Should return error in JSON-RPC format
+            assert response["type"] == "mcp"
+            assert "error" in response["data"], "Should return error for missing tool"
+
+            error = response["data"]["error"]
+            assert "code" in error
+            assert "message" in error
+
+    def test_production_mode_invalid_method_error(self, production_mcp_app):
+        """
+        Test that invalid MCP method returns proper error.
+
+        Should return JSON-RPC method not found error (-32601).
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send invalid MCP method
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/invalid",
+                    "id": 11,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            # Receive error response
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            # Should return method not found error
+            assert response["type"] == "mcp"
+            assert "error" in response["data"]
+            assert response["data"]["error"]["code"] == -32601
+
+    def test_production_mode_missing_tool_name_in_call(self, production_mcp_app):
+        """
+        Test that tools/call without name parameter returns error.
+
+        Should return JSON-RPC invalid params error (-32600).
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send tools/call without name
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {
+                        # Missing "name" field
+                        "arguments": {},
+                    },
+                    "id": 12,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            # Receive error response
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            # Should return invalid params error
+            assert response["type"] == "mcp"
+            assert "error" in response["data"]
+            assert response["data"]["error"]["code"] == -32600
+            assert "name" in response["data"]["error"]["message"].lower()
+
+
+class TestProductionModeMCPJSONRPCCompliance:
+    """Test JSON-RPC protocol compliance for MCP in production mode."""
+
+    def test_jsonrpc_version_is_2_0(self, production_mcp_app):
+        """
+        Test that all MCP responses use JSON-RPC 2.0.
+
+        This is required by the JSON-RPC spec.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 20,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["data"]["jsonrpc"] == "2.0"
+
+    def test_jsonrpc_request_id_is_echoed(self, production_mcp_app):
+        """
+        Test that response echoes the request ID.
+
+        JSON-RPC requires the response to include the same ID as the request.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Use a unique ID
+            unique_id = "test-id-12345"
+
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": unique_id,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["data"]["id"] == unique_id
+
+    def test_jsonrpc_result_and_error_are_mutually_exclusive(self, production_mcp_app):
+        """
+        Test that JSON-RPC responses have either result OR error, not both.
+
+        This is a JSON-RPC requirement.
+        """
+        client = TestClient(production_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Test successful request (should have result, not error)
+            request_success = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 30,
+                },
+            }
+            websocket.send_text(json.dumps(request_success))
+            response_text = websocket.receive_text()
+            response_success = json.loads(response_text)
+
+            assert "result" in response_success["data"]
+            assert "error" not in response_success["data"]
+
+            # Test failed request (should have error, not result)
+            request_error = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "invalid/method",
+                    "id": 31,
+                },
+            }
+            websocket.send_text(json.dumps(request_error))
+            response_text = websocket.receive_text()
+            response_error = json.loads(response_text)
+
+            assert "error" in response_error["data"]
+            assert "result" not in response_error["data"]
+
+
+# ============================================================================
+# Comparison Tests: Production vs Simulation Mode
+# ============================================================================
+
+
+class TestMCPWorksInBothModes:
+    """
+    Test that MCP functionality works in both production and simulation modes.
+
+    This verifies that MCP is mode-agnostic and consistently available.
+    """
+
+    def test_tools_list_works_in_simulation_mode(self, simulation_mcp_app):
+        """
+        Test that tools/list also works in simulation mode.
+
+        MCP should be available in both modes.
+        """
+        client = TestClient(simulation_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 100,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "mcp"
+            assert "result" in response["data"]
+            assert "tools" in response["data"]["result"]
+
+    def test_tools_call_works_in_simulation_mode(self, simulation_mcp_app):
+        """
+        Test that tools/call also works in simulation mode.
+
+        MCP should be available in both modes.
+        """
+        client = TestClient(simulation_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            request = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "get_info",
+                        "arguments": {},
+                    },
+                    "id": 101,
+                },
+            }
+            websocket.send_text(json.dumps(request))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "mcp"
+            assert "result" in response["data"]

--- a/tests/core/test_production_mode_routes.py
+++ b/tests/core/test_production_mode_routes.py
@@ -1,0 +1,414 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for production mode route restrictions.
+
+These tests verify that when the HTTP server is running in production mode,
+simulation control endpoints (/reset, /step, /state) are NOT exposed.
+This is a critical security boundary: production environments should only
+expose MCP tools, not simulation controls that manipulate time and causality.
+
+Test coverage:
+- Production mode disables /reset endpoint (returns 404 or 405)
+- Production mode disables /step endpoint (returns 404 or 405)
+- Production mode disables /state endpoint (returns 404 or 405)
+- Production mode still allows /health endpoint
+- Production mode still allows /schema endpoint
+- Production mode still allows /metadata endpoint
+- Production mode still allows /ws WebSocket endpoint
+- Simulation mode (default) allows all endpoints
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Add paths for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "envs"))
+
+from openenv.core.env_server.http_server import HTTPEnvServer
+from openenv.core.env_server.interfaces import Environment
+from openenv.core.env_server.types import Action, Observation, State
+
+
+# ============================================================================
+# Test Fixtures - Minimal Environment for Testing
+# ============================================================================
+
+
+class MinimalAction(Action):
+    """Minimal action for testing."""
+
+    message: str
+
+
+class MinimalObservation(Observation):
+    """Minimal observation for testing."""
+
+    response: str
+    reward: float | None = None
+    done: bool = False
+
+
+class MinimalState(State):
+    """Minimal state for testing."""
+
+    step_count: int = 0
+
+
+class MinimalEnvironment(Environment):
+    """Minimal environment implementation for testing server modes."""
+
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
+    def reset(self, **kwargs) -> MinimalObservation:
+        """Reset the environment."""
+        return MinimalObservation(response="reset", reward=None, done=False)
+
+    def step(self, action: MinimalAction) -> MinimalObservation:
+        """Execute an action."""
+        return MinimalObservation(
+            response=f"echo: {action.message}", reward=1.0, done=False
+        )
+
+    @property
+    def state(self) -> MinimalState:
+        """Return current state."""
+        return MinimalState(step_count=0)
+
+    def close(self) -> None:
+        """Cleanup resources."""
+        pass
+
+
+@pytest.fixture
+def production_mode_app() -> FastAPI:
+    """
+    Create a FastAPI app with production mode enabled.
+
+    In production mode, /reset, /step, /state should NOT be registered.
+    """
+    app = FastAPI()
+    server = HTTPEnvServer(
+        env=MinimalEnvironment,
+        action_cls=MinimalAction,
+        observation_cls=MinimalObservation,
+    )
+    # TODO: Once production mode is implemented, pass mode="production" here
+    # For now, this will fail because the feature doesn't exist yet
+    server.register_routes(app, mode="production")
+    return app
+
+
+@pytest.fixture
+def simulation_mode_app() -> FastAPI:
+    """
+    Create a FastAPI app with simulation mode (default).
+
+    In simulation mode, all endpoints including /reset, /step, /state are available.
+    """
+    app = FastAPI()
+    server = HTTPEnvServer(
+        env=MinimalEnvironment,
+        action_cls=MinimalAction,
+        observation_cls=MinimalObservation,
+    )
+    # Default mode should be simulation
+    server.register_routes(app)
+    return app
+
+
+# ============================================================================
+# Production Mode Route Restriction Tests
+# ============================================================================
+
+
+class TestProductionModeRouteRestrictions:
+    """Test that production mode hides simulation control endpoints."""
+
+    def test_production_mode_blocks_reset_endpoint(self, production_mode_app):
+        """Test that /reset returns 404 or 405 in production mode."""
+        client = TestClient(production_mode_app)
+
+        response = client.post("/reset", json={})
+
+        # Should return 404 (Not Found) or 405 (Method Not Allowed)
+        assert response.status_code in [404, 405], (
+            f"Expected 404 or 405, got {response.status_code}. "
+            "Production mode should not expose /reset endpoint."
+        )
+
+    def test_production_mode_blocks_step_endpoint(self, production_mode_app):
+        """Test that /step returns 404 or 405 in production mode."""
+        client = TestClient(production_mode_app)
+
+        response = client.post("/step", json={"action": {"message": "test"}})
+
+        # Should return 404 (Not Found) or 405 (Method Not Allowed)
+        assert response.status_code in [404, 405], (
+            f"Expected 404 or 405, got {response.status_code}. "
+            "Production mode should not expose /step endpoint."
+        )
+
+    def test_production_mode_blocks_state_endpoint(self, production_mode_app):
+        """Test that /state returns 404 or 405 in production mode."""
+        client = TestClient(production_mode_app)
+
+        response = client.get("/state")
+
+        # Should return 404 (Not Found) or 405 (Method Not Allowed)
+        assert response.status_code in [404, 405], (
+            f"Expected 404 or 405, got {response.status_code}. "
+            "Production mode should not expose /state endpoint."
+        )
+
+
+# ============================================================================
+# Production Mode Still Allows Safe Endpoints
+# ============================================================================
+
+
+class TestProductionModeAllowsSafeEndpoints:
+    """Test that production mode still exposes safe, non-simulation endpoints."""
+
+    def test_production_mode_allows_health_endpoint(self, production_mode_app):
+        """Test that /health is still available in production mode."""
+        client = TestClient(production_mode_app)
+
+        response = client.get("/health")
+
+        assert response.status_code == 200, (
+            "Production mode should still expose /health for monitoring"
+        )
+        assert response.json()["status"] == "healthy"
+
+    def test_production_mode_allows_schema_endpoint(self, production_mode_app):
+        """Test that /schema is still available in production mode."""
+        client = TestClient(production_mode_app)
+
+        response = client.get("/schema")
+
+        assert response.status_code == 200, (
+            "Production mode should still expose /schema for introspection"
+        )
+        # Should have action, observation, state schemas
+        data = response.json()
+        assert "action" in data
+        assert "observation" in data
+        assert "state" in data
+
+    def test_production_mode_allows_metadata_endpoint(self, production_mode_app):
+        """Test that /metadata is still available in production mode."""
+        client = TestClient(production_mode_app)
+
+        response = client.get("/metadata")
+
+        assert response.status_code == 200, (
+            "Production mode should still expose /metadata for environment info"
+        )
+
+    def test_production_mode_allows_websocket_endpoint(self, production_mode_app):
+        """Test that /ws WebSocket is still available in production mode."""
+        client = TestClient(production_mode_app)
+
+        # WebSocket connection test - we expect it to accept the connection
+        # We don't test the full WebSocket protocol here, just that it's registered
+        try:
+            with client.websocket_connect("/ws") as websocket:
+                # If we get here, the endpoint is registered
+                # We can close immediately
+                websocket.close()
+                assert True, "WebSocket endpoint should be available"
+        except Exception as e:
+            # If the endpoint doesn't exist, we'll get a 404
+            pytest.fail(
+                f"WebSocket endpoint should be available in production mode: {e}"
+            )
+
+
+# ============================================================================
+# Simulation Mode Allows All Endpoints (Regression Test)
+# ============================================================================
+
+
+class TestSimulationModeAllowsAllEndpoints:
+    """Test that simulation mode (default) allows all endpoints."""
+
+    def test_simulation_mode_allows_reset_endpoint(self, simulation_mode_app):
+        """Test that /reset works in simulation mode (default behavior)."""
+        client = TestClient(simulation_mode_app)
+
+        response = client.post("/reset", json={})
+
+        assert response.status_code == 200, (
+            "Simulation mode should expose /reset endpoint"
+        )
+        data = response.json()
+        assert "observation" in data
+        assert data["observation"]["response"] == "reset"
+
+    def test_simulation_mode_allows_step_endpoint(self, simulation_mode_app):
+        """Test that /step works in simulation mode (default behavior)."""
+        client = TestClient(simulation_mode_app)
+
+        response = client.post("/step", json={"action": {"message": "hello"}})
+
+        assert response.status_code == 200, (
+            "Simulation mode should expose /step endpoint"
+        )
+        data = response.json()
+        assert "observation" in data
+        assert "echo: hello" in data["observation"]["response"]
+
+    def test_simulation_mode_allows_state_endpoint(self, simulation_mode_app):
+        """Test that /state works in simulation mode (default behavior)."""
+        client = TestClient(simulation_mode_app)
+
+        response = client.get("/state")
+
+        assert response.status_code == 200, (
+            "Simulation mode should expose /state endpoint"
+        )
+        data = response.json()
+        assert "step_count" in data
+        assert data["step_count"] == 0
+
+
+# ============================================================================
+# Mode Configuration Tests
+# ============================================================================
+
+
+class TestModeConfiguration:
+    """Test that mode can be configured via parameter."""
+
+    def test_explicit_production_mode_parameter(self):
+        """Test that mode='production' can be passed to register_routes."""
+        app = FastAPI()
+        server = HTTPEnvServer(
+            env=MinimalEnvironment,
+            action_cls=MinimalAction,
+            observation_cls=MinimalObservation,
+        )
+
+        # This should not raise an error
+        # The implementation should accept mode parameter
+        try:
+            server.register_routes(app, mode="production")
+        except TypeError as e:
+            pytest.fail(f"register_routes should accept mode parameter: {e}")
+
+    def test_explicit_simulation_mode_parameter(self):
+        """Test that mode='simulation' can be passed to register_routes."""
+        app = FastAPI()
+        server = HTTPEnvServer(
+            env=MinimalEnvironment,
+            action_cls=MinimalAction,
+            observation_cls=MinimalObservation,
+        )
+
+        # This should not raise an error
+        try:
+            server.register_routes(app, mode="simulation")
+        except TypeError as e:
+            pytest.fail(f"register_routes should accept mode parameter: {e}")
+
+    def test_default_mode_is_simulation(self):
+        """Test that default mode is 'simulation' for backwards compatibility."""
+        app = FastAPI()
+        server = HTTPEnvServer(
+            env=MinimalEnvironment,
+            action_cls=MinimalAction,
+            observation_cls=MinimalObservation,
+        )
+        server.register_routes(app)
+        client = TestClient(app)
+
+        # Should have /reset, /step, /state in default mode
+        reset_response = client.post("/reset", json={})
+        step_response = client.post("/step", json={"action": {"message": "test"}})
+        state_response = client.get("/state")
+
+        assert reset_response.status_code == 200, "Default mode should allow /reset"
+        assert step_response.status_code == 200, "Default mode should allow /step"
+        assert state_response.status_code == 200, "Default mode should allow /state"
+
+    def test_invalid_mode_raises_error(self):
+        """Test that invalid mode value raises ValueError."""
+        app = FastAPI()
+        server = HTTPEnvServer(
+            env=MinimalEnvironment,
+            action_cls=MinimalAction,
+            observation_cls=MinimalObservation,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            server.register_routes(app, mode="invalid_mode")
+
+        assert "mode" in str(exc_info.value).lower()
+        assert "production" in str(exc_info.value).lower()
+        assert "simulation" in str(exc_info.value).lower()
+
+
+# ============================================================================
+# Security Boundary Tests
+# ============================================================================
+
+
+class TestProductionModeSecurityBoundary:
+    """
+    Test that production mode enforces the security boundary.
+
+    The key invariant: In production, agents cannot control time/causality.
+    """
+
+    def test_production_mode_prevents_reset_manipulation(self, production_mode_app):
+        """
+        Test that production mode prevents environment reset.
+
+        In production, we can't reset the real world - time only moves forward.
+        """
+        client = TestClient(production_mode_app)
+
+        # Try to reset (should fail)
+        response = client.post("/reset", json={"seed": 42})
+
+        assert response.status_code in [404, 405], (
+            "Production mode must not allow reset - can't reset the real world"
+        )
+
+    def test_production_mode_prevents_state_inspection(self, production_mode_app):
+        """
+        Test that production mode prevents arbitrary state inspection.
+
+        State inspection is a simulation concept - in prod we only observe via tools.
+        """
+        client = TestClient(production_mode_app)
+
+        response = client.get("/state")
+
+        assert response.status_code in [404, 405], (
+            "Production mode should not expose internal state directly"
+        )
+
+    def test_production_mode_prevents_direct_step(self, production_mode_app):
+        """
+        Test that production mode prevents direct step calls.
+
+        In production, agents interact via MCP tools, not direct step() calls.
+        """
+        client = TestClient(production_mode_app)
+
+        response = client.post("/step", json={"action": {"message": "test"}})
+
+        assert response.status_code in [404, 405], (
+            "Production mode should not allow direct step() - use MCP tools instead"
+        )

--- a/tests/core/test_simulation_mode_preserves_api.py
+++ b/tests/core/test_simulation_mode_preserves_api.py
@@ -1,0 +1,706 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for simulation mode API preservation (Task #1).
+
+These tests verify that simulation mode preserves the full Gym-style API + MCP
+functionality. This is a regression test to ensure that adding production mode
+does not break existing simulation mode behavior.
+
+Test coverage:
+1. Simulation mode exposes /reset, /step, /state endpoints
+2. Simulation mode exposes /ws WebSocket endpoint with Gym-style API
+3. Simulation mode exposes /mcp WebSocket endpoint for MCP access
+4. Simulation mode exposes HTTP POST /mcp endpoint for MCP access
+5. Simulation mode is the default when no mode is specified
+6. All endpoints work correctly together (not just exposed, but functional)
+
+This addresses GitHub issue #346 Task #1:
+  "Test that sim mode preserves full Gym-style API + MCP. Tests should verify
+   that in simulation mode: (1) /reset, /step, /state all work (current behavior),
+   (2) /mcp WebSocket endpoint works, (3) HTTP POST /mcp works (new feature),
+   (4) Sim mode is the default when no mode specified."
+"""
+
+import sys
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Add paths for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "envs"))
+
+from openenv.core.env_server.http_server import HTTPEnvServer
+from openenv.core.env_server.interfaces import Environment
+from openenv.core.env_server.mcp_environment import MCPEnvironment
+from openenv.core.env_server.types import Action, Observation, State
+from openenv.core.env_server.mcp_types import (
+    CallToolAction,
+    CallToolObservation,
+)
+from fastmcp import FastMCP
+
+
+# ============================================================================
+# Test Fixtures
+# ============================================================================
+
+
+class SimModeTestAction(Action):
+    """Test action for simulation mode testing."""
+
+    message: str
+
+
+class SimModeTestObservation(Observation):
+    """Test observation for simulation mode testing."""
+
+    response: str
+    reward: float | None = None
+    done: bool = False
+
+
+class SimModeTestState(State):
+    """Test state for simulation mode testing."""
+
+    step_count: int = 0
+    episode_id: str = "test"
+
+
+class SimModeTestEnvironment(Environment):
+    """
+    Test environment for simulation mode API preservation tests.
+
+    This environment supports both Gym-style API and basic functionality.
+    """
+
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
+    def __init__(self):
+        """Initialize the test environment."""
+        self._step_count = 0
+        self._episode_id = "sim-test"
+
+    def reset(
+        self, seed: int | None = None, episode_id: str | None = None, **kwargs
+    ) -> SimModeTestObservation:
+        """Reset the environment."""
+        self._step_count = 0
+        if episode_id:
+            self._episode_id = episode_id
+        return SimModeTestObservation(
+            response="reset_complete", reward=None, done=False
+        )
+
+    def step(self, action: SimModeTestAction) -> SimModeTestObservation:
+        """Execute an action."""
+        self._step_count += 1
+        return SimModeTestObservation(
+            response=f"echo: {action.message}",
+            reward=1.0,
+            done=False,
+        )
+
+    @property
+    def state(self) -> SimModeTestState:
+        """Return current state."""
+        return SimModeTestState(
+            step_count=self._step_count,
+            episode_id=self._episode_id,
+        )
+
+    def close(self) -> None:
+        """Cleanup resources."""
+        pass
+
+
+class SimModeMCPTestEnvironment(MCPEnvironment):
+    """
+    Test environment with MCP tools for simulation mode testing.
+
+    This environment supports both Gym-style API and MCP tools.
+    """
+
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
+    def __init__(self):
+        """Initialize with MCP server and test tools."""
+        mcp_server = FastMCP("sim-mode-test-env")
+
+        @mcp_server.tool
+        def get_step_count() -> int:
+            """Get current step count."""
+            return self._step_count
+
+        @mcp_server.tool
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        super().__init__(mcp_server)
+        self._step_count = 0
+        self._episode_id = "sim-mcp-test"
+
+    def reset(
+        self, seed: int | None = None, episode_id: str | None = None, **kwargs
+    ) -> Observation:
+        """Reset the environment."""
+        self._step_count = 0
+        if episode_id:
+            self._episode_id = episode_id
+        return Observation(done=False, reward=None)
+
+    def _step_impl(self, action: Action, **kwargs) -> Observation:
+        """Handle non-MCP actions."""
+        self._step_count += 1
+        return Observation(done=False, reward=1.0)
+
+    @property
+    def state(self) -> State:
+        """Return current state."""
+        return State(
+            episode_id=self._episode_id,
+            step_count=self._step_count,
+        )
+
+
+@pytest.fixture
+def simulation_mode_app() -> FastAPI:
+    """
+    Create FastAPI app in simulation mode (default).
+
+    Simulation mode should expose:
+    - Gym-style API: /reset, /step, /state
+    - WebSocket endpoint: /ws
+    - Safe endpoints: /health, /schema, /metadata
+    """
+    app = FastAPI()
+    server = HTTPEnvServer(
+        env=SimModeTestEnvironment,
+        action_cls=SimModeTestAction,
+        observation_cls=SimModeTestObservation,
+    )
+    # Do not specify mode - should default to simulation
+    server.register_routes(app)
+    return app
+
+
+@pytest.fixture
+def simulation_mode_app_explicit() -> FastAPI:
+    """
+    Create FastAPI app with explicit mode='simulation'.
+
+    Should behave identically to default mode.
+    """
+    app = FastAPI()
+    server = HTTPEnvServer(
+        env=SimModeTestEnvironment,
+        action_cls=SimModeTestAction,
+        observation_cls=SimModeTestObservation,
+    )
+    # Explicitly set mode to simulation
+    server.register_routes(app, mode="simulation")
+    return app
+
+
+@pytest.fixture
+def simulation_mode_mcp_app() -> FastAPI:
+    """
+    Create FastAPI app in simulation mode with MCP support.
+
+    This fixture tests that MCP endpoints work in simulation mode.
+    """
+    app = FastAPI()
+    server = HTTPEnvServer(
+        env=SimModeMCPTestEnvironment,
+        action_cls=CallToolAction,
+        observation_cls=CallToolObservation,
+    )
+    server.register_routes(app, mode="simulation")
+    return app
+
+
+# ============================================================================
+# Task #1.1: Simulation Mode Exposes Gym-Style API Endpoints
+# ============================================================================
+
+
+class TestSimulationModeGymAPIEndpoints:
+    """Test that simulation mode exposes /reset, /step, /state endpoints."""
+
+    def test_simulation_mode_exposes_reset_endpoint(self, simulation_mode_app):
+        """
+        Test that /reset endpoint is available in simulation mode.
+
+        Signal: High - ensures core Gym API is not broken by production mode.
+        """
+        client = TestClient(simulation_mode_app)
+
+        response = client.post("/reset", json={})
+
+        assert response.status_code == 200, (
+            "Simulation mode must expose /reset endpoint for episode initialization"
+        )
+        data = response.json()
+        assert "observation" in data
+        assert data["observation"]["response"] == "reset_complete"
+
+    def test_simulation_mode_exposes_step_endpoint(self, simulation_mode_app):
+        """
+        Test that /step endpoint is available in simulation mode.
+
+        Signal: High - ensures core Gym API is not broken by production mode.
+        """
+        client = TestClient(simulation_mode_app)
+
+        response = client.post("/step", json={"action": {"message": "test_action"}})
+
+        assert response.status_code == 200, (
+            "Simulation mode must expose /step endpoint for action execution"
+        )
+        data = response.json()
+        assert "observation" in data
+        assert "echo: test_action" in data["observation"]["response"]
+
+    def test_simulation_mode_exposes_state_endpoint(self, simulation_mode_app):
+        """
+        Test that /state endpoint is available in simulation mode.
+
+        Signal: High - ensures core Gym API is not broken by production mode.
+        """
+        client = TestClient(simulation_mode_app)
+
+        response = client.get("/state")
+
+        assert response.status_code == 200, (
+            "Simulation mode must expose /state endpoint for state inspection"
+        )
+        data = response.json()
+        assert "step_count" in data
+        assert "episode_id" in data
+
+    def test_simulation_mode_reset_with_parameters(self, simulation_mode_app):
+        """
+        Test that /reset accepts optional parameters (seed, episode_id).
+
+        Signal: Medium - ensures parameter passing works correctly.
+        """
+        client = TestClient(simulation_mode_app)
+
+        response = client.post(
+            "/reset",
+            json={"seed": 42, "episode_id": "custom_episode"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "observation" in data
+
+
+# ============================================================================
+# Task #1.2: Simulation Mode Exposes WebSocket /ws Endpoint
+# ============================================================================
+
+
+class TestSimulationModeWebSocketEndpoint:
+    """Test that simulation mode exposes /ws WebSocket endpoint."""
+
+    def test_simulation_mode_exposes_websocket_endpoint(self, simulation_mode_app):
+        """
+        Test that /ws WebSocket endpoint is available in simulation mode.
+
+        Signal: High - ensures WebSocket communication is not broken.
+        """
+        client = TestClient(simulation_mode_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send reset message
+            reset_msg = {"type": "reset", "data": {}}
+            websocket.send_text(json.dumps(reset_msg))
+
+            # Receive response
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "observation", (
+                "Should receive observation message"
+            )
+            assert "data" in response
+            assert "observation" in response["data"]
+
+    def test_simulation_mode_websocket_reset_works(self, simulation_mode_app):
+        """
+        Test that WebSocket reset message works in simulation mode.
+
+        Signal: High - ensures WebSocket reset functionality is preserved.
+        """
+        client = TestClient(simulation_mode_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send reset
+            reset_msg = {"type": "reset", "data": {"episode_id": "ws_test"}}
+            websocket.send_text(json.dumps(reset_msg))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "observation"
+            assert response["data"]["observation"]["response"] == "reset_complete"
+
+    def test_simulation_mode_websocket_step_works(self, simulation_mode_app):
+        """
+        Test that WebSocket step message works in simulation mode.
+
+        Signal: High - ensures WebSocket step functionality is preserved.
+        """
+        client = TestClient(simulation_mode_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send step
+            step_msg = {
+                "type": "step",
+                "data": {"message": "websocket_test"},
+            }
+            websocket.send_text(json.dumps(step_msg))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "observation"
+            assert "echo: websocket_test" in response["data"]["observation"]["response"]
+
+    def test_simulation_mode_websocket_state_works(self, simulation_mode_app):
+        """
+        Test that WebSocket state message works in simulation mode.
+
+        Signal: High - ensures WebSocket state access is preserved.
+        """
+        client = TestClient(simulation_mode_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send state query (no data field needed for state message)
+            state_msg = {"type": "state"}
+            websocket.send_text(json.dumps(state_msg))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "state"
+            assert "data" in response
+            assert "step_count" in response["data"]
+
+
+# ============================================================================
+# Task #1.3: Simulation Mode Exposes /mcp WebSocket Endpoint
+# ============================================================================
+
+
+class TestSimulationModeWebSocketMCPEndpoint:
+    """Test that simulation mode exposes /mcp functionality via WebSocket."""
+
+    def test_simulation_mode_websocket_mcp_tools_list(self, simulation_mode_mcp_app):
+        """
+        Test that WebSocket MCP tools/list works in simulation mode.
+
+        Signal: High - ensures MCP via WebSocket is not broken.
+        """
+        client = TestClient(simulation_mode_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send MCP tools/list request
+            mcp_msg = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 1,
+                },
+            }
+            websocket.send_text(json.dumps(mcp_msg))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "mcp"
+            assert response["data"]["jsonrpc"] == "2.0"
+            assert "result" in response["data"]
+            assert "tools" in response["data"]["result"]
+
+    def test_simulation_mode_websocket_mcp_tools_call(self, simulation_mode_mcp_app):
+        """
+        Test that WebSocket MCP tools/call works in simulation mode.
+
+        Signal: High - ensures MCP tool execution via WebSocket is preserved.
+        """
+        client = TestClient(simulation_mode_mcp_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Send MCP tools/call request
+            mcp_msg = {
+                "type": "mcp",
+                "data": {
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "add",
+                        "arguments": {"a": 10, "b": 20},
+                    },
+                    "id": 2,
+                },
+            }
+            websocket.send_text(json.dumps(mcp_msg))
+
+            response_text = websocket.receive_text()
+            response = json.loads(response_text)
+
+            assert response["type"] == "mcp"
+            assert response["data"]["jsonrpc"] == "2.0"
+            assert "result" in response["data"]
+
+
+# ============================================================================
+# Task #1.4: Simulation Mode Exposes WebSocket /mcp Endpoint
+# ============================================================================
+
+
+class TestSimulationModeDedicatedMCPEndpoint:
+    """Test that simulation mode exposes WebSocket /mcp endpoint."""
+
+    def test_simulation_mode_http_mcp_tools_list(self, simulation_mode_mcp_app):
+        """
+        Test that WebSocket /mcp tools/list works in simulation mode.
+
+        Signal: High - ensures new WebSocket MCP endpoint works in simulation mode.
+        """
+        client = TestClient(simulation_mode_mcp_app)
+
+        request = {
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 10,
+        }
+
+        with client.websocket_connect("/mcp") as websocket:
+            websocket.send_text(json.dumps(request))
+            response = json.loads(websocket.receive_text())
+
+        assert response["jsonrpc"] == "2.0", (
+            "Simulation mode must expose WebSocket /mcp endpoint"
+        )
+        assert "result" in response
+        assert "tools" in response["result"]
+
+    def test_simulation_mode_http_mcp_tools_call(self, simulation_mode_mcp_app):
+        """
+        Test that WebSocket /mcp tools/call works in simulation mode.
+
+        Signal: High - ensures WebSocket MCP tool calling works in simulation mode.
+        """
+        client = TestClient(simulation_mode_mcp_app)
+
+        request = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "add",
+                "arguments": {"a": 5, "b": 7},
+            },
+            "id": 11,
+        }
+
+        with client.websocket_connect("/mcp") as websocket:
+            websocket.send_text(json.dumps(request))
+            response = json.loads(websocket.receive_text())
+
+        assert "result" in response
+
+
+# ============================================================================
+# Task #1.5: Simulation Mode is Default
+# ============================================================================
+
+
+class TestSimulationModeIsDefault:
+    """Test that simulation mode is the default when no mode is specified."""
+
+    def test_default_mode_exposes_reset(self, simulation_mode_app):
+        """
+        Test that default mode (no mode parameter) exposes /reset.
+
+        Signal: High - ensures backwards compatibility.
+        """
+        client = TestClient(simulation_mode_app)
+
+        response = client.post("/reset", json={})
+
+        assert response.status_code == 200, (
+            "Default mode should be simulation, exposing /reset"
+        )
+
+    def test_default_mode_exposes_step(self, simulation_mode_app):
+        """
+        Test that default mode (no mode parameter) exposes /step.
+
+        Signal: High - ensures backwards compatibility.
+        """
+        client = TestClient(simulation_mode_app)
+
+        response = client.post("/step", json={"action": {"message": "test"}})
+
+        assert response.status_code == 200, (
+            "Default mode should be simulation, exposing /step"
+        )
+
+    def test_default_mode_exposes_state(self, simulation_mode_app):
+        """
+        Test that default mode (no mode parameter) exposes /state.
+
+        Signal: High - ensures backwards compatibility.
+        """
+        client = TestClient(simulation_mode_app)
+
+        response = client.get("/state")
+
+        assert response.status_code == 200, (
+            "Default mode should be simulation, exposing /state"
+        )
+
+    def test_explicit_simulation_matches_default(
+        self, simulation_mode_app, simulation_mode_app_explicit
+    ):
+        """
+        Test that explicit mode='simulation' behaves identically to default.
+
+        Signal: Medium - ensures explicit and implicit modes are equivalent.
+        """
+        default_client = TestClient(simulation_mode_app)
+        explicit_client = TestClient(simulation_mode_app_explicit)
+
+        # Test /reset
+        default_reset = default_client.post("/reset", json={})
+        explicit_reset = explicit_client.post("/reset", json={})
+
+        assert default_reset.status_code == explicit_reset.status_code == 200
+
+        # Test /step
+        default_step = default_client.post(
+            "/step", json={"action": {"message": "test"}}
+        )
+        explicit_step = explicit_client.post(
+            "/step", json={"action": {"message": "test"}}
+        )
+
+        assert default_step.status_code == explicit_step.status_code == 200
+
+        # Test /state
+        default_state = default_client.get("/state")
+        explicit_state = explicit_client.get("/state")
+
+        assert default_state.status_code == explicit_state.status_code == 200
+
+
+# ============================================================================
+# Task #1.6: Integration Test - All APIs Work Together
+# ============================================================================
+
+
+class TestSimulationModeFullIntegration:
+    """
+    Test that all simulation mode APIs work together correctly.
+
+    This is a high-signal integration test to ensure the full system works,
+    not just individual endpoints.
+    """
+
+    def test_simulation_mode_full_gym_workflow(self, simulation_mode_app):
+        """
+        Test complete Gym workflow: reset -> step -> step -> state.
+
+        Signal: High - ensures full Gym API workflow is preserved.
+        """
+        client = TestClient(simulation_mode_app)
+
+        # Reset
+        reset_response = client.post("/reset", json={"episode_id": "integration_test"})
+        assert reset_response.status_code == 200
+
+        # Step 1
+        step1_response = client.post("/step", json={"action": {"message": "step1"}})
+        assert step1_response.status_code == 200
+        assert "echo: step1" in step1_response.json()["observation"]["response"]
+
+        # Step 2
+        step2_response = client.post("/step", json={"action": {"message": "step2"}})
+        assert step2_response.status_code == 200
+        assert "echo: step2" in step2_response.json()["observation"]["response"]
+
+        # Check state
+        state_response = client.get("/state")
+        assert state_response.status_code == 200
+        # Note: HTTP endpoints create new env instances, so step_count is 0
+        # This is expected behavior for stateless HTTP endpoints
+
+    def test_simulation_mode_full_websocket_workflow(self, simulation_mode_app):
+        """
+        Test complete WebSocket workflow: connect -> reset -> step -> state -> close.
+
+        Signal: High - ensures full WebSocket workflow is preserved.
+        """
+        client = TestClient(simulation_mode_app)
+
+        with client.websocket_connect("/ws") as websocket:
+            # Reset
+            websocket.send_text(json.dumps({"type": "reset", "data": {}}))
+            reset_resp = json.loads(websocket.receive_text())
+            assert reset_resp["type"] == "observation"
+
+            # Step
+            websocket.send_text(
+                json.dumps({"type": "step", "data": {"message": "ws_step"}})
+            )
+            step_resp = json.loads(websocket.receive_text())
+            assert step_resp["type"] == "observation"
+
+            # State
+            websocket.send_text(json.dumps({"type": "state"}))
+            state_resp = json.loads(websocket.receive_text())
+            assert state_resp["type"] == "state"
+            assert state_resp["data"]["step_count"] == 1  # WebSocket maintains state
+
+            # Close
+            websocket.send_text(json.dumps({"type": "close", "data": {}}))
+
+    def test_simulation_mode_mcp_and_gym_coexist(self, simulation_mode_mcp_app):
+        """
+        Test that MCP and Gym-style APIs coexist in simulation mode.
+
+        Signal: High - ensures dual API boundary is preserved.
+        """
+        client = TestClient(simulation_mode_mcp_app)
+
+        # Test Gym API
+        reset_response = client.post("/reset", json={})
+        assert reset_response.status_code == 200
+
+        # Test MCP API via WebSocket
+        mcp_request = {
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 100,
+        }
+        with client.websocket_connect("/mcp") as websocket:
+            websocket.send_text(json.dumps(mcp_request))
+            mcp_response = json.loads(websocket.receive_text())
+
+        assert "result" in mcp_response
+
+        # Both should work - Gym step uses CallToolAction for MCP environments
+        # The action format depends on the environment's action type


### PR DESCRIPTION
## Summary

Implements production mode for MCP-enabled environments per #346.

- **Production mode**: Blocks simulation control endpoints (`/reset`, `/step`, `/state`) while keeping MCP tools accessible via WebSocket `/mcp`
- **Simulation mode**: Full Gym-style API + MCP (default, backwards compatible)
- **WebSocket /mcp endpoint**: Dedicated MCP-only WebSocket path, aligning with HTTP deprecation direction
- **Mode selection**: Via constructor parameter or `OPENENV_CLIENT_MODE` environment variable

### Key Changes

| File | Change |
|------|--------|
| `src/openenv/core/env_server/http_server.py` | Add `mode` parameter, WebSocket `/mcp` endpoint |
| `src/openenv/core/env_client.py` | Client-side mode selection |
| `src/openenv/core/mcp_client.py` | MCP client mode defaults |

### Invariants Preserved

- ✅ Agents cannot reset (blocked in prod mode)
- ✅ Dual API boundary (WebSocket for infra, MCP for agents)
- ✅ WebSocket-only (no new HTTP endpoints)

## Test plan

- [x] 20 tests for mode selection mechanism
- [x] 17 tests for production mode route blocking
- [x] 13 tests for production mode MCP functionality
- [x] 19 tests for simulation mode API preservation (regression)
- [x] All 411 existing tests pass

Closes #346