### PR TITLE
fix: use finrl 0.3.5 to avoid 0.3.6 PyPI metadata bug (#73)

### DIFF
--- a/envs/finrl_env/server/Dockerfile
+++ b/envs/finrl_env/server/Dockerfile
@@ -17,8 +17,10 @@
 FROM envtorch-base:latest
 
 # Install FinRL and its dependencies with pinned versions for reproducibility
+# Note: finrl 0.3.6 has PyPI metadata bug (reports 0.3.5), 0.3.7 can cause runtime errors.
+# Using 0.3.5 for stable Docker builds (see https://github.com/meta-pytorch/OpenEnv/issues/73)
 RUN pip install --no-cache-dir \
-    finrl==0.3.7 \
+    finrl==0.3.5 \
     alpaca-trade-api>=3.0.0 \
     exchange_calendars>=4.5 \
     wrds>=3.2.0 \


### PR DESCRIPTION
pinning to 0.3.5 since 0.3.6 has that metadata mismatch on pypi (reports 0.3.5 internally) which breaks the docker build. 0.3.7 was causing runtime issues per the comments. worth a shot