### PR TITLE
feat(mcp): Enable code mode for MCP environments

### DIFF
--- a/src/openenv/core/mcp_client.py
+++ b/src/openenv/core/mcp_client.py
@@ -14,6 +14,25 @@ This module provides async client classes for interacting with MCP-enabled envir
 These clients abstract away the MCP protocol details, providing a clean interface
 for listing and calling tools on remote environments. All clients are async by default.
 
+Architecture Overview::
+
+    ┌─────────────────────────────────────────────────────────┐
+    │                    HTTPEnvServer                        │
+    ├─────────────────────────────────────────────────────────┤
+    │  Simulation Mode (default):                             │
+    │    /ws    → OpenEnv protocol (reset/step/state)         │
+    │    /mcp   → MCP JSON-RPC (tools/list, tools/call)       │
+    │    /reset, /step, /state → HTTP endpoints               │
+    ├─────────────────────────────────────────────────────────┤
+    │  Production Mode (use_production_mode=True):                     │
+    │    /mcp   → MCP JSON-RPC (tools/list, tools/call)       │
+    │    Bypasses step() for direct tool access               │
+    └─────────────────────────────────────────────────────────┘
+
+    Client Usage:
+      MCPToolClient (default)     → /ws (step-based, with rewards)
+      MCPToolClient (production)    → /mcp (direct tool access, no rewards)
+
 Example (async):
     >>> from openenv.core.mcp_client import MCPToolClient
     >>>
@@ -98,6 +117,7 @@ class MCPClientBase(EnvClient[Any, Observation, State]):
             mode=mode,
         )
         self._tools_cache: Optional[List[Tool]] = None
+        self.use_production_mode = False
 
     async def list_tools(self, use_cache: bool = True) -> List[Tool]:
         """
@@ -117,6 +137,44 @@ class MCPClientBase(EnvClient[Any, Observation, State]):
         """
         if use_cache and self._tools_cache is not None:
             return self._tools_cache
+
+        # Use production mode HTTP endpoint if enabled
+        if self.use_production_mode:
+            import requests
+
+            # Convert ws:// URL to http:// URL
+            url = self._ws_url.replace("ws://", "http://").replace("wss://", "https://")
+            # Remove /ws suffix if present and add /mcp
+            url = url.rstrip("/ws").rstrip("/") + "/mcp"
+
+            try:
+                response = requests.post(
+                    url,
+                    json={
+                        "jsonrpc": "2.0",
+                        "method": "tools/list",
+                        "params": {},
+                        "id": 1,
+                    },
+                )
+                data = response.json()
+                if "result" in data and "tools" in data["result"]:
+                    tools = [
+                        Tool(
+                            name=t.get("name", ""),
+                            description=t.get("description", ""),
+                            input_schema=t.get(
+                                "input_schema", t.get("inputSchema", {})
+                            ),
+                        )
+                        for t in data["result"]["tools"]
+                    ]
+                    self._tools_cache = tools
+                    return tools
+            except Exception:
+                # If HTTP request fails, return empty list
+                pass
+            return []
 
         result = await self.step(ListToolsAction())
         self._tools_cache = result.observation.tools

--- a/tests/core/test_mcp/test_mcp_client.py
+++ b/tests/core/test_mcp/test_mcp_client.py
@@ -245,6 +245,7 @@ class TestMCPToolClient:
         client = MCPToolClient.__new__(MCPToolClient)
         client._ws = None
         client._tools_cache = None
+        client.use_production_mode = False
 
         # Mock the step method (now async)
         mock_obs = ListToolsObservation(tools=mock_tools, done=False)


### PR DESCRIPTION
## Summary

Enable code mode for MCP environments and add direct MCP JSON-RPC access for production deployments. Rebased on top of mode-aware tool registration from PR #360.

**Code mode** (`mcp_environment.py`):
- `supports_code_mode` property for capability detection
- `get_callables()` extracts Python callables from FastMCP tools, integrated with mode-aware tool filtering
- `execute_code()` enables the CodeAct pattern — agents write Python code that calls tools directly, avoiding JSON-RPC overhead

**Production MCP endpoints** (`http_server.py`):
- HTTP POST `/mcp` endpoint for direct MCP JSON-RPC access
- Bypasses `step()` overhead for production inference
- Supports `tools/list` and `tools/call` with proper JSON-RPC error handling

**Client support** (`mcp_client.py`):
- `use_production_mode` flag for HTTP `/mcp` endpoint routing
- Architecture overview documentation

## Changes from previous version

This PR was rebased on top of `main` (which now includes PR #360's mode-aware tool registration). Key integration changes:
- Dropped multi-server support in favor of main's single-server architecture
- `get_callables()` now integrates with mode-aware tools (filters by current mode)
- Tests updated to use real `FastMCP` servers instead of `MagicMock`
- Removed dead `_compute_reward()` method

## Test plan

- [x] 35 mode selection tests (client modes + code mode + mode-aware tool integration)
- [x] 38 production mode route tests (route restrictions + MCP endpoints + WebSocket MCP)
- [x] 19 mode-aware tools tests (from PR #360, regression check)
- [x] 330 total core tests pass
- [x] Lint clean (`ruff format` + `ruff check`)
- [x] No conflicts with main

Closes #347