### PR TITLE
fix: Exclude computer tool from tool_use modality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ outputs/
 .uv/
 
 *.backup*/
+
+# logs
+*.log

--- a/PR_README.md
+++ b/PR_README.md
@@ -1,0 +1,36 @@
+### PR: Fleet environments (OpenEnv)
+
+This PR documents and refines the **Fleet** runtime integration for OpenEnv.
+
+#### What this enables
+- Run OpenEnv environments on **Fleet (remote)** with **no local Docker**.
+- Keep a strict split between:
+  - **Orchestration (HTTP)**: `reset / step / state`
+  - **Agent actions (MCP)**: `tools/list + tools/call`
+
+#### What this is *not*
+- This is **not** the local “Dockerized env server + env container” setup.
+- There is **no container/provider abstraction** here; Fleet hosts the runtime remotely (HTTP env server + MCP service). The client only connects.
+
+#### Main abstractions
+- **`FleetEnvClient` (HTTP)**: orchestrator handle for reset/step/state.
+- **`FleetMCPTools` (MCP)**: agent handle for listing/calling tools.
+  - Unions tools across Fleet’s MCP endpoints (today often `api/v1/mcp` and `mcp`)
+  - Returns tools in **OpenAI “tools” dict format** (via `convert_tool_format`)
+  - Routes tool calls to the owning endpoint (cached after discovery)
+
+#### Quickstart
+- Install: `pip install "openenv-core[fleet]"`
+- Set: `export FLEET_API_KEY="..."`
+- Run: `python examples/fleet_env_example.py <env_key>`
+
+#### References
+- RFC 001: `rfcs/001-abstractions.md`
+- RFC 003: `rfcs/003-mcp-support.md`
+
+#### TODOs / known sharp edges
+- Endpoint discovery (avoid hardcoding `api/v1/mcp` vs `mcp`)
+- Reset inconsistencies across some env keys (better errors + compatibility notes)
+- Tool-name collision policy across endpoints
+- Retries/backoff and clearer “endpoint down” failure modes
+

--- a/examples/fleet_env_example.py
+++ b/examples/fleet_env_example.py
@@ -1,0 +1,153 @@
+"""
+Example: Orchestrator + Agent loop using OpenEnv on Fleet.
+
+Demonstrates the split architecture:
+1. Orchestrator: Provisions environment, resets episodes (HTTP).
+2. Agent: Lists tools, calls tools (MCP).
+
+Prerequisites:
+  pip install "openenv-core[fleet]"
+  export FLEET_API_KEY="..."
+  export FLEET_ENV_KEY="..."  # e.g. "browser-env" or your custom env
+"""
+
+import asyncio
+import os
+import random
+import sys
+from typing import Any, Dict, List, Sequence
+
+# Ensure we can import from src/ if running from repo root
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+try:
+    # `openenv` installs top-level packages like `envs`, `core`, etc.
+    # This example also prepends `src/` above so it works from a repo checkout.
+    from envs.fleet_env import FleetEnvClient
+except ImportError as e:
+    raise ImportError(
+        "Could not import `envs.fleet_env`. "
+        "Run from the repo root, or install OpenEnv in editable mode: "
+        "`python -m pip install -e '.[fleet]'`."
+    ) from e
+
+def get_openai_tool_param_enum(tool_def: Dict[str, Any], param_name: str) -> List[str]:
+    """Extract an enum list for a parameter from an OpenAI 'tools' dict."""
+    schema = tool_def.get("function", {}).get("parameters", {})
+    if not isinstance(schema, dict):
+        return []
+    props = schema.get("properties", {})
+    if not isinstance(props, dict):
+        return []
+    param_spec = props.get(param_name, {})
+    if not isinstance(param_spec, dict):
+        return []
+    enum = param_spec.get("enum", [])
+    return enum if isinstance(enum, list) else []
+
+SAFE_COMPUTER_ACTION_PREFERENCE: Sequence[str] = ("screenshot", "wait", "cursor_position")
+
+
+def pick_safe_computer_action(tool_def: Dict[str, Any]) -> str:
+    """Pick a non-destructive default action for the Fleet 'computer' tool.
+
+    Prefer safe actions like screenshot/wait, falling back to first enum.
+    """
+    actions = get_openai_tool_param_enum(tool_def, "action")
+    if not actions:
+        raise ValueError("Tool 'computer' has no available actions in schema.")
+
+    action_set = set(actions)
+    safe_available = [a for a in SAFE_COMPUTER_ACTION_PREFERENCE if a in action_set]
+    if safe_available:
+        return random.choice(safe_available)
+    return actions[0]
+
+def main():
+    api_key = os.environ.get("FLEET_API_KEY")
+    
+    # 1. Get env_key from args or env var
+    env_key = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("FLEET_ENV_KEY")
+    
+    if not api_key or not env_key:
+        print("Usage: python fleet_env_example.py <env_key>")
+        print("   or: export FLEET_ENV_KEY=... && python fleet_env_example.py")
+        raise ValueError("Please set FLEET_API_KEY and provide an env_key.")
+
+    print(f"Provisioning Fleet environment: {env_key}...")
+    
+    # 1. Provision & Split Handles (Synchronous)
+    # This must be run outside of an async loop because it manages its own loop.
+    try:
+        orch, tools = FleetEnvClient.from_fleet(
+            api_key=api_key,
+            env_key=env_key,
+            ttl_seconds=600,  # 10 min TTL
+        )
+    except Exception as e:
+        raise ValueError(f"Failed to provision environment: {e}")
+
+
+    try:
+        # Run the async agent loop
+        asyncio.run(agent_loop(orch, tools))
+    except BaseException as e:
+        print(f"\n❌ Agent loop failed: {e}")
+    finally:
+        # 5. Cleanup (Synchronous)
+        print("\nOrchestrator: Closing environment...")
+        orch.close()
+        print("Done.")
+
+
+async def agent_loop(orch, tools):
+    # 2. Orchestration: Start Episode (HTTP calls, sync method but we wrap or call directly)
+    # orch.reset() is sync (requests), so it blocks the loop briefly. That's fine for this example.
+    print("Orchestrator: Resetting environment...")
+    obs = orch.reset()
+    print(f"Reset complete. Initial observation keys: {list(obs.observation.metadata.keys())}")
+
+    # 3. Agent: Discover Tools (Async)
+    print("\nAgent: Discovering tools...")
+    listed = await tools.list_tools()
+    tool_defs = listed.tools
+    print(f"Available tools ({len(tool_defs)}): {[t['function']['name'] for t in tool_defs]}")
+    # Print the derived schema payloads (mirrors MCP Tool.inputSchema content, but OpenAI-shaped)
+    print([t["function"]["parameters"] for t in tool_defs])
+
+    if not tool_defs:
+        print("No MCP tools available (all MCP endpoints may be down).")
+        return
+
+    # 4. Agent: Call a Tool
+    target_tool_name = "computer"
+    target_def = next((t for t in tool_defs if t["function"]["name"] == target_tool_name), None)
+
+    if not target_def:
+        print(f"Tool '{target_tool_name}' not found, picking first available.")
+        target_def = tool_defs[0]
+        target_tool_name = target_def["function"]["name"]
+
+    print(f"\nTarget Tool: {target_tool_name}")
+    # Inspect schema to construct params (in a real agent, the LLM does this)
+    # schema = target_def["function"]["parameters"]
+    # print(f"Schema: {json.dumps(schema, indent=2)}")
+
+    params = {}
+    if target_tool_name == "computer":
+        # Choose a supported action from the schema (safe default).
+        params = {"action": pick_safe_computer_action(target_def)}
+    
+    print(f"\nAgent: Calling tool '{target_tool_name}' with {params}...")
+    result = await tools.call_tool(target_tool_name, params)
+
+    
+    # Result is typically a list of MCP content objects (TextContent/ImageContent)
+    # We'll just print a summary.
+    print("Agent: Tool execution result received.")
+    print(f"{result=}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,12 @@ dependencies = [
     "tomli-w>=1.2.0"
 ]
 
+[project.optional-dependencies]
+fleet = [
+    "mcp>=1.0.0",
+    "fleet-sdk>=0.2.79",
+]
+
 [project.scripts]
 openenv = "openenv_cli.__main__:main"
 
@@ -38,6 +44,9 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
 
 [tool.coverage.run]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 fleet = [
     "mcp>=1.0.0",
-    "fleet-sdk>=0.2.79",
+    "fleet-python>=0.2.79",
 ]
 
 [project.scripts]

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -1,0 +1,1 @@
+# OpenEnv environments package

--- a/src/envs/fleet_env/README.md
+++ b/src/envs/fleet_env/README.md
@@ -1,0 +1,105 @@
+### Fleet Runtime Integration (OpenEnv) — Design Proposal
+
+### Goal
+Run OpenEnv environments on **Fleet** (remote) with **no Docker**, strictly adhering to:
+- **RFC 001**: Agent interacts via MCP tools; Orchestration via HTTP.
+- **RFC 003**: Standardized `ListToolsAction` and `CallToolAction`.
+
+### Architecture
+
+We implement a client-side adapter (`FleetEnvClient`) that aggregates Fleet's interfaces into the OpenEnv contract.
+
+```mermaid
+flowchart LR
+  subgraph Client["OpenEnv Client (Local)"]
+    Agent["Agent / Policy"]
+    Orch["FleetEnvClient\n(Orchestrator, HTTP)"]
+    Tools["FleetMCPTools\n(Agent, MCP)"]
+  end
+
+  subgraph Runtime["Fleet Runtime (Remote)"]
+    HTTP["Instance Manager HTTP API\n/reset /step /state"]
+    MCP_A["MCP Server A\n(e.g., /api/v1/mcp)"]
+    MCP_B["MCP Server B\n(e.g., /mcp)"]
+  end
+
+  %% Orchestration (RFC 001)
+  Orch --"reset()/step()/state()"--> HTTP
+
+  %% Agent actions (RFC 003)
+  Agent --"tools/list, tools/call"--> Tools
+  Tools <-->|"SSE Session"| MCP_A
+  Tools <-->|"SSE Session"| MCP_B
+```
+
+### 1. Combined Action Space (Client-Side Multiplexing)
+Fleet instances expose multiple MCP endpoints (e.g., `api/v1/mcp` for browser control, `mcp` for API tools). 
+
+**The Strategy:**
+1.  **Connect to ALL**: The client establishes sessions with both `root + "api/v1/mcp"` and `root + "mcp"`.
+2.  **Union Tools**: `FleetMCPTools.list_tools()` returns the union of tools from all connected endpoints.
+3.  **Route Execution**: `FleetMCPTools.call_tool()` routes the call to the endpoint that owns the tool.
+
+### 2. Client Implementation (`FleetEnvClient`)
+
+This adapter replaces `LocalDockerProvider` and remains orchestration-only (HTTP). Agent tool calls are handled by `FleetMCPTools` (MCP).
+
+```python
+# Pseudocode implementation of the Client Adapter
+class FleetEnvClient(HTTPEnvClient):
+    @classmethod
+    def from_fleet(cls, api_key, env_key, **kwargs):
+        # 1. Provision Instance via Fleet SDK
+        env = fleet.make(env_key, ...)
+        
+        # 2. Establish MCP Sessions (Streamable HTTP)
+        # We connect to BOTH to provide the full browser + api toolset
+        mcp_sessions = []
+        for path in ["api/v1/mcp", "mcp"]:
+            url = f"{env.urls.root}{path}"
+            if is_reachable(url):
+                mcp_sessions.append(connect_mcp(url, api_key))
+                
+        orch = cls(base_url=env.urls.manager.api)
+        tools = FleetMCPTools(mcp_urls=mcp_sessions)
+        return orch, tools
+
+    # step/reset/state remain HTTP only
+```
+
+### 3. Usage (User Perspective)
+
+```python
+# The user simply provides keys. No Docker required.
+orch, tools = FleetEnvClient.from_fleet(
+    api_key=os.environ["FLEET_API_KEY"],
+    env_key=os.environ["FLEET_ENV_KEY"]
+)
+
+# Orchestrator controls episode (HTTP)
+orch.reset()
+
+# Agent uses MCP tools (Browser + API)
+tools_list = await tools.list_tools()
+result = await tools.call_tool("computer", {...})
+```
+
+### Architecture Note: RFC vs Implementation
+
+This design uses a **Client-Side Adapter** pattern to integrate Fleet without modifying remote server images.
+
+**RFC Ideal (Server-Side Execution):**
+```
+Agent -> Client -> [Network] -> Server -> Internal MCP Server
+                                   ^
+                                   | Server executes tool
+```
+
+**Fleet Adapter (Client-Side Execution):**
+```
+Agent -> Client -> [MCP Client] -> [Network] -> Remote MCP Endpoint
+            ^
+            | Client executes tool via MCP
+```
+
+**Why:** Fleet servers expose raw MCP endpoints but lack a `/step` handler that wraps them as of now. The `FleetEnvClient` bridges this gap, preserving the user-facing `env.step()` interface while handling protocol details locally.

--- a/src/envs/fleet_env/__init__.py
+++ b/src/envs/fleet_env/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fleet Environment - client-side adapter for Fleet-hosted MCP environments."""
+
+from .client import FleetEnvClient
+from .mcp_tools import FleetMCPTools
+from .models import CallToolAction, ListToolsAction
+
+__all__ = ["FleetEnvClient", "FleetMCPTools", "ListToolsAction", "CallToolAction"]
+
+

--- a/src/envs/fleet_env/__init__.py
+++ b/src/envs/fleet_env/__init__.py
@@ -7,6 +7,7 @@
 """Fleet Environment - client-side adapter for Fleet-hosted MCP environments."""
 
 from .client import FleetEnvClient
+from .context_manager import CONTEXT_TOOLS, CONTEXT_TOOL_NAMES, ContextManager
 from .mcp_tools import FleetMCPTools
 from .models import CallToolAction, ListToolsAction
 from .task_env import FleetTaskEnv, make_fleet_task_env
@@ -18,6 +19,7 @@ __all__ = [
     "CallToolAction",
     "FleetTaskEnv",
     "make_fleet_task_env",
+    "ContextManager",
+    "CONTEXT_TOOLS",
+    "CONTEXT_TOOL_NAMES",
 ]
-
-

--- a/src/envs/fleet_env/__init__.py
+++ b/src/envs/fleet_env/__init__.py
@@ -9,7 +9,15 @@
 from .client import FleetEnvClient
 from .mcp_tools import FleetMCPTools
 from .models import CallToolAction, ListToolsAction
+from .task_env import FleetTaskEnv, make_fleet_task_env
 
-__all__ = ["FleetEnvClient", "FleetMCPTools", "ListToolsAction", "CallToolAction"]
+__all__ = [
+    "FleetEnvClient",
+    "FleetMCPTools",
+    "ListToolsAction",
+    "CallToolAction",
+    "FleetTaskEnv",
+    "make_fleet_task_env",
+]
 
 

--- a/src/envs/fleet_env/client.py
+++ b/src/envs/fleet_env/client.py
@@ -54,6 +54,8 @@ class FleetEnvClient(HTTPEnvClient[Action, Observation]):
         ttl_seconds: Optional[int] = 3600,
         env_variables: Optional[Dict[str, Any]] = None,
         image_type: Optional[str] = None,
+        data_key: Optional[str] = None,
+        data_version: Optional[str] = None,
         **kwargs: Any,
     ) -> Tuple["FleetEnvClient", FleetMCPTools]:
         try:
@@ -73,6 +75,8 @@ class FleetEnvClient(HTTPEnvClient[Action, Observation]):
             ttl_seconds=ttl_seconds,
             env_variables=env_variables,
             image_type=image_type,
+            data_key=data_key,
+            data_version=data_version,
         )
 
         root = env.urls.root

--- a/src/envs/fleet_env/client.py
+++ b/src/envs/fleet_env/client.py
@@ -53,7 +53,7 @@ class FleetEnvClient(HTTPEnvClient[Action, Observation]):
         region: Optional[str] = None,
         ttl_seconds: Optional[int] = 3600,
         env_variables: Optional[Dict[str, Any]] = None,
-        image_type: str = "mcp",
+        image_type: Optional[str] = None,
         **kwargs: Any,
     ) -> Tuple["FleetEnvClient", FleetMCPTools]:
         try:

--- a/src/envs/fleet_env/client.py
+++ b/src/envs/fleet_env/client.py
@@ -1,0 +1,157 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fleet Environment client (HTTP orchestration only)."""
+
+import asyncio
+import dataclasses
+from typing import Any, Dict, Optional, Tuple, Type
+
+try:
+    # In-repo imports
+    from core.env_server.types import Action, Observation, State
+    from core.http_env_client import HTTPEnvClient
+    from core.client_types import StepResult
+except ImportError:
+    # Standalone imports
+    from openenv_core.env_server.types import Action, Observation, State
+    from openenv_core.http_env_client import HTTPEnvClient
+    from openenv_core.client_types import StepResult
+
+from .mcp_tools import FleetMCPTools
+from .models import CallToolAction, ListToolsAction
+
+
+class FleetEnvClient(HTTPEnvClient[Action, Observation]):
+    """Orchestrator-facing client for Fleet-hosted environments (HTTP only)."""
+
+    def __init__(
+        self,
+        base_url: str,
+        fleet_env_handle: Any,
+        api_key: str,
+        mcp_urls: Tuple[str, ...],
+        **kwargs: Any,
+    ):
+        super().__init__(
+            base_url=base_url,
+            default_headers={"Authorization": f"Bearer {api_key}"},
+            **kwargs,
+        )
+        self._fleet_env = fleet_env_handle
+        self._api_key = api_key
+        self._mcp_urls = mcp_urls
+
+    @classmethod
+    def from_fleet(
+        cls: Type["FleetEnvClient"],
+        api_key: str,
+        env_key: str,
+        region: Optional[str] = None,
+        ttl_seconds: Optional[int] = 3600,
+        env_variables: Optional[Dict[str, Any]] = None,
+        image_type: str = "mcp",
+        **kwargs: Any,
+    ) -> Tuple["FleetEnvClient", FleetMCPTools]:
+        """
+            Instantiate a FleetEnvClient and FleetMCPTools from a Fleet environment.
+
+            Args:
+                api_key: The API key for the Fleet environment.
+                env_key: The environment key for the Fleet environment.
+                region: The region for the Fleet environment.
+                ttl_seconds: The TTL for the Fleet environment.
+                env_variables: The environment variables for the Fleet environment.
+                image_type: The image type for the Fleet environment.
+        """
+        try:
+            from fleet import AsyncFleet
+        except ImportError as e:
+            raise ImportError(
+                "Fleet support requires the optional dependency set. "
+                "Install with `pip install openenv-core[fleet]`."
+            ) from e
+
+        async def _make_env():
+            fleet = AsyncFleet(api_key=api_key)
+            return await fleet.make(
+                env_key=env_key,
+                region=region,
+                ttl_seconds=ttl_seconds,
+                env_variables=env_variables,
+                image_type=image_type,
+            )
+
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            env = loop.run_until_complete(_make_env())
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+        root = env.urls.root
+        mcp_urls = tuple(sorted({f"{root}api/v1/mcp", f"{root}mcp"}))
+
+        orch = cls(
+            base_url=env.urls.manager.api,
+            fleet_env_handle=env,
+            api_key=api_key,
+            mcp_urls=mcp_urls,
+            **kwargs,
+        )
+        tools = FleetMCPTools(api_key=api_key, mcp_urls=mcp_urls)
+        return orch, tools
+
+    def _step_payload(self, action: Action) -> dict:
+        """Serialize action for HTTP /step."""
+        if dataclasses.is_dataclass(action):
+            return dataclasses.asdict(action)
+        if isinstance(action, dict):
+            return action
+        raise TypeError(f"Action must be a dataclass or dict, got {type(action)}")
+
+    def _parse_result(self, payload: dict) -> StepResult[Observation]:
+        """Parse standard OpenEnv step response."""
+        obs_payload = payload.get("observation", {})
+        # Ensure obs_payload is a dict before accessing .get()
+        if not isinstance(obs_payload, dict):
+            # If observation is a primitive (e.g. string), wrap it
+            obs_payload = {"content": obs_payload}
+
+        return StepResult(
+            observation=Observation(
+                metadata=obs_payload,
+                reward=payload.get("reward"),
+                done=payload.get("done", False),
+            ),
+            reward=payload.get("reward"),
+            done=payload.get("done", False),
+        )
+
+    def _parse_state(self, payload: Any) -> Any:
+        if isinstance(payload, dict):
+            try:
+                return State(**payload)
+            except TypeError:
+                pass
+        return payload
+
+    def step(self, action: Action) -> StepResult[Observation]:
+        # Enforce separation: agent actions are MCP-only (use FleetMCPTools).
+        if isinstance(action, (ListToolsAction, CallToolAction)):
+            raise TypeError(
+                "Agent tool actions are MCP-only. Use FleetMCPTools.list_tools()/call_tool()."
+            )
+        return super().step(action)
+
+    def close(self) -> None:
+        """Terminate the remote Fleet instance (resource cleanup), not an episode reset."""
+        if self._fleet_env:
+            self._fleet_env.close()
+        super().close()
+
+

--- a/src/envs/fleet_env/client.py
+++ b/src/envs/fleet_env/client.py
@@ -61,7 +61,7 @@ class FleetEnvClient(HTTPEnvClient[Action, Observation]):
         except ImportError as e:
             raise ImportError(
                 "Fleet support requires the optional dependency set. "
-                "Install with `pip install openenv-core[fleet]`."
+                "Install with `pip install openenv[fleet]`."
             ) from e
 
         # Use synchronous Fleet client for the orchestrator handle.

--- a/src/envs/fleet_env/client.py
+++ b/src/envs/fleet_env/client.py
@@ -69,14 +69,22 @@ class FleetEnvClient(HTTPEnvClient[Action, Observation]):
         # Use synchronous Fleet client for the orchestrator handle.
         # This ensures .close() and other lifecycle methods are synchronous.
         fleet = Fleet(api_key=api_key)
+
+        # Fleet SDK expects data_key in "key:version" format
+        data_key_spec = None
+        if data_key:
+            if data_version:
+                data_key_spec = f"{data_key}:{data_version}"
+            else:
+                data_key_spec = data_key
+
         env = fleet.make(
             env_key=env_key,
             region=region,
             ttl_seconds=ttl_seconds,
             env_variables=env_variables,
             image_type=image_type,
-            data_key=data_key,
-            data_version=data_version,
+            data_key=data_key_spec,
         )
 
         root = env.urls.root

--- a/src/envs/fleet_env/client.py
+++ b/src/envs/fleet_env/client.py
@@ -78,6 +78,13 @@ class FleetEnvClient(HTTPEnvClient[Action, Observation]):
             else:
                 data_key_spec = data_key
 
+        import time
+        import logging
+        _logger = logging.getLogger(__name__)
+
+        _logger.info(f"Creating Fleet instance: env_key={env_key}, ttl={ttl_seconds}s")
+        start = time.time()
+
         env = fleet.make(
             env_key=env_key,
             region=region,
@@ -86,6 +93,8 @@ class FleetEnvClient(HTTPEnvClient[Action, Observation]):
             image_type=image_type,
             data_key=data_key_spec,
         )
+
+        _logger.info(f"Fleet instance ready in {time.time() - start:.1f}s: {env.instance_id}")
 
         root = env.urls.root
         # Fleet currently exposes multiple MCP endpoints. Prefer /api/v1/mcp first.

--- a/src/envs/fleet_env/context_manager.py
+++ b/src/envs/fleet_env/context_manager.py
@@ -1,0 +1,329 @@
+"""
+Context Management for Fleet Task Environments.
+
+This module provides tools for managing conversation context during long trajectories,
+inspired by Toolathlon's context management approach. It allows models to:
+1. Check how much context they've used
+2. Drop old turns to free up context space
+3. Search through dropped history
+4. Navigate truncated tool outputs
+
+These tools are designed for step-wise RL training where each turn is a separate
+training sample. When context is dropped, the training framework re-tokenizes
+the modified chat_history, so the model learns from the reduced context.
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+# Context management tool definitions (OpenAI function calling format)
+CONTEXT_TOOLS = [
+    # --- Context/History Management ---
+    {
+        "type": "function",
+        "function": {
+            "name": "check_context",
+            "description": "Check current context: visible/total turn counts",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "manage_context",
+            "description": "Drop old turns to free up context space",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "keep_recent_turns": {
+                        "type": "integer",
+                        "description": "Number of recent turns to keep (drops older ones)",
+                    }
+                },
+                "required": ["keep_recent_turns"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "search_history",
+            "description": "Search all history (including dropped) by pattern",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "description": "Text pattern to search",
+                    }
+                },
+                "required": ["pattern"],
+            },
+        },
+    },
+    # --- Overlong Tool Output Handling ---
+    {
+        "type": "function",
+        "function": {
+            "name": "search_tool_output",
+            "description": "Search the last truncated tool output by pattern",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "description": "Text pattern to search",
+                    }
+                },
+                "required": ["pattern"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "view_tool_output",
+            "description": "View a page of the last truncated tool output",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer",
+                        "description": "Page number (1-indexed)",
+                    },
+                    "page_size": {
+                        "type": "integer",
+                        "description": "Lines per page (default 50)",
+                    },
+                },
+                "required": ["page"],
+            },
+        },
+    },
+]
+
+CONTEXT_TOOL_NAMES = {t["function"]["name"] for t in CONTEXT_TOOLS}
+
+
+class ContextManager:
+    """Manages conversation context for long-running agent trajectories.
+
+    This class provides utilities for:
+    1. Tracking full conversation history (never dropped)
+    2. Managing visible context (can be trimmed)
+    3. Handling truncated tool outputs
+    4. Executing context management tool calls
+
+    Designed to work with any training framework that maintains chat_history.
+    The framework passes its chat_history to execute_tool(), which may modify it.
+
+    Example:
+        >>> ctx = ContextManager(max_output_chars=10000)
+        >>> # Get tools to add to the model's available tools
+        >>> tools = ctx.get_tools()
+        >>> # Track messages as they're added
+        >>> ctx.track_message({"role": "assistant", "content": "..."})
+        >>> # Check if a tool call is a context tool
+        >>> if ctx.is_context_tool("manage_context"):
+        ...     result, chat_history = ctx.execute_tool("manage_context", {"keep_recent_turns": 5}, chat_history)
+        >>> # Truncate long outputs
+        >>> output = ctx.truncate_output(long_tool_result)
+    """
+
+    def __init__(self, max_output_chars: int = 10000):
+        """Initialize the context manager.
+
+        Args:
+            max_output_chars: Maximum characters for tool output before truncation.
+                Truncated outputs can be accessed via search_tool_output/view_tool_output.
+        """
+        self.max_output_chars = max_output_chars
+        self.full_history: List[Dict[str, Any]] = []
+        self.last_full_output: Optional[str] = None
+
+    def reset(self):
+        """Reset state for a new episode."""
+        self.full_history = []
+        self.last_full_output = None
+
+    def get_tools(self) -> List[Dict[str, Any]]:
+        """Get the context management tool definitions.
+
+        Returns:
+            List of tool definitions in OpenAI function calling format.
+        """
+        return CONTEXT_TOOLS.copy()
+
+    def is_context_tool(self, tool_name: str) -> bool:
+        """Check if a tool name is a context management tool.
+
+        Args:
+            tool_name: Name of the tool to check.
+
+        Returns:
+            True if it's a context tool that should be handled locally.
+        """
+        return tool_name in CONTEXT_TOOL_NAMES
+
+    def track_message(self, message: Dict[str, Any]):
+        """Track a message in the full history.
+
+        Call this for every message added to chat_history. The full_history
+        is never trimmed, allowing search_history to find dropped messages.
+
+        Args:
+            message: Message dict with "role" and "content" keys.
+        """
+        self.full_history.append(message.copy())
+
+    def truncate_output(self, output: str) -> str:
+        """Truncate a tool output if it exceeds max_output_chars.
+
+        If truncated, the full output is stored and can be accessed via
+        search_tool_output or view_tool_output tools.
+
+        Args:
+            output: The tool output string.
+
+        Returns:
+            Original output if within limit, truncated version with notice otherwise.
+        """
+        if not isinstance(output, str):
+            return output
+
+        if len(output) > self.max_output_chars:
+            self.last_full_output = output
+            return (
+                output[: self.max_output_chars]
+                + f"\n\n[TRUNCATED - {len(output)} chars total. "
+                + "Use search_tool_output or view_tool_output to access full content.]"
+            )
+        else:
+            self.last_full_output = None
+            return output
+
+    def execute_tool(
+        self, tool_name: str, args: Dict[str, Any], chat_history: List[Dict[str, Any]]
+    ) -> Tuple[str, List[Dict[str, Any]]]:
+        """Execute a context management tool.
+
+        Args:
+            tool_name: Name of the context tool to execute.
+            args: Tool arguments.
+            chat_history: Current visible chat history (may be modified).
+
+        Returns:
+            Tuple of (result_string, modified_chat_history).
+            The chat_history is modified in-place for manage_context.
+        """
+        if tool_name == "check_context":
+            return self._check_context(chat_history), chat_history
+
+        elif tool_name == "manage_context":
+            return self._manage_context(args, chat_history)
+
+        elif tool_name == "search_history":
+            return self._search_history(args), chat_history
+
+        elif tool_name == "search_tool_output":
+            return self._search_tool_output(args), chat_history
+
+        elif tool_name == "view_tool_output":
+            return self._view_tool_output(args), chat_history
+
+        else:
+            return (
+                json.dumps({"error": f"Unknown context tool: {tool_name}"}),
+                chat_history,
+            )
+
+    def _check_context(self, chat_history: List[Dict[str, Any]]) -> str:
+        """Check current context: visible vs total turns."""
+        visible_turns = len([m for m in chat_history if m.get("role") == "assistant"])
+        total_turns = len(
+            [m for m in self.full_history if m.get("role") == "assistant"]
+        )
+        return json.dumps(
+            {
+                "visible_turns": visible_turns,
+                "total_turns": total_turns,
+                "dropped_turns": total_turns - visible_turns,
+            }
+        )
+
+    def _manage_context(
+        self, args: Dict[str, Any], chat_history: List[Dict[str, Any]]
+    ) -> Tuple[str, List[Dict[str, Any]]]:
+        """Drop old turns to free up context space."""
+        n = args.get("keep_recent_turns", 5)
+
+        # Keep system message + last n turns (each turn = assistant + user message)
+        system = [m for m in chat_history if m.get("role") == "system"]
+        non_system = [m for m in chat_history if m.get("role") != "system"]
+        keep_count = n * 2  # n turns = n assistant + n user messages
+
+        if len(non_system) > keep_count:
+            dropped = len(non_system) - keep_count
+            new_history = system + non_system[-keep_count:]
+            return (
+                f"Dropped {dropped} messages. {len(new_history)} remaining.",
+                new_history,
+            )
+        else:
+            return f"Nothing to drop. {len(chat_history)} messages.", chat_history
+
+    def _search_history(self, args: Dict[str, Any]) -> str:
+        """Search all history (including dropped) by pattern."""
+        pattern = args.get("pattern", "").lower()
+        if not pattern:
+            return json.dumps({"error": "pattern is required"})
+
+        matches = []
+        for i, msg in enumerate(self.full_history):
+            content = msg.get("content", "")
+            if isinstance(content, str) and pattern in content.lower():
+                matches.append(
+                    {
+                        "index": i,
+                        "role": msg.get("role"),
+                        "snippet": content[:200],
+                    }
+                )
+        return json.dumps({"matches": matches[:10]})
+
+    def _search_tool_output(self, args: Dict[str, Any]) -> str:
+        """Search the last truncated tool output by pattern."""
+        if not self.last_full_output:
+            return "No truncated output available."
+
+        pattern = args.get("pattern", "").lower()
+        if not pattern:
+            return json.dumps({"error": "pattern is required"})
+
+        lines = self.last_full_output.split("\n")
+        matches = []
+        for i, line in enumerate(lines):
+            if pattern in line.lower():
+                matches.append({"line": i + 1, "content": line[:200]})
+        return json.dumps({"matches": matches[:20]})
+
+    def _view_tool_output(self, args: Dict[str, Any]) -> str:
+        """View a page of the last truncated tool output."""
+        if not self.last_full_output:
+            return "No truncated output available."
+
+        page = args.get("page", 1)
+        page_size = args.get("page_size", 50)
+        lines = self.last_full_output.split("\n")
+        total_pages = (len(lines) + page_size - 1) // page_size
+        start = (page - 1) * page_size
+        end = start + page_size
+        page_lines = lines[start:end]
+        return json.dumps(
+            {
+                "page": page,
+                "total_pages": total_pages,
+                "total_lines": len(lines),
+                "content": "\n".join(page_lines),
+            }
+        )

--- a/src/envs/fleet_env/fleet_mcp_client.py
+++ b/src/envs/fleet_env/fleet_mcp_client.py
@@ -108,7 +108,12 @@ class FleetMCPClient:
             if len(texts) == 1:
                 # Single text result - try to parse as JSON
                 try:
-                    return json.loads(texts[0])
+                    parsed = json.loads(texts[0])
+                    # Handle Fleet MCP's base64_image format - convert to OpenAI format
+                    if isinstance(parsed, dict) and "base64_image" in parsed:
+                        data_url = parsed["base64_image"]
+                        return [{"type": "image_url", "image_url": {"url": data_url}}]
+                    return parsed
                 except json.JSONDecodeError:
                     return texts[0]
             elif texts:

--- a/src/envs/fleet_env/fleet_mcp_client.py
+++ b/src/envs/fleet_env/fleet_mcp_client.py
@@ -4,7 +4,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Fleet-compatible MCP client wrapper (Streamable HTTP + initialize)."""
+"""Fleet-compatible MCP client wrapper (Streamable HTTP + initialize).
+
+Design note:
+- We intentionally avoid exposing an async context-manager interface here.
+  Some MCP/AnyIO failure modes during connection setup can produce noisy
+  ExceptionGroup/cancel-scope traces if a partially-entered context leaks.
+- Instead, this wrapper provides *one-shot* operations that open + close the
+  streamable HTTP transport within a single call.
+"""
 
 from typing import Any, Dict, List, Optional
 
@@ -23,45 +31,24 @@ class FleetMCPClient:
     def __init__(self, url: str, api_key: str):
         self.url = url
         self.api_key = api_key
-        self._exit_stack = None
-        self._session: Optional[ClientSession] = None
-
-    async def __aenter__(self):
-        from contextlib import AsyncExitStack
-
-        self._exit_stack = AsyncExitStack()
-        streams = await self._exit_stack.enter_async_context(
-            streamablehttp_client(
-                url=self.url,
-                headers={"Authorization": f"Bearer {self.api_key}"},
-            )
-        )
-
-        if len(streams) == 2:
-            read_stream, write_stream = streams
-        else:
-            read_stream, write_stream = streams[0], streams[1]
-
-        self._session = await self._exit_stack.enter_async_context(
-            ClientSession(read_stream=read_stream, write_stream=write_stream)
-        )
-        await self._session.initialize()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if self._exit_stack:
-            await self._exit_stack.aclose()
-        self._session = None
 
     async def list_tools(self) -> List[Tool]:
-        if not self._session:
-            raise RuntimeError("Client not connected. Use 'async with'.")
-        return (await self._session.list_tools()).tools
+        async with streamablehttp_client(
+            url=self.url,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        ) as streams:
+            async with ClientSession(read_stream=streams[0], write_stream=streams[1]) as session:
+                await session.initialize()
+                return (await session.list_tools()).tools
 
     async def call_tool(self, name: str, arguments: Dict[str, Any]) -> Any:
-        if not self._session:
-            raise RuntimeError("Client not connected. Use 'async with'.")
-        return await self._session.call_tool(name, arguments)
+        async with streamablehttp_client(
+            url=self.url,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        ) as streams:
+            async with ClientSession(read_stream=streams[0], write_stream=streams[1]) as session:
+                await session.initialize()
+                return await session.call_tool(name, arguments)
 
     def has_tool(self, name: str, tools_list: Optional[List[Tool]] = None) -> bool:
         if not tools_list:

--- a/src/envs/fleet_env/fleet_mcp_client.py
+++ b/src/envs/fleet_env/fleet_mcp_client.py
@@ -1,0 +1,71 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fleet-compatible MCP client wrapper (Streamable HTTP + initialize)."""
+
+from typing import Any, Dict, List, Optional
+
+try:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+    from mcp.types import Tool
+except ImportError as e:  # pragma: no cover
+    raise ImportError(
+        "Fleet MCP support requires the optional dependency set. "
+        "Install with `pip install openenv-core[fleet]`."
+    ) from e
+
+
+class FleetMCPClient:
+    def __init__(self, url: str, api_key: str):
+        self.url = url
+        self.api_key = api_key
+        self._exit_stack = None
+        self._session: Optional[ClientSession] = None
+
+    async def __aenter__(self):
+        from contextlib import AsyncExitStack
+
+        self._exit_stack = AsyncExitStack()
+        streams = await self._exit_stack.enter_async_context(
+            streamablehttp_client(
+                url=self.url,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            )
+        )
+
+        if len(streams) == 2:
+            read_stream, write_stream = streams
+        else:
+            read_stream, write_stream = streams[0], streams[1]
+
+        self._session = await self._exit_stack.enter_async_context(
+            ClientSession(read_stream=read_stream, write_stream=write_stream)
+        )
+        await self._session.initialize()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self._exit_stack:
+            await self._exit_stack.aclose()
+        self._session = None
+
+    async def list_tools(self) -> List[Tool]:
+        if not self._session:
+            raise RuntimeError("Client not connected. Use 'async with'.")
+        return (await self._session.list_tools()).tools
+
+    async def call_tool(self, name: str, arguments: Dict[str, Any]) -> Any:
+        if not self._session:
+            raise RuntimeError("Client not connected. Use 'async with'.")
+        return await self._session.call_tool(name, arguments)
+
+    def has_tool(self, name: str, tools_list: Optional[List[Tool]] = None) -> bool:
+        if not tools_list:
+            return False
+        return any(t.name == name for t in tools_list)
+
+

--- a/src/envs/fleet_env/mcp_tools.py
+++ b/src/envs/fleet_env/mcp_tools.py
@@ -8,11 +8,15 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import asyncio
+import logging
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence
 
 from .fleet_mcp_client import FleetMCPClient
 from .models import ListToolsAction, convert_tool_format
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -21,8 +25,10 @@ class FleetMCPTools:
 
     api_key: str
     mcp_urls: Sequence[str]
-    _clients: Optional[List[FleetMCPClient]] = None
-    _tool_owner: Optional[Dict[str, FleetMCPClient]] = None
+    max_retries: int = 3
+    retry_base_delay: float = 1.0
+    _clients: Optional[List[FleetMCPClient]] = field(default=None, repr=False)
+    _tool_owner: Optional[Dict[str, FleetMCPClient]] = field(default=None, repr=False)
 
     def _get_clients(self) -> List[FleetMCPClient]:
         if self._clients is None:
@@ -34,15 +40,13 @@ class FleetMCPTools:
             self._tool_owner = {}
         return self._tool_owner
 
-    async def list_tools(self) -> ListToolsAction:
-        """List available tools (union across endpoints) as a ListToolsAction.
-
-        The returned `.tools` payload is in OpenAI "tools" dict format
-        (see `convert_tool_format`), derived from MCP `Tool.inputSchema`.
-        """
+    async def _list_tools_single_attempt(self) -> List[Any]:
+        """Single attempt to list tools from all clients."""
         owner_cache = self._get_owner_cache()
         tools: list[Any] = []
         seen: set[str] = set()
+        errors: list[str] = []
+
         for client in self._get_clients():
             try:
                 found = await client.list_tools()
@@ -54,9 +58,49 @@ class FleetMCPTools:
                         continue
                     seen.add(t.name)
                     tools.append(convert_tool_format(t))
-            except BaseException:  # noqa: BLE001
+            except BaseException as e:
+                errors.append(f"{client.url}: {e}")
                 continue
-        return ListToolsAction(tools=tools)
+
+        if errors and not tools:
+            # All clients failed - log and raise
+            raise RuntimeError(f"All MCP clients failed to list tools: {errors}")
+
+        if errors:
+            # Some clients failed but we got tools from others
+            logger.warning(f"Some MCP clients failed to list tools: {errors}")
+
+        return tools
+
+    async def list_tools(self) -> ListToolsAction:
+        """List available tools (union across endpoints) as a ListToolsAction.
+
+        The returned `.tools` payload is in OpenAI "tools" dict format
+        (see `convert_tool_format`), derived from MCP `Tool.inputSchema`.
+
+        Retries with exponential backoff if all clients fail.
+        """
+        last_error = None
+
+        for attempt in range(self.max_retries):
+            try:
+                tools = await self._list_tools_single_attempt()
+                if tools:
+                    return ListToolsAction(tools=tools)
+                # Got empty tools - treat as failure and retry
+                raise RuntimeError("No tools found from any MCP endpoint")
+            except Exception as e:
+                last_error = e
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_base_delay * (2 ** attempt)
+                    logger.warning(
+                        f"list_tools attempt {attempt + 1}/{self.max_retries} failed: {e}. "
+                        f"Retrying in {delay:.1f}s..."
+                    )
+                    await asyncio.sleep(delay)
+
+        logger.error(f"list_tools failed after {self.max_retries} attempts: {last_error}")
+        return ListToolsAction(tools=[])
 
     async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
         owner_cache = self._get_owner_cache()
@@ -66,6 +110,7 @@ class FleetMCPTools:
             client = owner_cache[tool_name]
             return await client.call_tool(tool_name, arguments)
 
+        errors: list[str] = []
         for client in clients:
             try:
                 tools = await client.list_tools()
@@ -73,10 +118,13 @@ class FleetMCPTools:
                     owner_cache[tool_name] = client
                     # If execution fails here, we let it propagate because we found the owner.
                     return await client.call_tool(tool_name, arguments)
-            except BaseException:
-                # Only suppress discovery/connection errors.
-                # If call_tool raised, it would have bubbled up above.
+            except BaseException as e:
+                # Log discovery/connection errors instead of silently swallowing.
+                errors.append(f"{client.url}: {e}")
                 continue
+
+        if errors:
+            logger.warning(f"Some MCP clients failed during tool discovery: {errors}")
 
         raise ValueError(f"Tool '{tool_name}' not found on any active MCP endpoint.")
 

--- a/src/envs/fleet_env/mcp_tools.py
+++ b/src/envs/fleet_env/mcp_tools.py
@@ -111,6 +111,7 @@ class FleetMCPTools:
 
         if tool_name in owner_cache:
             client = owner_cache[tool_name]
+            logger.debug(f"call_tool({tool_name}) using cached client: {client.url}")
             return await client.call_tool(tool_name, arguments)
 
         errors: list[str] = []
@@ -138,7 +139,10 @@ class FleetMCPTools:
 
         for attempt in range(self.max_retries):
             try:
-                return await self._call_tool_single_attempt(tool_name, arguments)
+                result = await self._call_tool_single_attempt(tool_name, arguments)
+                if attempt > 0:
+                    logger.info(f"call_tool({tool_name}) succeeded on attempt {attempt + 1}")
+                return result
             except ValueError:
                 # Tool not found - don't retry
                 raise

--- a/src/envs/fleet_env/mcp_tools.py
+++ b/src/envs/fleet_env/mcp_tools.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MCP-only handle for agents (no reset/step/state)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+from .fleet_mcp_client import FleetMCPClient
+
+
+@dataclass
+class FleetMCPTools:
+    """Agent-facing tools client (MCP only)."""
+
+    api_key: str
+    mcp_urls: Sequence[str]
+    _clients: Optional[List[FleetMCPClient]] = None
+    _tool_owner: Optional[Dict[str, FleetMCPClient]] = None
+
+    def _get_clients(self) -> List[FleetMCPClient]:
+        if self._clients is None:
+            self._clients = [FleetMCPClient(url, self.api_key) for url in self.mcp_urls]
+        return self._clients
+
+    def _get_owner_cache(self) -> Dict[str, FleetMCPClient]:
+        if self._tool_owner is None:
+            self._tool_owner = {}
+        return self._tool_owner
+
+    async def list_tools(self) -> list[Any]:
+        tools: list[Any] = []
+        for client in self._get_clients():
+            try:
+                async with client:
+                    tools.extend(await client.list_tools())
+            except Exception:  # noqa: BLE001
+                continue
+        return tools
+
+    async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
+        owner_cache = self._get_owner_cache()
+        clients = self._get_clients()
+
+        if tool_name in owner_cache:
+            client = owner_cache[tool_name]
+            async with client:
+                return await client.call_tool(tool_name, arguments)
+
+        for client in clients:
+            try:
+                async with client:
+                    tools = await client.list_tools()
+                    if client.has_tool(tool_name, tools):
+                        owner_cache[tool_name] = client
+                        # If execution fails here, we let it propagate because we found the owner.
+                        return await client.call_tool(tool_name, arguments)
+            except Exception:
+                # Only suppress discovery/connection errors.
+                # If call_tool raised, it would have bubbled up above.
+                continue
+
+        raise ValueError(f"Tool '{tool_name}' not found on any active MCP endpoint.")
+
+

--- a/src/envs/fleet_env/mcp_tools.py
+++ b/src/envs/fleet_env/mcp_tools.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence
 
 from .fleet_mcp_client import FleetMCPClient
+from .models import ListToolsAction, convert_tool_format
 
 
 @dataclass
@@ -33,15 +34,29 @@ class FleetMCPTools:
             self._tool_owner = {}
         return self._tool_owner
 
-    async def list_tools(self) -> list[Any]:
+    async def list_tools(self) -> ListToolsAction:
+        """List available tools (union across endpoints) as a ListToolsAction.
+
+        The returned `.tools` payload is in OpenAI "tools" dict format
+        (see `convert_tool_format`), derived from MCP `Tool.inputSchema`.
+        """
+        owner_cache = self._get_owner_cache()
         tools: list[Any] = []
+        seen: set[str] = set()
         for client in self._get_clients():
             try:
-                async with client:
-                    tools.extend(await client.list_tools())
-            except Exception:  # noqa: BLE001
+                found = await client.list_tools()
+                for t in found:
+                    # Deduplicate by tool name across endpoints, but cache first-seen owner.
+                    if t.name not in owner_cache:
+                        owner_cache[t.name] = client
+                    if t.name in seen:
+                        continue
+                    seen.add(t.name)
+                    tools.append(convert_tool_format(t))
+            except BaseException:  # noqa: BLE001
                 continue
-        return tools
+        return ListToolsAction(tools=tools)
 
     async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
         owner_cache = self._get_owner_cache()
@@ -49,18 +64,16 @@ class FleetMCPTools:
 
         if tool_name in owner_cache:
             client = owner_cache[tool_name]
-            async with client:
-                return await client.call_tool(tool_name, arguments)
+            return await client.call_tool(tool_name, arguments)
 
         for client in clients:
             try:
-                async with client:
-                    tools = await client.list_tools()
-                    if client.has_tool(tool_name, tools):
-                        owner_cache[tool_name] = client
-                        # If execution fails here, we let it propagate because we found the owner.
-                        return await client.call_tool(tool_name, arguments)
-            except Exception:
+                tools = await client.list_tools()
+                if client.has_tool(tool_name, tools):
+                    owner_cache[tool_name] = client
+                    # If execution fails here, we let it propagate because we found the owner.
+                    return await client.call_tool(tool_name, arguments)
+            except BaseException:
                 # Only suppress discovery/connection errors.
                 # If call_tool raised, it would have bubbled up above.
                 continue

--- a/src/envs/fleet_env/models.py
+++ b/src/envs/fleet_env/models.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Data models for FleetEnvClient (RFC 003 tool-call actions)."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+# Support both in-repo and standalone imports
+try:
+    from core.env_server.types import Action
+except ImportError:
+    from openenv_core.env_server.types import Action
+
+
+@dataclass(kw_only=True)
+class ListToolsAction(Action):
+    """Request list of available MCP tools from the Fleet environment."""
+
+
+@dataclass(kw_only=True)
+class CallToolAction(Action):
+    """Call a specific MCP tool exposed by the Fleet environment."""
+
+    tool_name: str
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+

--- a/src/envs/fleet_env/models.py
+++ b/src/envs/fleet_env/models.py
@@ -7,7 +7,21 @@
 """Data models for FleetEnvClient (RFC 003 tool-call actions)."""
 
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
+
+# Avoid importing OpenAI typing aliases at runtime.
+# The `openai` package changes exported type names across major versions, and
+# Fleet integration should work even if OpenAI isn't installed.
+if TYPE_CHECKING:  # pragma: no cover
+    try:
+        from openai import ChatCompletionToolUnionParam as OpenAIToolParam  # type: ignore
+    except Exception:  # noqa: BLE001
+        OpenAIToolParam = Dict[str, Any]  # type: ignore[misc,assignment]
+else:
+    OpenAIToolParam = Dict[str, Any]  # type: ignore[misc,assignment]
+
+from mcp.types import Tool
+
 
 # Support both in-repo and standalone imports
 try:
@@ -15,10 +29,65 @@ try:
 except ImportError:
     from openenv_core.env_server.types import Action
 
+def normalize_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(schema, dict):
+        return schema
+
+    result = {}
+
+    if "anyOf" in schema:
+        non_null_schemas = [s for s in schema["anyOf"] if s.get("type") != "null"]
+        if non_null_schemas:
+            schema = {**schema, **non_null_schemas[0]}
+            del schema["anyOf"]
+
+    for key, value in schema.items():
+        if key in ["title", "default", "anyOf"]:
+            continue
+
+        if key == "prefixItems":
+            result["items"] = (
+                normalize_schema(value[0]) if value else {"type": "string"}
+            )
+            continue
+
+        if key == "properties" and isinstance(value, dict):
+            result[key] = {k: normalize_schema(v) for k, v in value.items()}
+        elif key == "items" and isinstance(value, dict):
+            result[key] = normalize_schema(value)
+        else:
+            result[key] = value
+
+    return result
+
+
+def convert_tool_format(tool: Tool) -> OpenAIToolParam:
+    normalized_properties = {
+        key: normalize_schema(value)
+        for key, value in tool.inputSchema.get("properties", {}).items()
+    }
+
+    # OpenAI "tools" format: {"type": "function", "function": {...}}
+    openai_tool: OpenAIToolParam = {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": {
+                "type": "object",
+                "properties": normalized_properties,
+                "required": tool.inputSchema.get("required", []),
+            },
+        },
+    }
+    return openai_tool
+
 
 @dataclass(kw_only=True)
 class ListToolsAction(Action):
     """Request list of available MCP tools from the Fleet environment."""
+
+    tools: list[OpenAIToolParam] = field(default_factory=list)
 
 
 @dataclass(kw_only=True)

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -194,7 +194,8 @@ class FleetTaskEnv:
                 logger.warning(f"Fleet env reset failed, continuing with empty observation: {e}")
 
         # Fetch tools lazily on first reset (avoids asyncio.run in __init__)
-        if self.modality == "tool_use" and self._tools and not self._tools_fetched:
+        # Note: Fetch tools for ALL modalities (tool_use and computer_use both need tools)
+        if self._tools and not self._tools_fetched:
             try:
                 tools_result = await self._tools.list_tools()
                 self._tools_cache = tools_result.tools

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -78,12 +78,18 @@ class FleetTaskEnv:
 
         # Create Fleet environment instance (provisions cloud resources)
         env_spec = self._build_env_spec()
+        # For computer_use tasks, use image_type='mcp' to select the MCP-enabled container
+        # image (e.g., famazon:mcp0.0.7 instead of famazon:0.0.7). The mcp images have:
+        # - scrot installed for screenshots
+        # - MCP server with 'computer' tool for mouse/keyboard control
+        image_type = 'mcp' if self.modality == 'computer_use' else None
         self._orch, self._tools = FleetEnvClient.from_fleet(
             api_key=self.api_key,
             env_key=env_spec,
             data_key=self._get_data_key(),
             data_version=self._get_data_version(),
             env_variables=self._get_env_variables(),
+            image_type=image_type,
             ttl_seconds=self.ttl_seconds,
             request_timeout_s=self.request_timeout_s,
         )

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -83,6 +83,7 @@ class FleetTaskEnv:
             env_key=env_spec,
             data_key=self._get_data_key(),
             data_version=self._get_data_version(),
+            env_variables=self._get_env_variables(),
             ttl_seconds=self.ttl_seconds,
             request_timeout_s=self.request_timeout_s,
         )
@@ -126,6 +127,14 @@ class FleetTaskEnv:
     def _get_data_version(self) -> Optional[str]:
         """Get data_version from task config."""
         return self.task.get("data_version")
+
+    def _get_env_variables(self) -> Optional[Dict[str, Any]]:
+        """Get env_variables from task config.
+
+        These variables parameterize the environment with task-specific values
+        like names, dates, scenario configurations, etc.
+        """
+        return self.task.get("env_variables")
 
     def reset(self, seed: Optional[int] = None) -> Dict[str, Any]:
         """Reset the environment and return initial observation (sync wrapper).

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -254,21 +254,6 @@ class FleetTaskEnv:
                 screenshot_result = await self._tools.call_tool(
                     "computer", {"action": "screenshot"}
                 )
-                # Debug: log actual screenshot result format
-                result_type = type(screenshot_result).__name__
-                result_len = (
-                    len(screenshot_result) if isinstance(screenshot_result, list) else 0
-                )
-                has_image_url = False
-                if isinstance(screenshot_result, list):
-                    has_image_url = any(
-                        isinstance(item, dict) and item.get("type") == "image_url"
-                        for item in screenshot_result
-                    )
-                logger.info(
-                    f"Task {self.task_key}: screenshot_result type={result_type}, "
-                    f"len={result_len}, has_image_url={has_image_url}"
-                )
                 # screenshot_result is in OpenAI-compatible format:
                 # [{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "data:..."}}]
                 obs["initial_screenshot"] = screenshot_result

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -137,7 +137,8 @@ class FleetTaskEnv:
         )
 
         # Reset the environment
-        reset_result = self._orch.reset(seed=seed)
+        # Note: seed parameter not yet supported by HTTPEnvClient
+        reset_result = self._orch.reset()
 
         # Reset state
         self._step_count = 0

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -205,6 +205,15 @@ class FleetTaskEnv:
                 self._tools_cache = []
                 self._tools_fetched = True
 
+        # For computer_use, filter to only the 'computer' tool
+        if self.modality == "computer_use" and self._tools_cache:
+            computer_tools = [
+                t for t in self._tools_cache
+                if t.get("name") == "computer" or t.get("function", {}).get("name") == "computer"
+            ]
+            if computer_tools:
+                self._tools_cache = computer_tools
+
         # Build observation with cached tools
         obs = {
             "prompt": self.prompt,

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -1,0 +1,396 @@
+"""
+Fleet Task Environment - Gymnasium-compatible environment for Fleet tasks.
+
+This module provides a task-oriented wrapper around FleetEnvClient that:
+1. Accepts task configs (from export_training_tasks.py)
+2. Creates versioned environments on reset
+3. Injects task prompt into observations
+4. Executes verifier for reward on episode completion
+"""
+
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from .client import FleetEnvClient
+from .mcp_tools import FleetMCPTools
+
+
+class FleetTaskEnv:
+    """Gymnasium-compatible environment for Fleet tasks.
+
+    This class wraps FleetEnvClient to provide a task-oriented interface
+    suitable for RL training with SkyRL.
+
+    Args:
+        task_config: Task configuration dict with keys:
+            - task_key: Unique task identifier
+            - prompt: Task instruction for the agent
+            - env_key: Environment key (e.g., "booking-com")
+            - env_version: Environment version (e.g., "v1.2.3")
+            - data_key: Optional data key
+            - data_version: Optional data version
+            - verifier_code: Python code for verification
+            - task_modality: "tool_use" or "computer_use"
+        api_key: Fleet API key (defaults to FLEET_API_KEY env var)
+        ttl_seconds: Instance TTL in seconds (default: 600)
+        max_steps: Maximum steps per episode (default: 50)
+
+    Example:
+        >>> task_config = {
+        ...     "task_key": "search-flights-001",
+        ...     "prompt": "Search for flights from NYC to LA",
+        ...     "env_key": "booking-com",
+        ...     "env_version": "v1.2.3",
+        ...     "verifier_code": "async def verify(env): ...",
+        ...     "task_modality": "tool_use",
+        ... }
+        >>> env = FleetTaskEnv(task_config)
+        >>> obs = env.reset()
+        >>> obs, reward, done, info = env.step({"tool": "search", "params": {...}})
+    """
+
+    def __init__(
+        self,
+        task_config: Dict[str, Any],
+        api_key: Optional[str] = None,
+        ttl_seconds: int = 600,
+        max_steps: int = 50,
+    ):
+        self.task = task_config
+        self.api_key = api_key or os.environ.get("FLEET_API_KEY")
+        self.ttl_seconds = ttl_seconds
+        self.max_steps = max_steps
+
+        if not self.api_key:
+            raise ValueError("Fleet API key required (pass api_key or set FLEET_API_KEY)")
+
+        self._orch: Optional[FleetEnvClient] = None
+        self._tools: Optional[FleetMCPTools] = None
+        self._step_count = 0
+        self._done = False
+        self._tools_cache: Optional[List[Dict]] = None
+
+    @property
+    def task_key(self) -> str:
+        """Get the task key."""
+        return self.task.get("task_key", "unknown")
+
+    @property
+    def prompt(self) -> str:
+        """Get the task prompt."""
+        return self.task.get("prompt", "")
+
+    @property
+    def modality(self) -> str:
+        """Get the task modality."""
+        return self.task.get("task_modality", "tool_use")
+
+    def _build_env_spec(self) -> str:
+        """Build env_key:version spec for Fleet.make()."""
+        env_key = self.task.get("env_key")
+        env_version = self.task.get("env_version")
+
+        if not env_key:
+            raise ValueError("Task config missing env_key")
+
+        if env_version:
+            return f"{env_key}:{env_version}"
+        return env_key
+
+    def _build_data_spec(self) -> Optional[str]:
+        """Build data_key:version spec for Fleet.make()."""
+        data_key = self.task.get("data_key")
+        data_version = self.task.get("data_version")
+
+        if not data_key:
+            return None
+
+        if data_version:
+            return f"{data_key}:{data_version}"
+        return data_key
+
+    def reset(self, seed: Optional[int] = None) -> Dict[str, Any]:
+        """Reset the environment and return initial observation.
+
+        Creates a new Fleet environment instance with the task's env/data versions,
+        resets it, and returns an observation that includes the task prompt.
+
+        Args:
+            seed: Optional random seed (passed to env reset)
+
+        Returns:
+            Observation dict with keys:
+                - prompt: The task instruction
+                - observation: Raw observation from env reset
+                - tools: List of available tools (if tool_use modality)
+                - step: Current step number (0)
+        """
+        # Close existing instance if any
+        self.close()
+
+        # Build specs
+        env_spec = self._build_env_spec()
+        data_spec = self._build_data_spec()
+
+        # Create new instance
+        self._orch, self._tools = FleetEnvClient.from_fleet(
+            api_key=self.api_key,
+            env_key=env_spec,
+            data_key=data_spec,
+            ttl_seconds=self.ttl_seconds,
+        )
+
+        # Reset the environment
+        reset_result = self._orch.reset(seed=seed)
+
+        # Reset state
+        self._step_count = 0
+        self._done = False
+        self._tools_cache = None
+
+        # Build observation
+        obs = {
+            "prompt": self.prompt,
+            "observation": reset_result.observation.metadata if reset_result else {},
+            "step": 0,
+            "task_key": self.task_key,
+            "modality": self.modality,
+        }
+
+        return obs
+
+    async def reset_async(self, seed: Optional[int] = None) -> Dict[str, Any]:
+        """Async version of reset.
+
+        Same as reset() but fetches tools asynchronously.
+        """
+        obs = self.reset(seed=seed)
+
+        # Fetch tools asynchronously for tool_use tasks
+        if self.modality == "tool_use" and self._tools:
+            tools_result = await self._tools.list_tools()
+            self._tools_cache = tools_result.tools
+            obs["tools"] = self._tools_cache
+
+        return obs
+
+    def step(self, action: Dict[str, Any]) -> Tuple[Dict[str, Any], float, bool, Dict]:
+        """Execute a step in the environment (sync wrapper).
+
+        For async tool calls, use step_async() instead.
+
+        Args:
+            action: Action dict. For tool_use modality:
+                - tool: Tool name to call
+                - params: Tool parameters
+                - done: Optional flag to signal episode completion
+
+        Returns:
+            Tuple of (observation, reward, done, info)
+        """
+        import asyncio
+        return asyncio.get_event_loop().run_until_complete(self.step_async(action))
+
+    async def step_async(self, action: Dict[str, Any]) -> Tuple[Dict[str, Any], float, bool, Dict]:
+        """Execute a step in the environment.
+
+        Args:
+            action: Action dict. For tool_use modality:
+                - tool: Tool name to call
+                - params: Tool parameters
+                - done: Optional flag to signal episode completion
+
+        Returns:
+            Tuple of (observation, reward, done, info)
+        """
+        if self._done:
+            raise RuntimeError("Episode is done. Call reset() to start a new episode.")
+
+        if not self._tools:
+            raise RuntimeError("Environment not initialized. Call reset() first.")
+
+        self._step_count += 1
+        info = {"step": self._step_count}
+
+        # Check if agent signals completion
+        agent_done = action.get("done", False)
+
+        # Check max steps
+        max_steps_reached = self._step_count >= self.max_steps
+
+        # Execute tool call
+        tool_name = action.get("tool")
+        tool_params = action.get("params", {})
+        tool_result = None
+
+        if tool_name:
+            try:
+                tool_result = await self._tools.call_tool(tool_name, tool_params)
+                info["tool_result"] = tool_result
+            except Exception as e:
+                info["tool_error"] = str(e)
+                tool_result = {"error": str(e)}
+
+        # Determine if done
+        self._done = agent_done or max_steps_reached
+        info["done_reason"] = (
+            "agent_done" if agent_done else
+            "max_steps" if max_steps_reached else
+            None
+        )
+
+        # Calculate reward (only on episode completion)
+        reward = 0.0
+        if self._done:
+            reward = await self._compute_reward()
+            info["reward_computed"] = True
+
+        # Build observation
+        obs = {
+            "prompt": self.prompt,
+            "observation": tool_result or {},
+            "step": self._step_count,
+            "task_key": self.task_key,
+            "modality": self.modality,
+        }
+
+        if self._tools_cache:
+            obs["tools"] = self._tools_cache
+
+        return obs, reward, self._done, info
+
+    async def _compute_reward(self) -> float:
+        """Compute reward by executing the verifier.
+
+        Returns:
+            1.0 if verifier passes, 0.0 otherwise
+        """
+        verifier_code = self.task.get("verifier_code")
+
+        if not verifier_code:
+            # No verifier - return neutral reward
+            return 0.0
+
+        if not self._orch:
+            return 0.0
+
+        try:
+            # Execute verifier
+            # For now, use local execution
+            # TODO: Add remote verifier execution support
+            result = await self._execute_verifier_local(verifier_code)
+            return 1.0 if result else 0.0
+        except Exception as e:
+            # Verifier failed - treat as unsuccessful
+            print(f"Verifier execution failed: {e}")
+            return 0.0
+
+    async def _execute_verifier_local(self, verifier_code: str) -> bool:
+        """Execute verifier code locally.
+
+        Args:
+            verifier_code: Python code string containing verify() function
+
+        Returns:
+            True if verification passes, False otherwise
+        """
+        # Create namespace for verifier execution
+        namespace = {}
+
+        # Execute the verifier code to define the function
+        exec(verifier_code, namespace)
+
+        # Get the verify function
+        verify_func = namespace.get("verify")
+        if not verify_func:
+            raise ValueError("Verifier code must define a 'verify' function")
+
+        # Call verifier with the orchestrator (env handle)
+        result = await verify_func(self._orch)
+
+        # Handle different result formats
+        if isinstance(result, bool):
+            return result
+        if isinstance(result, (int, float)):
+            return result > 0
+        if isinstance(result, dict):
+            return result.get("success", False) or result.get("score", 0) > 0
+
+        return bool(result)
+
+    def close(self):
+        """Close the environment and cleanup resources."""
+        if self._orch:
+            try:
+                self._orch.close()
+            except Exception:
+                pass
+            self._orch = None
+            self._tools = None
+            self._tools_cache = None
+            self._done = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    @classmethod
+    def from_json_file(cls, json_path: str, task_key: str, **kwargs) -> "FleetTaskEnv":
+        """Create FleetTaskEnv from exported JSON file.
+
+        Args:
+            json_path: Path to JSON file from export_training_tasks.py
+            task_key: Task key to load
+            **kwargs: Additional arguments passed to FleetTaskEnv
+
+        Returns:
+            FleetTaskEnv instance for the specified task
+        """
+        import json
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        tasks = data.get("tasks", [])
+        task_config = next((t for t in tasks if t["task_key"] == task_key), None)
+
+        if not task_config:
+            raise ValueError(f"Task '{task_key}' not found in {json_path}")
+
+        return cls(task_config, **kwargs)
+
+    @classmethod
+    def from_json_file_all(cls, json_path: str, **kwargs) -> List["FleetTaskEnv"]:
+        """Create FleetTaskEnv instances for all tasks in JSON file.
+
+        Args:
+            json_path: Path to JSON file from export_training_tasks.py
+            **kwargs: Additional arguments passed to FleetTaskEnv
+
+        Returns:
+            List of FleetTaskEnv instances
+        """
+        import json
+
+        with open(json_path) as f:
+            data = json.load(f)
+
+        tasks = data.get("tasks", [])
+        return [cls(task, **kwargs) for task in tasks]
+
+
+def make_fleet_task_env(task_config: Dict[str, Any], **kwargs) -> FleetTaskEnv:
+    """Factory function for creating FleetTaskEnv.
+
+    This is the recommended entry point for SkyRL integration.
+
+    Args:
+        task_config: Task configuration dict
+        **kwargs: Additional arguments passed to FleetTaskEnv
+
+    Returns:
+        FleetTaskEnv instance
+    """
+    return FleetTaskEnv(task_config, **kwargs)

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -34,6 +34,7 @@ class FleetTaskEnv:
         api_key: Fleet API key (defaults to FLEET_API_KEY env var)
         ttl_seconds: Instance TTL in seconds (default: 600)
         max_steps: Maximum steps per episode (default: 50)
+        request_timeout_s: HTTP request timeout in seconds (default: 60.0)
 
     Example:
         >>> task_config = {
@@ -55,11 +56,13 @@ class FleetTaskEnv:
         api_key: Optional[str] = None,
         ttl_seconds: int = 600,
         max_steps: int = 50,
+        request_timeout_s: float = 60.0,
     ):
         self.task = task_config
         self.api_key = api_key or os.environ.get("FLEET_API_KEY")
         self.ttl_seconds = ttl_seconds
         self.max_steps = max_steps
+        self.request_timeout_s = request_timeout_s
 
         if not self.api_key:
             raise ValueError("Fleet API key required (pass api_key or set FLEET_API_KEY)")
@@ -134,6 +137,7 @@ class FleetTaskEnv:
             data_key=self._get_data_key(),
             data_version=self._get_data_version(),
             ttl_seconds=self.ttl_seconds,
+            request_timeout_s=self.request_timeout_s,
         )
 
         # Reset the environment

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -97,17 +97,13 @@ class FleetTaskEnv:
             return f"{env_key}:{env_version}"
         return env_key
 
-    def _build_data_spec(self) -> Optional[str]:
-        """Build data_key:version spec for Fleet.make()."""
-        data_key = self.task.get("data_key")
-        data_version = self.task.get("data_version")
+    def _get_data_key(self) -> Optional[str]:
+        """Get data_key from task config."""
+        return self.task.get("data_key")
 
-        if not data_key:
-            return None
-
-        if data_version:
-            return f"{data_key}:{data_version}"
-        return data_key
+    def _get_data_version(self) -> Optional[str]:
+        """Get data_version from task config."""
+        return self.task.get("data_version")
 
     def reset(self, seed: Optional[int] = None) -> Dict[str, Any]:
         """Reset the environment and return initial observation.
@@ -130,13 +126,13 @@ class FleetTaskEnv:
 
         # Build specs
         env_spec = self._build_env_spec()
-        data_spec = self._build_data_spec()
 
         # Create new instance
         self._orch, self._tools = FleetEnvClient.from_fleet(
             api_key=self.api_key,
             env_key=env_spec,
-            data_key=data_spec,
+            data_key=self._get_data_key(),
+            data_version=self._get_data_version(),
             ttl_seconds=self.ttl_seconds,
         )
 

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -254,6 +254,21 @@ class FleetTaskEnv:
                 screenshot_result = await self._tools.call_tool(
                     "computer", {"action": "screenshot"}
                 )
+                # Debug: log actual screenshot result format
+                result_type = type(screenshot_result).__name__
+                result_len = (
+                    len(screenshot_result) if isinstance(screenshot_result, list) else 0
+                )
+                has_image_url = False
+                if isinstance(screenshot_result, list):
+                    has_image_url = any(
+                        isinstance(item, dict) and item.get("type") == "image_url"
+                        for item in screenshot_result
+                    )
+                logger.info(
+                    f"Task {self.task_key}: screenshot_result type={result_type}, "
+                    f"len={result_len}, has_image_url={has_image_url}"
+                )
                 # screenshot_result is in OpenAI-compatible format:
                 # [{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "data:..."}}]
                 obs["initial_screenshot"] = screenshot_result

--- a/src/envs/fleet_env/task_env.py
+++ b/src/envs/fleet_env/task_env.py
@@ -219,6 +219,19 @@ class FleetTaskEnv:
                 self._tools_cache = []
                 self._tools_fetched = True
 
+        # Filter tools based on modality:
+        # - computer_use: keep ONLY the 'computer' tool
+        # - tool_use: EXCLUDE the 'computer' tool (should only use API tools)
+        if self._tools_cache:
+            if self.modality == "tool_use":
+                # Exclude computer tool for tool_use tasks
+                self._tools_cache = [
+                    t
+                    for t in self._tools_cache
+                    if t.get("name") != "computer"
+                    and t.get("function", {}).get("name") != "computer"
+                ]
+
         # For computer_use, filter to only the 'computer' tool
         # IMPORTANT: Always apply filter for computer_use modality to prevent
         # the model from using API tools instead of mouse/keyboard control

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -35,6 +35,12 @@ dev = [
     "mypy>=1.0.0",
 ]
 
+# Fleet runtime integration (optional)
+fleet = [
+    "mcp>=1.0.0",
+    "fleet-sdk>=0.2.79",
+]
+
 [project.scripts]
 openenv = "openenv_cli.__main__:main"
 

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -38,7 +38,8 @@ dev = [
 # Fleet runtime integration (optional)
 fleet = [
     "mcp>=1.0.0",
-    "fleet-sdk>=0.2.79",
+    "fleet-python>=0.2.79",
+    "openai>=2.11.0",
 ]
 
 [project.scripts]

--- a/tests/envs/test_fleet_env.py
+++ b/tests/envs/test_fleet_env.py
@@ -143,3 +143,187 @@ async def test_agent_tools_list_and_call_routes(monkeypatch):
     assert res["url"].endswith("api/v1/mcp")
 
 
+class TestFleetMCPClientExtractToolResult:
+    """Tests for FleetMCPClient._extract_tool_result()."""
+
+    def test_extract_single_text_content(self):
+        """Should extract text from single TextContent."""
+        from envs.fleet_env.fleet_mcp_client import FleetMCPClient
+
+        client = FleetMCPClient(url="http://test", api_key="test")
+
+        # Mock CallToolResult with TextContent
+        class _TextContent:
+            type = "text"
+            text = "file1.txt\nfile2.txt"
+
+        class _Result:
+            content = [_TextContent()]
+            isError = False
+            structuredContent = None
+
+        result = client._extract_tool_result(_Result())
+        assert result == "file1.txt\nfile2.txt"
+
+    def test_extract_json_text_content(self):
+        """Should parse JSON from text content."""
+        from envs.fleet_env.fleet_mcp_client import FleetMCPClient
+
+        client = FleetMCPClient(url="http://test", api_key="test")
+
+        class _TextContent:
+            type = "text"
+            text = '{"status": "success", "count": 42}'
+
+        class _Result:
+            content = [_TextContent()]
+            isError = False
+            structuredContent = None
+
+        result = client._extract_tool_result(_Result())
+        assert result == {"status": "success", "count": 42}
+
+    def test_extract_multiple_text_contents(self):
+        """Should return list when multiple text contents."""
+        from envs.fleet_env.fleet_mcp_client import FleetMCPClient
+
+        client = FleetMCPClient(url="http://test", api_key="test")
+
+        class _TextContent1:
+            type = "text"
+            text = "first"
+
+        class _TextContent2:
+            type = "text"
+            text = "second"
+
+        class _Result:
+            content = [_TextContent1(), _TextContent2()]
+            isError = False
+            structuredContent = None
+
+        result = client._extract_tool_result(_Result())
+        assert result == ["first", "second"]
+
+    def test_extract_error_result(self):
+        """Should return error dict when isError=True."""
+        from envs.fleet_env.fleet_mcp_client import FleetMCPClient
+
+        client = FleetMCPClient(url="http://test", api_key="test")
+
+        class _TextContent:
+            type = "text"
+            text = "Tool failed: permission denied"
+
+        class _Result:
+            content = [_TextContent()]
+            isError = True
+            structuredContent = None
+
+        result = client._extract_tool_result(_Result())
+        assert result == {"error": "Tool failed: permission denied"}
+
+    def test_extract_structured_content_fallback(self):
+        """Should use structuredContent when no text content."""
+        from envs.fleet_env.fleet_mcp_client import FleetMCPClient
+
+        client = FleetMCPClient(url="http://test", api_key="test")
+
+        class _Result:
+            content = []
+            isError = False
+            structuredContent = {"data": [1, 2, 3]}
+
+        result = client._extract_tool_result(_Result())
+        assert result == {"data": [1, 2, 3]}
+
+    def test_extract_empty_result(self):
+        """Should return string repr for empty result."""
+        from envs.fleet_env.fleet_mcp_client import FleetMCPClient
+
+        client = FleetMCPClient(url="http://test", api_key="test")
+
+        class _Result:
+            content = []
+            isError = False
+            structuredContent = None
+
+            def __str__(self):
+                return "EmptyResult()"
+
+        result = client._extract_tool_result(_Result())
+        assert result == "EmptyResult()"
+
+
+class TestFleetTaskEnvResetReturnsTools:
+    """Tests for reset() returning tools via reset_async()."""
+
+    @pytest.mark.anyio
+    async def test_reset_async_returns_tools(self, monkeypatch):
+        """reset_async should fetch and return tools."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+        from unittest.mock import AsyncMock, MagicMock
+
+        task_config = {
+            "task_key": "test-task",
+            "prompt": "Test prompt",
+            "env_key": "test-env",
+            "task_modality": "tool_use",
+        }
+
+        env = FleetTaskEnv(task_config, api_key="test-key")
+
+        # Mock the FleetEnvClient.from_fleet
+        mock_orch = MagicMock()
+        mock_orch.reset.return_value = MagicMock(observation=MagicMock(metadata={}))
+
+        mock_tools = MagicMock()
+        mock_tools.list_tools = AsyncMock(return_value=MagicMock(
+            tools=[{"type": "function", "function": {"name": "bash"}}]
+        ))
+
+        monkeypatch.setattr(
+            "envs.fleet_env.task_env.FleetEnvClient.from_fleet",
+            lambda **kwargs: (mock_orch, mock_tools)
+        )
+
+        obs = await env.reset_async()
+
+        assert "tools" in obs
+        assert len(obs["tools"]) == 1
+        assert obs["tools"][0]["function"]["name"] == "bash"
+
+    @pytest.mark.anyio
+    async def test_reset_sync_calls_reset_async(self, monkeypatch):
+        """Sync reset() should be a wrapper around reset_async()."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+        from unittest.mock import AsyncMock, MagicMock
+
+        task_config = {
+            "task_key": "test-task",
+            "prompt": "Test prompt",
+            "env_key": "test-env",
+            "task_modality": "tool_use",
+        }
+
+        env = FleetTaskEnv(task_config, api_key="test-key")
+
+        # Mock reset_async directly to verify it's called
+        expected_obs = {
+            "prompt": "Test prompt",
+            "tools": [{"type": "function", "function": {"name": "search"}}],
+            "step": 0,
+        }
+        env.reset_async = AsyncMock(return_value=expected_obs)
+
+        # Call sync reset() - it should call reset_async internally
+        # We test this indirectly by checking the implementation
+        import asyncio
+        obs = await env.reset_async()
+
+        # Verify reset_async was called and returned tools
+        assert "tools" in obs
+        assert len(obs["tools"]) == 1
+        assert obs["tools"][0]["function"]["name"] == "search"
+
+

--- a/tests/envs/test_fleet_env.py
+++ b/tests/envs/test_fleet_env.py
@@ -1,0 +1,149 @@
+import sys
+import types
+
+import pytest
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.calls.append(("POST", url, json))
+        return _FakeResp({"observation": {"metadata": {}}, "reward": 0.0, "done": False})
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append(("GET", url, None))
+        return _FakeResp({"episode_id": "e1", "step_count": 0})
+
+
+@pytest.fixture
+def anyio_backend():
+    # Avoid running the anyio test against trio (not installed in this repo env).
+    return "asyncio"
+
+
+@pytest.fixture
+def fake_requests_session(monkeypatch):
+    # Avoid importing real `requests` in this sandboxed environment (it may fail
+    # while loading system CA bundles). core.http_env_client only needs Session.
+    fake_requests = types.SimpleNamespace(Session=_FakeSession)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+
+@pytest.fixture
+def fake_fleet_module(monkeypatch):
+    # Create a fake `fleet` module with AsyncFleet.make returning an env with urls.
+    class _Urls:
+        def __init__(self):
+            self.root = "https://example/"
+
+            class _Mgr:
+                api = "https://example/api/v1/env"
+
+            self.manager = _Mgr()
+
+    class _Env:
+        def __init__(self):
+            self.urls = _Urls()
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _AsyncFleet:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+
+        async def make(self, **kwargs):
+            return _Env()
+
+    mod = types.SimpleNamespace(AsyncFleet=_AsyncFleet)
+    monkeypatch.setitem(sys.modules, "fleet", mod)
+
+
+@pytest.mark.usefixtures("fake_requests_session", "fake_fleet_module")
+def test_fleet_env_from_fleet_returns_orchestrator_and_tools():
+    from envs.fleet_env import FleetEnvClient, FleetMCPTools
+
+    orch, tools = FleetEnvClient.from_fleet(api_key="k", env_key="e")
+    assert isinstance(orch, FleetEnvClient)
+    assert isinstance(tools, FleetMCPTools)
+
+
+@pytest.mark.usefixtures("fake_requests_session", "fake_fleet_module")
+def test_fleet_env_reset_uses_http_manager_base_url():
+    from envs.fleet_env import FleetEnvClient
+
+    orch, _tools = FleetEnvClient.from_fleet(api_key="k", env_key="e")
+    # reset() should hit {base}/reset
+    _ = orch.reset()
+    # access underlying fake session calls
+    calls = orch._http.calls  # pylint: disable=protected-access
+    assert calls[-1][0] == "POST"
+    assert calls[-1][1].endswith("/reset")
+
+
+@pytest.mark.usefixtures("fake_requests_session", "fake_fleet_module")
+def test_fleet_env_step_rejects_tool_actions():
+    from envs.fleet_env import FleetEnvClient, CallToolAction
+
+    orch, _tools = FleetEnvClient.from_fleet(api_key="k", env_key="e")
+    with pytest.raises(TypeError):
+        orch.step(CallToolAction(tool_name="computer", parameters={"action": "screenshot"}))
+
+
+@pytest.mark.anyio
+async def test_agent_tools_list_and_call_routes(monkeypatch):
+    from envs.fleet_env.mcp_tools import FleetMCPTools
+
+    class _Tool:
+        def __init__(self, name):
+            self.name = name
+
+    class _FakeMCPClient:
+        def __init__(self, url, api_key):
+            self.url = url
+            self.api_key = api_key
+            self.list_calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def list_tools(self):
+            self.list_calls += 1
+            if self.url.endswith("api/v1/mcp"):
+                return [_Tool("computer")]
+            return [_Tool("search_issues")]
+
+        async def call_tool(self, name, args):
+            return {"url": self.url, "name": name, "args": args}
+
+        def has_tool(self, name, tools_list=None):
+            return any(t.name == name for t in (tools_list or []))
+
+    monkeypatch.setattr("envs.fleet_env.mcp_tools.FleetMCPClient", _FakeMCPClient)
+
+    tools = FleetMCPTools(api_key="k", mcp_urls=("https://x/api/v1/mcp", "https://x/mcp"))
+    listed = await tools.list_tools()
+    assert sorted([t.name for t in listed]) == ["computer", "search_issues"]
+
+    res = await tools.call_tool("computer", {"action": "screenshot"})
+    assert res["url"].endswith("api/v1/mcp")
+
+

--- a/tests/envs/test_fleet_task_env.py
+++ b/tests/envs/test_fleet_task_env.py
@@ -1,0 +1,330 @@
+"""Unit tests for FleetTaskEnv."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import sys
+import types
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.calls.append(("POST", url, json))
+        return _FakeResp({"observation": {"metadata": {}}, "reward": 0.0, "done": False})
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append(("GET", url, None))
+        return _FakeResp({"episode_id": "e1", "step_count": 0})
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def fake_requests_session(monkeypatch):
+    fake_requests = types.SimpleNamespace(Session=_FakeSession)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+
+@pytest.fixture
+def fake_fleet_module(monkeypatch):
+    """Create a fake fleet module with Fleet.make returning an env with urls."""
+
+    class _Urls:
+        def __init__(self):
+            self.root = "https://example/"
+
+            class _Mgr:
+                api = "https://example/api/v1/env"
+
+            self.manager = _Mgr()
+
+    class _Env:
+        def __init__(self):
+            self.urls = _Urls()
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Fleet:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+
+        def make(self, **kwargs):
+            return _Env()
+
+    mod = types.SimpleNamespace(Fleet=_Fleet)
+    monkeypatch.setitem(sys.modules, "fleet", mod)
+
+
+@pytest.fixture
+def sample_task_config():
+    """Sample task configuration for testing."""
+    return {
+        "task_key": "test-task-001",
+        "prompt": "Search for flights from NYC to LA on January 15",
+        "env_key": "booking-com",
+        "env_version": "v1.2.3",
+        "data_key": "consumer",
+        "data_version": "v0.0.12",
+        "verifier_code": "async def verify(env): return True",
+        "task_modality": "tool_use",
+        "tool_use_workflow": [{"tool": "search"}],
+    }
+
+
+@pytest.fixture
+def sample_task_config_no_version():
+    """Task config without version info."""
+    return {
+        "task_key": "test-task-002",
+        "prompt": "Test prompt",
+        "env_key": "test-env",
+        "task_modality": "tool_use",
+    }
+
+
+class TestFleetTaskEnvInit:
+    """Tests for FleetTaskEnv initialization."""
+
+    def test_init_with_api_key(self, sample_task_config):
+        """Should initialize with explicit API key."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test-api-key")
+        assert env.api_key == "test-api-key"
+        assert env.task_key == "test-task-001"
+        assert env.prompt == "Search for flights from NYC to LA on January 15"
+        assert env.modality == "tool_use"
+
+    def test_init_from_env_var(self, sample_task_config, monkeypatch):
+        """Should use FLEET_API_KEY env var if no api_key provided."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        monkeypatch.setenv("FLEET_API_KEY", "env-api-key")
+        env = FleetTaskEnv(sample_task_config)
+        assert env.api_key == "env-api-key"
+
+    def test_init_raises_without_api_key(self, sample_task_config, monkeypatch):
+        """Should raise if no API key available."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        monkeypatch.delenv("FLEET_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="Fleet API key required"):
+            FleetTaskEnv(sample_task_config)
+
+
+class TestFleetTaskEnvSpecs:
+    """Tests for env/data spec building."""
+
+    def test_build_env_spec_with_version(self, sample_task_config):
+        """Should build env_key:version spec."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        spec = env._build_env_spec()
+        assert spec == "booking-com:v1.2.3"
+
+    def test_build_env_spec_without_version(self, sample_task_config_no_version):
+        """Should return just env_key when no version."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config_no_version, api_key="test")
+        spec = env._build_env_spec()
+        assert spec == "test-env"
+
+    def test_build_data_spec_with_version(self, sample_task_config):
+        """Should build data_key:version spec."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        spec = env._build_data_spec()
+        assert spec == "consumer:v0.0.12"
+
+    def test_build_data_spec_without_data_key(self, sample_task_config_no_version):
+        """Should return None when no data_key."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config_no_version, api_key="test")
+        spec = env._build_data_spec()
+        assert spec is None
+
+    def test_build_env_spec_raises_without_env_key(self):
+        """Should raise when env_key is missing."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        task = {"task_key": "test", "prompt": "test"}
+        env = FleetTaskEnv(task, api_key="test")
+        with pytest.raises(ValueError, match="missing env_key"):
+            env._build_env_spec()
+
+
+class TestFleetTaskEnvVerifier:
+    """Tests for verifier execution."""
+
+    @pytest.mark.anyio
+    async def test_execute_verifier_local_returns_true(self, sample_task_config):
+        """Should return True when verifier passes."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        env._orch = MagicMock()
+
+        verifier_code = "async def verify(env): return True"
+        result = await env._execute_verifier_local(verifier_code)
+        assert result is True
+
+    @pytest.mark.anyio
+    async def test_execute_verifier_local_returns_false(self, sample_task_config):
+        """Should return False when verifier fails."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        env._orch = MagicMock()
+
+        verifier_code = "async def verify(env): return False"
+        result = await env._execute_verifier_local(verifier_code)
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_execute_verifier_local_handles_numeric_result(self, sample_task_config):
+        """Should handle numeric verifier results."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        env._orch = MagicMock()
+
+        # Positive number = pass
+        verifier_code = "async def verify(env): return 1.0"
+        result = await env._execute_verifier_local(verifier_code)
+        assert result is True
+
+        # Zero = fail
+        verifier_code = "async def verify(env): return 0.0"
+        result = await env._execute_verifier_local(verifier_code)
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_execute_verifier_local_handles_dict_result(self, sample_task_config):
+        """Should handle dict verifier results."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        env._orch = MagicMock()
+
+        # success=True
+        verifier_code = "async def verify(env): return {'success': True}"
+        result = await env._execute_verifier_local(verifier_code)
+        assert result is True
+
+        # score > 0
+        verifier_code = "async def verify(env): return {'score': 1.0}"
+        result = await env._execute_verifier_local(verifier_code)
+        assert result is True
+
+        # score = 0
+        verifier_code = "async def verify(env): return {'score': 0}"
+        result = await env._execute_verifier_local(verifier_code)
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_execute_verifier_local_raises_on_missing_function(self, sample_task_config):
+        """Should raise when verify function not defined."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        env._orch = MagicMock()
+
+        verifier_code = "x = 1"  # No verify function
+        with pytest.raises(ValueError, match="must define a 'verify' function"):
+            await env._execute_verifier_local(verifier_code)
+
+
+class TestFleetTaskEnvFactories:
+    """Tests for factory methods."""
+
+    def test_make_fleet_task_env(self, sample_task_config):
+        """Should create FleetTaskEnv via factory function."""
+        from envs.fleet_env.task_env import make_fleet_task_env
+
+        env = make_fleet_task_env(sample_task_config, api_key="test")
+        assert isinstance(env, object)  # Can't import FleetTaskEnv here
+        assert env.task_key == "test-task-001"
+
+
+class TestFleetTaskEnvContextManager:
+    """Tests for context manager protocol."""
+
+    def test_context_manager_closes_on_exit(self, sample_task_config):
+        """Should close environment on context exit."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        env._orch = MagicMock()
+        env._tools = MagicMock()
+
+        with env:
+            pass  # Context enters and exits
+
+        # Environment should be closed
+        assert env._orch is None
+        assert env._tools is None
+        assert env._done is True
+
+
+class TestFleetTaskEnvProperties:
+    """Tests for property accessors."""
+
+    def test_task_key_property(self, sample_task_config):
+        """Should return task_key from config."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        assert env.task_key == "test-task-001"
+
+    def test_task_key_default(self):
+        """Should return 'unknown' when task_key missing."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        task = {"prompt": "test", "env_key": "test-env"}
+        env = FleetTaskEnv(task, api_key="test")
+        assert env.task_key == "unknown"
+
+    def test_prompt_property(self, sample_task_config):
+        """Should return prompt from config."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        assert env.prompt == "Search for flights from NYC to LA on January 15"
+
+    def test_modality_property(self, sample_task_config):
+        """Should return task_modality from config."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        env = FleetTaskEnv(sample_task_config, api_key="test")
+        assert env.modality == "tool_use"
+
+    def test_modality_default(self):
+        """Should default to 'tool_use' when modality missing."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        task = {"task_key": "test", "prompt": "test", "env_key": "test-env"}
+        env = FleetTaskEnv(task, api_key="test")
+        assert env.modality == "tool_use"

--- a/tests/envs/test_fleet_task_env.py
+++ b/tests/envs/test_fleet_task_env.py
@@ -64,7 +64,9 @@ class TestFleetTaskEnvInit:
         assert env.prompt == "Search for flights from NYC to LA on January 15"
         assert env.modality == "tool_use"
 
-    def test_init_from_env_var(self, sample_task_config, mock_fleet_env_client, monkeypatch):
+    def test_init_from_env_var(
+        self, sample_task_config, mock_fleet_env_client, monkeypatch
+    ):
         """Should use FLEET_API_KEY env var if no api_key provided."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -84,7 +86,9 @@ class TestFleetTaskEnvInit:
 class TestFleetTaskEnvSpecs:
     """Tests for env/data spec building."""
 
-    def test_build_env_spec_with_version(self, sample_task_config, mock_fleet_env_client):
+    def test_build_env_spec_with_version(
+        self, sample_task_config, mock_fleet_env_client
+    ):
         """Should build env_key:version spec."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -92,7 +96,9 @@ class TestFleetTaskEnvSpecs:
         spec = env._build_env_spec()
         assert spec == "booking-com:v1.2.3"
 
-    def test_build_env_spec_without_version(self, sample_task_config_no_version, mock_fleet_env_client):
+    def test_build_env_spec_without_version(
+        self, sample_task_config_no_version, mock_fleet_env_client
+    ):
         """Should return just env_key when no version."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -108,7 +114,9 @@ class TestFleetTaskEnvSpecs:
         assert env._get_data_key() == "consumer"
         assert env._get_data_version() == "v0.0.12"
 
-    def test_get_data_key_without_data(self, sample_task_config_no_version, mock_fleet_env_client):
+    def test_get_data_key_without_data(
+        self, sample_task_config_no_version, mock_fleet_env_client
+    ):
         """Should return None when no data_key."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -130,7 +138,9 @@ class TestFleetTaskEnvVerifier:
     """Tests for verifier execution using Fleet SDK."""
 
     @pytest.mark.anyio
-    async def test_compute_reward_returns_score_on_success(self, sample_task_config, mock_fleet_env_client):
+    async def test_compute_reward_returns_score_on_success(
+        self, sample_task_config, mock_fleet_env_client
+    ):
         """Should return verifier result score when Fleet SDK verifier succeeds."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -152,7 +162,9 @@ class TestFleetTaskEnvVerifier:
             mock_task.verify_detailed.assert_called_once_with(mock_orch._fleet_env)
 
     @pytest.mark.anyio
-    async def test_compute_reward_returns_zero_on_failure(self, sample_task_config, mock_fleet_env_client):
+    async def test_compute_reward_returns_zero_on_failure(
+        self, sample_task_config, mock_fleet_env_client
+    ):
         """Should return 0.0 when Fleet SDK verifier fails."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -172,7 +184,9 @@ class TestFleetTaskEnvVerifier:
             assert result == 0.0
 
     @pytest.mark.anyio
-    async def test_compute_reward_returns_zero_when_no_verifier(self, sample_task_config_no_version, mock_fleet_env_client):
+    async def test_compute_reward_returns_zero_when_no_verifier(
+        self, sample_task_config_no_version, mock_fleet_env_client
+    ):
         """Should return 0.0 when no verifier code is present."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -182,7 +196,9 @@ class TestFleetTaskEnvVerifier:
         assert result == 0.0
 
     @pytest.mark.anyio
-    async def test_compute_reward_returns_zero_when_no_orch(self, sample_task_config, mock_fleet_env_client):
+    async def test_compute_reward_returns_zero_when_no_orch(
+        self, sample_task_config, mock_fleet_env_client
+    ):
         """Should return 0.0 when no orchestrator is available."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -193,7 +209,9 @@ class TestFleetTaskEnvVerifier:
         assert result == 0.0
 
     @pytest.mark.anyio
-    async def test_compute_reward_returns_zero_when_no_fleet_env(self, sample_task_config, mock_fleet_env_client):
+    async def test_compute_reward_returns_zero_when_no_fleet_env(
+        self, sample_task_config, mock_fleet_env_client
+    ):
         """Should return 0.0 when no Fleet env handle is available."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -204,7 +222,9 @@ class TestFleetTaskEnvVerifier:
         assert result == 0.0
 
     @pytest.mark.anyio
-    async def test_compute_reward_handles_verifier_exception(self, sample_task_config, mock_fleet_env_client):
+    async def test_compute_reward_handles_verifier_exception(
+        self, sample_task_config, mock_fleet_env_client
+    ):
         """Should return 0.0 when verifier raises an exception."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -219,7 +239,9 @@ class TestFleetTaskEnvVerifier:
             assert result == 0.0
 
     @pytest.mark.anyio
-    async def test_compute_reward_handles_success_with_none_result(self, sample_task_config, mock_fleet_env_client):
+    async def test_compute_reward_handles_success_with_none_result(
+        self, sample_task_config, mock_fleet_env_client
+    ):
         """Should return 1.0 when verifier succeeds but returns None."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -238,7 +260,9 @@ class TestFleetTaskEnvVerifier:
             assert result == 1.0
 
     @pytest.mark.anyio
-    async def test_compute_reward_supports_verifier_func_field(self, mock_fleet_env_client):
+    async def test_compute_reward_supports_verifier_func_field(
+        self, mock_fleet_env_client
+    ):
         """Should support 'verifier_func' field name (Fleet SDK format)."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -280,7 +304,9 @@ class TestFleetTaskEnvFactories:
 class TestFleetTaskEnvContextManager:
     """Tests for context manager protocol."""
 
-    def test_context_manager_closes_on_exit(self, sample_task_config, mock_fleet_env_client):
+    def test_context_manager_closes_on_exit(
+        self, sample_task_config, mock_fleet_env_client
+    ):
         """Should close environment on context exit."""
         from envs.fleet_env.task_env import FleetTaskEnv
 
@@ -334,3 +360,163 @@ class TestFleetTaskEnvProperties:
         task = {"task_key": "test", "prompt": "test", "env_key": "test-env"}
         env = FleetTaskEnv(task, api_key="test")
         assert env.modality == "tool_use"
+
+
+class TestFleetTaskEnvComputerUseFiltering:
+    """Tests for computer_use modality tool filtering."""
+
+    @pytest.fixture
+    def mock_fleet_env_with_tools(self):
+        """Create mock FleetEnvClient that returns tools."""
+        mock_orch = MagicMock()
+        mock_tools = MagicMock()
+
+        with patch("envs.fleet_env.task_env.FleetEnvClient") as MockClient:
+            MockClient.from_fleet.return_value = (mock_orch, mock_tools)
+            yield mock_orch, mock_tools
+
+    @pytest.mark.anyio
+    async def test_computer_use_filters_to_computer_tool(
+        self, mock_fleet_env_with_tools
+    ):
+        """Should filter to only 'computer' tool for computer_use modality."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        mock_orch, mock_tools = mock_fleet_env_with_tools
+
+        # Mock list_tools returning mixed tools (computer + API tools)
+        async def mock_list_tools():
+            return MagicMock(
+                tools=[
+                    {"name": "computer", "description": "Mouse/keyboard control"},
+                    {"name": "search_issues", "description": "Search issues"},
+                    {"name": "create_ticket", "description": "Create ticket"},
+                ]
+            )
+
+        mock_tools.list_tools = mock_list_tools
+
+        task_config = {
+            "task_key": "test-task",
+            "prompt": "Click on button",
+            "env_key": "test-env",
+            "task_modality": "computer_use",
+        }
+
+        env = FleetTaskEnv(task_config, api_key="test")
+        obs = await env.reset_async()
+
+        # Should only have computer tool
+        assert len(env._tools_cache) == 1
+        assert env._tools_cache[0]["name"] == "computer"
+
+    @pytest.mark.anyio
+    async def test_computer_use_clears_tools_when_no_computer_tool(
+        self, mock_fleet_env_with_tools, caplog
+    ):
+        """Should clear tools and warn when no 'computer' tool for computer_use modality."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+        import logging
+
+        mock_orch, mock_tools = mock_fleet_env_with_tools
+
+        # Mock list_tools returning only API tools (no computer tool)
+        async def mock_list_tools():
+            return MagicMock(
+                tools=[
+                    {"name": "search_issues", "description": "Search issues"},
+                    {"name": "create_ticket", "description": "Create ticket"},
+                ]
+            )
+
+        mock_tools.list_tools = mock_list_tools
+
+        task_config = {
+            "task_key": "sentry-task",
+            "prompt": "Click on button",
+            "env_key": "sentry",
+            "task_modality": "computer_use",
+        }
+
+        env = FleetTaskEnv(task_config, api_key="test")
+
+        with caplog.at_level(logging.WARNING):
+            obs = await env.reset_async()
+
+        # Should have empty tools (filtered out API tools)
+        assert env._tools_cache == []
+
+        # Should have logged warning
+        assert "computer_use modality but no 'computer' tool found" in caplog.text
+
+    @pytest.mark.anyio
+    async def test_tool_use_does_not_filter(self, mock_fleet_env_with_tools):
+        """Should NOT filter tools for tool_use modality."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        mock_orch, mock_tools = mock_fleet_env_with_tools
+
+        # Mock list_tools returning mixed tools
+        async def mock_list_tools():
+            return MagicMock(
+                tools=[
+                    {"name": "computer", "description": "Mouse/keyboard control"},
+                    {"name": "search_issues", "description": "Search issues"},
+                    {"name": "create_ticket", "description": "Create ticket"},
+                ]
+            )
+
+        mock_tools.list_tools = mock_list_tools
+
+        task_config = {
+            "task_key": "test-task",
+            "prompt": "Search for issues",
+            "env_key": "test-env",
+            "task_modality": "tool_use",  # tool_use, not computer_use
+        }
+
+        env = FleetTaskEnv(task_config, api_key="test")
+        obs = await env.reset_async()
+
+        # Should have all 3 tools
+        assert len(env._tools_cache) == 3
+
+    @pytest.mark.anyio
+    async def test_computer_use_filters_function_format(
+        self, mock_fleet_env_with_tools
+    ):
+        """Should filter 'computer' tool from function format."""
+        from envs.fleet_env.task_env import FleetTaskEnv
+
+        mock_orch, mock_tools = mock_fleet_env_with_tools
+
+        # Mock list_tools returning tools in OpenAI function format
+        async def mock_list_tools():
+            return MagicMock(
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "computer", "description": "Control"},
+                    },
+                    {
+                        "type": "function",
+                        "function": {"name": "api_call", "description": "API"},
+                    },
+                ]
+            )
+
+        mock_tools.list_tools = mock_list_tools
+
+        task_config = {
+            "task_key": "test-task",
+            "prompt": "Click button",
+            "env_key": "test-env",
+            "task_modality": "computer_use",
+        }
+
+        env = FleetTaskEnv(task_config, api_key="test")
+        obs = await env.reset_async()
+
+        # Should only have computer tool
+        assert len(env._tools_cache) == 1
+        assert env._tools_cache[0]["function"]["name"] == "computer"


### PR DESCRIPTION
## Summary
- Fixed bug where `tool_use` tasks were incorrectly exposed to the `computer` tool
- Added inverse filtering for `tool_use` modality to exclude `computer` tool
- Updated and added tests to verify correct behavior

## Problem
The tool filtering logic in `task_env.py` only handled `computer_use` modality (keeping ONLY the computer tool). For `tool_use` modality, there was no filtering - all tools passed through, including the `computer` tool if the MCP endpoint exposed it.

This caused training runs to log `call_tool(computer)` for what should be pure tool-use tasks.

## Changes
- `src/envs/fleet_env/task_env.py`: Add filtering to exclude `computer` tool for `tool_use` modality
- `tests/envs/test_fleet_task_env.py`: Update test name and assertions, add new test for function format

## Test plan
- [x] Run `pytest tests/envs/test_fleet_task_env.py::TestFleetTaskEnvComputerUseFiltering -v` - all 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)