### PR TITLE
Add ruff check to lint workflow

### DIFF
--- a/.claude/hooks/lint.sh
+++ b/.claude/hooks/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Lint check for OpenEnv
-# Runs ruff format check on src/ and tests/
+# Runs ruff format check and ruff check (linting rules) on src/ and tests/
 
 set -e
 
@@ -11,7 +11,10 @@ if ! command -v uv &> /dev/null; then
     exit 1
 fi
 
-echo "=== Running lint check ==="
+echo "=== Running format check ==="
 uv run ruff format src/ tests/ --check
+
+echo "=== Running lint rules check ==="
+uv run ruff check src/ tests/
 
 echo "=== Lint check passed ==="

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,3 +68,6 @@ jobs:
 
       - name: Run ruff format check
         run: uv run ruff format src/ tests/ --check
+
+      - name: Run ruff lint check
+        run: uv run ruff check src/ tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,8 +161,9 @@ PYTHONPATH=src:envs uv run pytest tests/ -v --tb=short
 # Run a single test file
 PYTHONPATH=src:envs uv run pytest tests/envs/test_echo_environment.py -v
 
-# Lint check (format validation)
+# Lint check (format + rules)
 uv run ruff format src/ tests/ --check
+uv run ruff check src/ tests/
 
 # Auto-format code
 uv run ruff format src/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,20 @@ markers = [
     "network: Tests that require network access (HuggingFace, etc.)",
     "integration: Integration tests with external resources",
 ]
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]
+ignore = [
+    "E402",  # Module level import not at top of file (needed for pytest.importorskip patterns)
+    "E501",  # Line too long (not enforced previously, would require large refactor)
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Context manager variables that are intentionally unused
+"tests/envs/test_websockets.py" = ["F841"]
+"tests/test_cli/test_push.py" = ["F841"]
+# Compatibility shim module
+"src/openenv_core/__init__.py" = ["F401"]

--- a/src/openenv/auto/_discovery.py
+++ b/src/openenv/auto/_discovery.py
@@ -26,7 +26,7 @@ import re
 import tempfile
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import Dict, List, Optional, Type, Any
+from typing import Dict, Optional, Type, Any
 
 import yaml
 

--- a/src/openenv/auto/auto_action.py
+++ b/src/openenv/auto/auto_action.py
@@ -153,9 +153,9 @@ class AutoAction:
 
             if not available_envs:
                 raise ValueError(
-                    f"No OpenEnv environments found.\n"
-                    f"Install an environment with: pip install openenv-<env-name>\n"
-                    f"Or specify a HuggingFace Hub repository: AutoAction.from_env('openenv/echo_env')"
+                    "No OpenEnv environments found.\n"
+                    "Install an environment with: pip install openenv-<env-name>\n"
+                    "Or specify a HuggingFace Hub repository: AutoAction.from_env('openenv/echo_env')"
                 )
 
             # Try to suggest similar environment names

--- a/src/openenv/cli/commands/init.py
+++ b/src/openenv/cli/commands/init.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import random
 import shutil
 import subprocess
@@ -220,7 +219,6 @@ def _create_template_replacements(env_name: str) -> Dict[str, str]:
     - camelCase for variable names
     - snake_case for module names, file paths
     """
-    env_pascal = _snake_to_pascal(env_name)
     env_prefix = _get_env_prefix(env_name)
     env_camel = _snake_to_camel(env_name)
     env_title = _snake_to_title(env_name)

--- a/src/openenv/core/env_server/http_server.py
+++ b/src/openenv/core/env_server/http_server.py
@@ -858,7 +858,7 @@ Get JSON schemas for actions, observations, and state in a single response.
 
 Returns a combined schema object containing:
 - **action**: JSON schema for actions accepted by this environment
-- **observation**: JSON schema for observations returned by this environment  
+- **observation**: JSON schema for observations returned by this environment
 - **state**: JSON schema for environment state objects
 
 This is more efficient than calling individual schema endpoints and provides

--- a/src/openenv/core/env_server/web_interface.py
+++ b/src/openenv/core/env_server/web_interface.py
@@ -327,7 +327,7 @@ def create_web_interface_app(
     Returns:
         FastAPI application instance with web interface
     """
-    from .http_server import ConcurrencyConfig, create_fastapi_app
+    from .http_server import create_fastapi_app
 
     # Create the base environment app
     app = create_fastapi_app(

--- a/src/openenv/core/tools/local_python_executor.py
+++ b/src/openenv/core/tools/local_python_executor.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import json
 import logging
 import traceback
-from typing import Any
 
 from smolagents import LocalPythonExecutor
 
@@ -151,7 +150,7 @@ class PyExecutor:
 
             return CodeExecResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
 
-        except Exception as e:
+        except Exception:
             # Any unexpected exception from the LocalPythonExecutor is
             # returned with a full traceback to make debugging easier.
             tb = traceback.format_exc()

--- a/tests/core/test_mcp/test_mcp_client.py
+++ b/tests/core/test_mcp/test_mcp_client.py
@@ -14,9 +14,8 @@ These tests verify the MCPToolClient class functionality including:
 4. Error handling for tool failures
 """
 
-import json
 import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import AsyncMock
 
 from openenv.core.mcp_client import MCPClientBase, MCPToolClient
 from openenv.core.env_server.mcp_types import (

--- a/tests/core/test_mcp/test_mcp_integration.py
+++ b/tests/core/test_mcp/test_mcp_integration.py
@@ -13,7 +13,6 @@ These tests verify:
 3. WebSocket MCP tools/list and tools/call endpoints
 """
 
-import asyncio
 import json
 from typing import Any, Optional
 
@@ -26,7 +25,6 @@ from openenv.core.env_server.mcp_types import (
     CallToolObservation,
     ListToolsAction,
     ListToolsObservation,
-    Tool,
 )
 from openenv.core.env_server.types import Action, Observation, State
 

--- a/tests/core/test_rubrics/test_async_environment_integration.py
+++ b/tests/core/test_rubrics/test_async_environment_integration.py
@@ -14,7 +14,7 @@ This test file verifies that rubrics work with async environments:
 """
 
 import pytest
-from typing import Any, Optional, List, Tuple
+from typing import Any, Optional
 
 from openenv.core.env_server.interfaces import Environment
 from openenv.core.env_server.types import Action, Observation, State

--- a/tests/core/test_rubrics/test_environment_integration.py
+++ b/tests/core/test_rubrics/test_environment_integration.py
@@ -6,7 +6,6 @@
 
 """Tests for rubric integration with Environment base class."""
 
-import pytest
 from typing import Any, Optional, List, Tuple
 
 from openenv.core.env_server.interfaces import Environment

--- a/tests/envs/test_connect4_env.py
+++ b/tests/envs/test_connect4_env.py
@@ -12,7 +12,6 @@ For comprehensive Connect4 tests, see test_websockets.py::TestConnect4Environmen
 
 import os
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -22,7 +21,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from envs.connect4_env import (
     Connect4Action,
     Connect4Observation,
-    Connect4State,
     Connect4Env,
 )
 import subprocess
@@ -94,7 +92,7 @@ class TestConnect4(unittest.TestCase):
         assert (
             len(observation.legal_actions) == 7
         )  # All columns should be legal at start
-        assert observation.done == False
+        assert not observation.done
         assert observation.reward == 0.0
 
         if isinstance(observation.legal_actions, float):

--- a/tests/envs/test_dipg_client.py
+++ b/tests/envs/test_dipg_client.py
@@ -6,7 +6,6 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from envs.dipg_safety_env.client import DIPGSafetyEnv
-from envs.dipg_safety_env.models import DIPGAction
 
 
 @pytest.mark.asyncio

--- a/tests/envs/test_discovery.py
+++ b/tests/envs/test_discovery.py
@@ -16,9 +16,7 @@ Tests cover:
 5. Helper functions (_normalize_env_name, _is_hub_url, etc.)
 """
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from pathlib import Path
+from unittest.mock import Mock, patch
 
 from openenv.auto._discovery import (
     EnvironmentDiscovery,

--- a/tests/envs/test_python_codeact_reset.py
+++ b/tests/envs/test_python_codeact_reset.py
@@ -10,7 +10,6 @@ import os
 import sys
 from pathlib import Path
 
-import pytest
 
 # Add the project root and src to the path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))

--- a/tests/envs/test_unity_environment.py
+++ b/tests/envs/test_unity_environment.py
@@ -27,7 +27,6 @@ Running Tests:
 """
 
 import os
-import shutil
 import subprocess
 import sys
 import time
@@ -40,7 +39,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 # Check if mlagents-envs is installed
 try:
-    import mlagents_envs
+    import mlagents_envs  # noqa: F401
 
     MLAGENTS_INSTALLED = True
 except ImportError:

--- a/tests/envs/test_websearch_environment.py
+++ b/tests/envs/test_websearch_environment.py
@@ -11,7 +11,7 @@ try:
     from envs.websearch_env.models import WebSearchAction, WebSearchObservation
 
     WEBSEARCH_AVAILABLE = True
-except ImportError as e:
+except ImportError:
     WEBSEARCH_AVAILABLE = False
     WebSearchEnvironment = None
     WebSearchAction = None

--- a/tests/envs/test_websockets.py
+++ b/tests/envs/test_websockets.py
@@ -19,16 +19,12 @@ Run with: pytest tests/envs/test_websockets.py -v
 Run specific category: pytest tests/envs/test_websockets.py -v -k "smoke"
 """
 
-import asyncio
-import json
 import os
-import signal
 import subprocess
 import sys
 import time
 from contextlib import contextmanager
-from typing import Generator, Tuple, Type, Callable
-from unittest.mock import patch
+from typing import Generator
 
 import pytest
 import requests

--- a/tests/scripts/test_manage_hf_collection.py
+++ b/tests/scripts/test_manage_hf_collection.py
@@ -7,7 +7,7 @@ These tests mock all external API calls to test the logic without making real AP
 import pytest
 import sys
 import os
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from huggingface_hub.utils import HfHubHTTPError
 
 

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -7,11 +7,8 @@
 """Tests for the openenv init command."""
 
 import os
-import tempfile
 from pathlib import Path
 
-import pytest
-import typer
 from typer.testing import CliRunner
 
 from openenv.cli.__main__ import app

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -6,13 +6,12 @@
 
 """Tests for the openenv __main__ module."""
 
-import sys
 from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
 
-from openenv.cli.__main__ import app, main
+from openenv.cli.__main__ import main
 
 
 runner = CliRunner()

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -7,12 +7,9 @@
 """Tests for the openenv push command."""
 
 import os
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-import typer
 from typer.testing import CliRunner
 
 from openenv.cli.__main__ import app

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -19,7 +19,6 @@ Tests cover:
 8. AutoAction with skip_install parameter
 """
 
-import asyncio
 from unittest.mock import Mock, patch, MagicMock, AsyncMock
 
 import pytest
@@ -320,7 +319,7 @@ class TestAutoEnvSkipInstall:
                 side_effect=mock_from_env_async,
             ) as mock_from_env,
         ):
-            client = AutoEnv.from_env(
+            AutoEnv.from_env(
                 "user/my-env",
                 skip_install=True,
             )


### PR DESCRIPTION
## Summary
- Adds `ruff check` (lint rules) to both CI workflow and local `.claude/hooks/lint.sh`
- Configures ruff in `pyproject.toml` with ignores for E402 (module imports not at top - needed for pytest.importorskip) and E501 (line too long - not enforced before)
- Fixes all existing lint violations (43 auto-fixed, 5 manual fixes)

This ensures local lint checks match CI, preventing lint failures that weren't caught locally.

## Test plan
- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run ruff format src/ tests/ --check` passes
- [x] Related tests pass