### PR TITLE
Move LLMClient from calendar_env to Core, drop LangChain

### DIFF
--- a/envs/calendar_env/client.py
+++ b/envs/calendar_env/client.py
@@ -770,8 +770,12 @@ class ScenarioRunner:
                     }
                 )
 
-        last_msg = messages[-1] if messages else {}
-        final_response = last_msg.get("content", "") if last_msg else ""
+        # Find the last assistant message (not a tool result).
+        final_response = ""
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant":
+                final_response = msg.get("content", "")
+                break
         return {
             "final_response": final_response,
             "conversation_flow": conversation_flow,

--- a/src/openenv/core/__init__.py
+++ b/src/openenv/core/__init__.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
     from .generic_client import GenericAction, GenericEnvClient
     from .llm_client import (
         AnthropicClient,
+        create_llm_client,
         LLMClient,
         LLMResponse,
         OpenAIClient,
         ToolCall,
-        create_llm_client,
     )
     from .mcp_client import MCPClientBase, MCPToolClient
     from .sync_client import SyncEnvClient

--- a/src/openenv/core/llm_client.py
+++ b/src/openenv/core/llm_client.py
@@ -268,9 +268,7 @@ class AnthropicClient(LLMClient):
             create_kwargs["system"] = self.system_prompt
 
         response = await self._client.messages.create(**create_kwargs)
-        return "".join(
-            block.text for block in response.content if block.type == "text"
-        )
+        return "".join(block.text for block in response.content if block.type == "text")
 
     async def complete_with_tools(
         self,
@@ -323,6 +321,7 @@ def create_llm_client(
     model: str,
     api_key: str,
     *,
+    system_prompt: str | None = None,
     temperature: float = 0.0,
     max_tokens: int = 4096,
 ) -> LLMClient:
@@ -332,6 +331,7 @@ def create_llm_client(
         provider: Provider name ("openai" or "anthropic").
         model: Model identifier.
         api_key: API key for the provider.
+        system_prompt: Optional system message prepended to every request.
         temperature: Sampling temperature.
         max_tokens: Maximum tokens in the response.
 
@@ -350,6 +350,7 @@ def create_llm_client(
         port,
         model,
         api_key=api_key,
+        system_prompt=system_prompt,
         temperature=temperature,
         max_tokens=max_tokens,
     )
@@ -364,6 +365,9 @@ def _clean_mcp_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Normalize an MCP tool ``inputSchema`` for LLM function-calling APIs."""
     if not isinstance(schema, dict):
         return {"type": "object", "properties": {}, "required": []}
+
+    # Shallow copy to avoid mutating the caller's schema dict.
+    schema = dict(schema)
 
     if "oneOf" in schema:
         for option in schema["oneOf"]:

--- a/tests/core/test_llm_client.py
+++ b/tests/core/test_llm_client.py
@@ -455,6 +455,14 @@ class TestCreateLLMClient:
         assert client.temperature == 0.5
         assert client.max_tokens == 1024
 
+    @patch("openenv.core.llm_client.AsyncOpenAI")
+    def test_system_prompt_forwarded(self, mock_openai_cls):
+        """system_prompt is forwarded to the client."""
+        client = create_llm_client(
+            "openai", "gpt-4", "sk-key", system_prompt="You are a judge."
+        )
+        assert client.system_prompt == "You are a judge."
+
 
 # ---------------------------------------------------------------------------
 # MCP schema helpers
@@ -511,6 +519,13 @@ class TestCleanMCPSchema:
     def test_sets_default_type(self):
         result = _clean_mcp_schema({"properties": {"a": {"type": "string"}}})
         assert result["type"] == "object"
+
+    def test_does_not_mutate_input(self):
+        """_clean_mcp_schema must not modify the caller's dict."""
+        original = {"type": "object"}
+        _clean_mcp_schema(original)
+        # Should not have added "properties" to the original dict.
+        assert "properties" not in original
 
 
 class TestMCPToolsToOpenAI:


### PR DESCRIPTION
## Summary

- The calendar env had its own `LLMClient` class (LangChain-based, multi-provider) that belongs in Core — it was a general-purpose LLM RPC utility buried in an env-specific file.
- Adds `AnthropicClient(LLMClient)` to core using the native `anthropic` SDK (lazy-imported, no new hard dep).
- Adds `complete_with_tools(messages, tools) -> LLMResponse` to both `OpenAIClient` and `AnthropicClient`, with `LLMResponse`/`ToolCall` dataclasses as normalized output across providers.
- Adds `create_llm_client(provider, model, api_key)` factory for one-liner hosted API setup.
- Moves MCP schema helpers (`_clean_mcp_schema`, tool format converters, OpenAI→Anthropic message conversion) from calendar env into core.
- Removes the inline `LLMClient` class and all `langchain` imports from `envs/calendar_env/client.py`; rewires `ScenarioRunner` + `VerifierEngine` to use core clients.

## Test plan

- [x] All 40 `test_llm_client.py` tests pass (28 new, 12 existing unchanged)
- [x] All 168 rubric tests pass (no regressions)
- [x] Full suite: 870 passed, 11 pre-existing websocket failures, 5 skipped
- [x] Lint clean on all modified files