### PR TITLE
Fix Dockerfile paths for unity-env, openapp-env, and openspiel-env

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -92,15 +92,15 @@ jobs:
           - name: snake-env
             dockerfile: envs/snake_env/server/Dockerfile
           - name: unity-env
-            dockerfile: server/Dockerfile
+            dockerfile: envs/unity_env/server/Dockerfile
             context: envs/unity_env
           - name: openapp-env
-            dockerfile: server/Dockerfile
+            dockerfile: envs/openapp_env/server/Dockerfile
             context: envs/openapp_env
           - name: maze-env
             dockerfile: envs/maze_env/server/Dockerfile
           - name: openspiel-env
-            dockerfile: server/Dockerfile
+            dockerfile: envs/openspiel_env/server/Dockerfile
             context: envs/openspiel_env
 
     steps:


### PR DESCRIPTION
## Problem

The `docker-build.yml` workflow fails for `unity-env`, `openapp-env`, and `openspiel-env` with:

```
ERROR: failed to build: resolve : lstat server: no such file or directory
```

## Root Cause

The `docker/build-push-action` resolves the `file` parameter relative to the **repository root**, not relative to the build `context`. These three matrix entries set a custom context (e.g., `envs/unity_env`) but used a relative Dockerfile path (`server/Dockerfile`), causing Docker to look for `<repo-root>/server/Dockerfile` which does not exist.

## Fix

Changed the `dockerfile` paths to be full repo-root-relative paths, matching the pattern used by all other env entries in the matrix:

| Entry | Before | After |
|---|---|---|
| `unity-env` | `server/Dockerfile` | `envs/unity_env/server/Dockerfile` |
| `openapp-env` | `server/Dockerfile` | `envs/openapp_env/server/Dockerfile` |
| `openspiel-env` | `server/Dockerfile` | `envs/openspiel_env/server/Dockerfile` |