### PR TITLE
fix(env): pass max_turns correctly to textarena env

### DIFF
--- a/envs/textarena_env/server/environment.py
+++ b/envs/textarena_env/server/environment.py
@@ -108,6 +108,9 @@ class TextArenaEnvironment(Environment):
         self.max_turns = max_turns
         self._env_kwargs = env_kwargs or {}
 
+        if max_turns is not None:
+            self._env_kwargs.setdefault("num_guesses", max_turns)
+
         self._ta_env = ta.make(env_id=env_id, **self._env_kwargs)
 
         self._state = TextArenaState(


### PR DESCRIPTION
## Summary
`max_turns` was not passed correctly to the textarena environment in `self._env_kwargs`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
Run the textarena environment with different `TEXTARENA_MAX_TURNS` environment variable values.

## Claude Code Review
N/A
