### PR TITLE
Release v0.2.3

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+global-exclude *.py[cod]
+global-exclude __pycache__/*

--- a/envs/repl_env/pyproject.toml
+++ b/envs/repl_env/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "smolagents>=1.22.0,<2",
     # LLM support via HuggingFace Inference API
     "huggingface_hub>=0.20.0",
+    # REPL custom Gradio tab on /web
+    "gradio>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/envs/repl_env/server/app.py
+++ b/envs/repl_env/server/app.py
@@ -35,16 +35,20 @@ Environment Variables:
     LLM_MODEL: Model to use for llm_query/llm_query_batched (default: Qwen/Qwen3.5-9B)
 """
 
+import inspect
+import logging
 import os
 
 try:
     from openenv.core.env_server.http_server import create_app
 
     from ..models import REPLAction, REPLObservation
+    from .gradio_ui import build_repl_gradio_app
     from .repl_environment import REPLEnvironment
 except ImportError:
     from models import REPLAction, REPLObservation
     from openenv.core.env_server.http_server import create_app
+    from server.gradio_ui import build_repl_gradio_app
     from server.repl_environment import REPLEnvironment
 
 
@@ -57,6 +61,8 @@ REPL_CONTEXT_PREVIEW_LENGTH = int(os.environ.get("REPL_CONTEXT_PREVIEW_LENGTH", 
 REPL_RLM_MAX_DEPTH = int(os.environ.get("REPL_RLM_MAX_DEPTH", "2"))
 REPL_RLM_MAX_ITERATIONS = int(os.environ.get("REPL_RLM_MAX_ITERATIONS", "30"))
 # ==========================================
+
+_logger = logging.getLogger(__name__)
 
 # Log LLM configuration
 if HF_TOKEN:
@@ -85,14 +91,29 @@ def create_repl_environment() -> REPLEnvironment:
     )
 
 
-# Create the app with web interface and README integration
-app = create_app(
-    create_repl_environment,
-    REPLAction,
-    REPLObservation,
-    env_name="repl_env",
-    max_concurrent_envs=8,
-)
+# Create the app with web interface and README integration.
+_sig = inspect.signature(create_app)
+if "gradio_builder" in _sig.parameters:
+    app = create_app(
+        create_repl_environment,
+        REPLAction,
+        REPLObservation,
+        env_name="repl_env",
+        max_concurrent_envs=8,
+        gradio_builder=build_repl_gradio_app,
+    )
+else:
+    _logger.warning(
+        "Installed openenv-core does not support gradio_builder; "
+        "custom REPL Gradio tab will not be available."
+    )
+    app = create_app(
+        create_repl_environment,
+        REPLAction,
+        REPLObservation,
+        env_name="repl_env",
+        max_concurrent_envs=8,
+    )
 
 
 def main():

--- a/envs/repl_env/server/gradio_ui.py
+++ b/envs/repl_env/server/gradio_ui.py
@@ -1,0 +1,195 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Custom Gradio tab for the REPL environment."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import gradio as gr
+from openenv.core.env_server.types import EnvironmentMetadata
+
+
+def _code_block(title: str, content: str) -> str:
+    if not content:
+        return ""
+    return f"**{title}:**\n```text\n{content}\n```"
+
+
+def _format_repl_response(data: Dict[str, Any]) -> str:
+    """Render REPL observations in a compact Markdown view."""
+    observation = data.get("observation", {})
+    result = observation.get("result", {})
+    sections: List[str] = ["# REPL Session"]
+
+    context_preview = observation.get("context_preview")
+    if context_preview:
+        sections.append(_code_block("Context Preview", context_preview))
+
+    task_prompt = observation.get("task_prompt")
+    if task_prompt:
+        sections.append(_code_block("Task Prompt", task_prompt))
+
+    available_variables = observation.get("available_variables") or []
+    if available_variables:
+        sections.append(
+            "**Available Variables:** " + ", ".join(f"`{name}`" for name in available_variables)
+        )
+
+    if result.get("locals_snapshot"):
+        sections.append(
+            "**Locals Snapshot:**\n```json\n"
+            + json.dumps(result["locals_snapshot"], indent=2, sort_keys=True)
+            + "\n```"
+        )
+
+    stdout = result.get("stdout", "")
+    stderr = result.get("stderr", "")
+    sections.append(_code_block("Stdout", stdout))
+    sections.append(_code_block("Stderr", stderr))
+
+    reward = data.get("reward")
+    done = data.get("done")
+    sections.append(f"**Reward:** `{reward}`")
+    sections.append(f"**Done:** `{done}`")
+
+    return "\n\n".join(section for section in sections if section)
+
+
+def build_repl_gradio_app(
+    web_manager: Any,
+    action_fields: List[Dict[str, Any]],
+    metadata: Optional[EnvironmentMetadata],
+    is_chat_env: bool,
+    title: str,
+    quick_start_md: str,
+) -> gr.Blocks:
+    """Build the REPL-specific Gradio tab."""
+    del action_fields, is_chat_env, metadata, quick_start_md
+
+    async def reset_repl(
+        context: str,
+        task_prompt: str,
+        hf_token: str,
+        llm_model: str,
+    ):
+        reset_kwargs: Dict[str, Any] = {}
+        if context.strip():
+            reset_kwargs["context"] = context
+        if task_prompt.strip():
+            reset_kwargs["task_prompt"] = task_prompt
+        if hf_token.strip():
+            reset_kwargs["hf_token"] = hf_token
+        if llm_model.strip():
+            reset_kwargs["llm_model"] = llm_model
+
+        try:
+            data = await web_manager.reset_environment(reset_kwargs)
+            state = web_manager.get_state()
+            return (
+                _format_repl_response(data),
+                json.dumps(data, indent=2, sort_keys=True),
+                json.dumps(state, indent=2, sort_keys=True),
+                "REPL reset complete.",
+            )
+        except Exception as exc:
+            return ("", "", "", f"Error: {exc}")
+
+    async def run_code(code: str):
+        if not code.strip():
+            return ("", "", "", "Enter Python code to run.")
+
+        try:
+            data = await web_manager.step_environment({"code": code})
+            state = web_manager.get_state()
+            return (
+                _format_repl_response(data),
+                json.dumps(data, indent=2, sort_keys=True),
+                json.dumps(state, indent=2, sort_keys=True),
+                "Code executed.",
+            )
+        except Exception as exc:
+            return ("", "", "", f"Error: {exc}")
+
+    def get_state_sync():
+        try:
+            return json.dumps(web_manager.get_state(), indent=2, sort_keys=True)
+        except Exception as exc:
+            return f"Error: {exc}"
+
+    with gr.Blocks(title=f"{title} - REPL") as blocks:
+        gr.Markdown(
+            "# REPL Control Panel\n\n"
+            "Load a problem into the REPL, execute Python, and inspect state without "
+            "leaving the Space."
+        )
+        with gr.Row():
+            with gr.Column(scale=2):
+                context = gr.Textbox(
+                    label="Context",
+                    placeholder="Problem context or source text...",
+                    lines=8,
+                )
+                task_prompt = gr.Textbox(
+                    label="Task Prompt",
+                    placeholder="What should the agent solve?",
+                    lines=3,
+                )
+                with gr.Accordion("Optional Model Settings", open=False):
+                    hf_token = gr.Textbox(
+                        label="Hugging Face Token",
+                        placeholder="Used only for this reset; not persisted in state",
+                        type="password",
+                    )
+                    llm_model = gr.Textbox(
+                        label="LLM Model",
+                        placeholder="Optional override for llm_query / rlm_query",
+                    )
+                code = gr.Textbox(
+                    label="Python Code",
+                    placeholder="count = len(context.split())",
+                    lines=10,
+                )
+                with gr.Row():
+                    reset_btn = gr.Button("Reset", variant="secondary")
+                    run_btn = gr.Button("Run", variant="primary")
+                    state_btn = gr.Button("Get state", variant="secondary")
+                status = gr.Textbox(label="Status", interactive=False)
+            with gr.Column(scale=3):
+                session_view = gr.Markdown(
+                    value="# REPL Session\n\nReset the environment to start."
+                )
+                raw_json = gr.Code(
+                    label="Raw JSON response",
+                    language="json",
+                    interactive=False,
+                )
+                state_json = gr.Code(
+                    label="Session state",
+                    language="json",
+                    interactive=False,
+                )
+
+        reset_btn.click(
+            fn=reset_repl,
+            inputs=[context, task_prompt, hf_token, llm_model],
+            outputs=[session_view, raw_json, state_json, status],
+        )
+        run_btn.click(
+            fn=run_code,
+            inputs=[code],
+            outputs=[session_view, raw_json, state_json, status],
+        )
+        code.submit(
+            fn=run_code,
+            inputs=[code],
+            outputs=[session_view, raw_json, state_json, status],
+        )
+        state_btn.click(fn=get_state_sync, outputs=[state_json])
+
+    return blocks

--- a/envs/repl_env/server/repl_environment.py
+++ b/envs/repl_env/server/repl_environment.py
@@ -32,16 +32,24 @@ except ImportError:
 try:
     from ..models import CodeBlockResult, REPLAction, REPLObservation, REPLState
 except ImportError:
-    from models import CodeBlockResult, REPLAction, REPLObservation, REPLState
+    try:
+        from repl_env.models import CodeBlockResult, REPLAction, REPLObservation, REPLState
+    except ImportError:
+        from models import CodeBlockResult, REPLAction, REPLObservation, REPLState
 
 try:
     from ..recursive_controller import create_server_recursive_controller
     from ..rubrics import REPLRubric
     from .python_executor import PythonExecutor
 except ImportError:
-    from python_executor import PythonExecutor
-    from recursive_controller import create_server_recursive_controller
-    from rubrics import REPLRubric
+    try:
+        from repl_env.recursive_controller import create_server_recursive_controller
+        from repl_env.rubrics import REPLRubric
+        from .python_executor import PythonExecutor
+    except ImportError:
+        from .python_executor import PythonExecutor
+        from recursive_controller import create_server_recursive_controller
+        from rubrics import REPLRubric
 
 
 class REPLEnvironment(Environment):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openenv-core"
-version = "0.2.3.dev0"
+version = "0.2.3"
 description = "A unified framework for reinforcement learning environments"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -86,8 +86,12 @@ include-package-data = true
 [tool.setuptools.package-data]
 "openenv.cli" = ["templates/**/*"]
 
+[tool.setuptools.exclude-package-data]
+"*" = ["*.pyc", "*.pyo", "__pycache__/*"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
+exclude = ["*.__pycache__", "*.__pycache__.*"]
 
 [tool.coverage.run]
 omit = [

--- a/scripts/manage_hf_collection.py
+++ b/scripts/manage_hf_collection.py
@@ -4,7 +4,7 @@ Hugging Face Collection Manager for OpenEnv.
 
 This script manages two collection flows:
 1) Versioned release collection (for deployed suffix spaces)
-2) Global OpenEnv collection (all spaces tagged with `openenv`)
+2) Global OpenEnv collection (validated first-party canonicals by default)
 """
 
 from __future__ import annotations
@@ -31,7 +31,7 @@ DEFAULT_COLLECTION_SLUG = "openenv/environment-hub-68f16377abea1ea114fa0743"
 DEFAULT_VERSIONED_COLLECTION_TITLE_PREFIX = "OpenEnv Environment Hub"
 DEFAULT_GLOBAL_COLLECTION_TITLE = "OpenEnv Environment Hub"
 DEFAULT_TAG_FILTER = "openenv"
-DEFAULT_GLOBAL_SCOPE = "tagged"
+DEFAULT_GLOBAL_SCOPE = "canonical"
 FALLBACK_DEFAULT_VERSION = "0.2.0"
 VERSION_SUFFIX_PATTERN = re.compile(r"-(?:\d+\.\d+\.\d+|v\d+-\d+-\d+)$")
 DUAL_MODE_FLAGS = frozenset(
@@ -202,17 +202,15 @@ def resolve_collection_slug(
     return collection.slug
 
 
-def get_collection_spaces(
-    api: HfApi, collection_slug: str = DEFAULT_COLLECTION_SLUG
-) -> Set[str]:
-    """Retrieve space IDs currently in collection."""
+def get_collection_items(api: HfApi, collection_slug: str = DEFAULT_COLLECTION_SLUG):
+    """Retrieve collection items currently present for Spaces."""
     logger.info(f"Fetching current collection contents: {collection_slug}")
 
     try:
         collection = api.get_collection(collection_slug)
-        space_ids = {item.item_id for item in collection.items if item.item_type == "space"}
-        logger.info(f"✓ Found {len(space_ids)} spaces in collection")
-        return space_ids
+        items = [item for item in collection.items if item.item_type == "space"]
+        logger.info(f"✓ Found {len(items)} spaces in collection")
+        return items
     except HfHubHTTPError as exc:
         if exc.response.status_code == 404:
             logger.error(f"Collection not found: {collection_slug}")
@@ -222,6 +220,15 @@ def get_collection_spaces(
     except Exception as exc:
         logger.error(f"Unexpected error fetching collection: {exc}")
         sys.exit(1)
+
+
+def get_collection_spaces(
+    api: HfApi, collection_slug: str = DEFAULT_COLLECTION_SLUG
+) -> Set[str]:
+    """Retrieve space IDs currently in collection."""
+    return {
+        item.item_id for item in get_collection_items(api, collection_slug=collection_slug)
+    }
 
 
 def discover_openenv_spaces(
@@ -310,6 +317,18 @@ def discover_canonical_openenv_spaces(
     return deduped
 
 
+def discover_global_target_spaces(
+    api: HfApi,
+    namespace: str,
+    tag_filter: str,
+    scope: str,
+) -> List[str]:
+    """Resolve global collection targets for the requested discovery scope."""
+    if scope == "canonical":
+        return discover_canonical_openenv_spaces(api, namespace, tag_filter)
+    return discover_openenv_spaces(api, tag_filter)
+
+
 def dedupe_preserve_order(values: Iterable[str]) -> List[str]:
     """Deduplicate while preserving insertion order."""
     seen = set()
@@ -370,6 +389,46 @@ def add_spaces_to_collection(
     return added_count
 
 
+def remove_spaces_from_collection(
+    api: HfApi,
+    collection_slug: str,
+    current_items,
+    target_space_ids: List[str],
+    dry_run: bool = False,
+) -> int:
+    """Remove spaces that are not part of the target set."""
+    target_ids = set(target_space_ids)
+    items_to_remove = [item for item in current_items if item.item_id not in target_ids]
+    if not items_to_remove:
+        logger.info("No stale spaces to remove")
+        return 0
+
+    removed_count = 0
+    failed_count = 0
+    for item in items_to_remove:
+        if dry_run:
+            logger.info(f"[DRY RUN] Would remove space from {collection_slug}: {item.item_id}")
+            removed_count += 1
+            continue
+
+        try:
+            logger.info(f"Removing stale space from collection: {item.item_id}")
+            api.delete_collection_item(
+                collection_slug=collection_slug,
+                item_object_id=item.item_object_id,
+                missing_ok=True,
+            )
+            logger.info(f"✓ Removed: {item.item_id}")
+            removed_count += 1
+        except Exception as exc:
+            logger.error(f"Failed to remove {item.item_id}: {exc}")
+            failed_count += 1
+
+    if failed_count > 0:
+        logger.warning(f"Failed to remove {failed_count} spaces")
+    return removed_count
+
+
 def should_skip_fetch(collection_slug: str) -> bool:
     """Skip fetch for dry-run synthetic slugs."""
     return "/dry-run-" in collection_slug
@@ -390,13 +449,18 @@ Examples:
   python scripts/manage_hf_collection.py --version 0.2.1 \\
       --space-id openenv/echo_env-0.2.1 --space-id openenv/coding_env-0.2.1
 
-  # Sync only global OpenEnv collection from tag discovery
+  # Sync only the curated public OpenEnv collection from canonical discovery
   python scripts/manage_hf_collection.py --skip-versioned-collection
         """,
     )
 
     parser.add_argument("--dry-run", action="store_true", help="Preview changes only")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "--reconcile",
+        action="store_true",
+        help="Remove stale collection items that are not part of the resolved target set.",
+    )
     parser.add_argument(
         "--version",
         default=DEFAULT_VERSION,
@@ -523,16 +587,22 @@ Examples:
             dry_run=args.dry_run,
         )
 
-        current_spaces = (
-            set()
+        current_items = (
+            []
             if args.dry_run and should_skip_fetch(collection_slug)
-            else get_collection_spaces(api, collection_slug)
+            else get_collection_items(api, collection_slug)
         )
+        current_spaces = {item.item_id for item in current_items}
 
         if args.space_id:
             resolved_spaces = dedupe_preserve_order(args.space_id)
         else:
-            resolved_spaces = discover_openenv_spaces(api, args.tag_filter)
+            resolved_spaces = discover_global_target_spaces(
+                api,
+                namespace=args.collection_namespace,
+                tag_filter=args.tag_filter,
+                scope=args.global_scope,
+            )
 
         new_spaces = [space_id for space_id in resolved_spaces if space_id not in current_spaces]
 
@@ -543,6 +613,10 @@ Examples:
         logger.info(f"  Total spaces in collection: {len(current_spaces)}")
         logger.info(f"  Total spaces resolved: {len(resolved_spaces)}")
         logger.info(f"  New spaces to add: {len(new_spaces)}")
+        logger.info(
+            f"  Stale spaces to remove: "
+            f"{len([item for item in current_items if item.item_id not in set(resolved_spaces)]) if args.reconcile else 0}"
+        )
         logger.info("=" * 60)
 
         add_spaces_to_collection(
@@ -552,6 +626,14 @@ Examples:
             version=args.version,
             dry_run=args.dry_run,
         )
+        if args.reconcile:
+            remove_spaces_from_collection(
+                api=api,
+                collection_slug=collection_slug,
+                current_items=current_items,
+                target_space_ids=resolved_spaces,
+                dry_run=args.dry_run,
+            )
         logger.info(f"Collection URL: https://huggingface.co/collections/{collection_slug}")
         return
 
@@ -560,12 +642,12 @@ Examples:
     if (not args.skip_global_collection) or (
         not args.skip_versioned_collection and len(explicit_spaces) == 0
     ):
-        if args.global_scope == "canonical":
-            discovered_spaces = discover_canonical_openenv_spaces(
-                api, args.collection_namespace, args.tag_filter
-            )
-        else:
-            discovered_spaces = discover_openenv_spaces(api, args.tag_filter)
+        discovered_spaces = discover_global_target_spaces(
+            api,
+            namespace=args.collection_namespace,
+            tag_filter=args.tag_filter,
+            scope=args.global_scope,
+        )
 
     versioned_targets = explicit_spaces if explicit_spaces else discovered_spaces
     global_targets = discovered_spaces
@@ -590,11 +672,12 @@ Examples:
             dry_run=args.dry_run,
         )
 
-        current_versioned = (
-            set()
+        current_versioned_items = (
+            []
             if args.dry_run and should_skip_fetch(versioned_slug)
-            else get_collection_spaces(api, versioned_slug)
+            else get_collection_items(api, versioned_slug)
         )
+        current_versioned = {item.item_id for item in current_versioned_items}
         new_versioned = [s for s in versioned_targets if s not in current_versioned]
 
         logger.info("=" * 60)
@@ -607,6 +690,10 @@ Examples:
         logger.info(f"  Current spaces: {len(current_versioned)}")
         logger.info(f"  Resolved spaces: {len(versioned_targets)}")
         logger.info(f"  New spaces to add: {len(new_versioned)}")
+        logger.info(
+            f"  Stale spaces to remove: "
+            f"{len([item for item in current_versioned_items if item.item_id not in set(versioned_targets)]) if args.reconcile else 0}"
+        )
         logger.info("=" * 60)
 
         add_spaces_to_collection(
@@ -617,24 +704,48 @@ Examples:
             dry_run=args.dry_run,
             note=f"OpenEnv release {normalize_version(args.version)}",
         )
+        if args.reconcile:
+            remove_spaces_from_collection(
+                api=api,
+                collection_slug=versioned_slug,
+                current_items=current_versioned_items,
+                target_space_ids=versioned_targets,
+                dry_run=args.dry_run,
+            )
         logger.info(f"Versioned collection URL: https://huggingface.co/collections/{versioned_slug}")
 
     if not args.skip_global_collection:
+        global_description = (
+            "Validated first-party canonical OpenEnv environments on Hugging Face Hub"
+            if args.global_scope == "canonical"
+            else "All OpenEnv-tagged environments on Hugging Face Hub"
+        )
+        global_note = (
+            "OpenEnv canonical sync"
+            if args.global_scope == "canonical"
+            else f"OpenEnv tag sync ({args.tag_filter})"
+        )
+        discovery_label = (
+            "Canonical spaces discovered"
+            if args.global_scope == "canonical"
+            else "Tagged spaces discovered"
+        )
         global_slug = resolve_collection_slug(
             api=api,
             namespace=args.collection_namespace,
             title=args.global_collection_title,
-            description="All OpenEnv-tagged environments on Hugging Face Hub",
+            description=global_description,
             explicit_slug=args.global_collection_slug,
             private=args.private_global_collection,
             dry_run=args.dry_run,
         )
 
-        current_global = (
-            set()
+        current_global_items = (
+            []
             if args.dry_run and should_skip_fetch(global_slug)
-            else get_collection_spaces(api, global_slug)
+            else get_collection_items(api, global_slug)
         )
+        current_global = {item.item_id for item in current_global_items}
         new_global = [s for s in global_targets if s not in current_global]
 
         logger.info("=" * 60)
@@ -644,8 +755,12 @@ Examples:
             f"  Visibility: {'private' if args.private_global_collection else 'public'}"
         )
         logger.info(f"  Current spaces: {len(current_global)}")
-        logger.info(f"  Tagged spaces discovered: {len(global_targets)}")
+        logger.info(f"  {discovery_label}: {len(global_targets)}")
         logger.info(f"  New spaces to add: {len(new_global)}")
+        logger.info(
+            f"  Stale spaces to remove: "
+            f"{len([item for item in current_global_items if item.item_id not in set(global_targets)]) if args.reconcile else 0}"
+        )
         logger.info("=" * 60)
 
         add_spaces_to_collection(
@@ -654,8 +769,16 @@ Examples:
             space_ids=new_global,
             version=args.version,
             dry_run=args.dry_run,
-            note=f"OpenEnv tag sync ({args.tag_filter})",
+            note=global_note,
         )
+        if args.reconcile:
+            remove_spaces_from_collection(
+                api=api,
+                collection_slug=global_slug,
+                current_items=current_global_items,
+                target_space_ids=global_targets,
+                dry_run=args.dry_run,
+            )
         logger.info(f"Global collection URL: https://huggingface.co/collections/{global_slug}")
 
 

--- a/scripts/prepare_hf_deployment.sh
+++ b/scripts/prepare_hf_deployment.sh
@@ -19,6 +19,7 @@ Environment selection:
 Deployment options:
   --base-sha <sha|tag>             openenv-base image ref suffix (default: latest)
   --hf-namespace <user|org>        HF namespace to deploy to (default: HF_NAMESPACE or openenv)
+  --repo-id <owner/repo>           Exact HF Space repo to update (single-env only)
   --space-suffix <suffix>          Suffix appended to each space name
                                    (default: -<openenv-version>, e.g. -0.2.1)
   --private                        Create/update spaces as private (default)
@@ -89,6 +90,7 @@ fi
 BASE_IMAGE_SHA=""
 BASE_IMAGE_REF=""
 HF_NAMESPACE="${HF_NAMESPACE:-}"
+SPACE_REPO_OVERRIDE="${SPACE_REPO_OVERRIDE:-}"
 SPACE_SUFFIX="${SPACE_SUFFIX:-}"
 STAGING_DIR="hf-staging"
 HUB_TAG="openenv"
@@ -178,6 +180,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --hf-namespace|--namespace|--hf-user|--hf-username)
             HF_NAMESPACE="$2"
+            shift 2
+            ;;
+        --repo-id|--space-repo)
+            SPACE_REPO_OVERRIDE="$2"
             shift 2
             ;;
         --space-suffix|--suffix)
@@ -318,6 +324,15 @@ discover_all_envs() {
 
 if [ "$DEPLOY_ALL" = true ]; then
     discover_all_envs
+fi
+
+if [ -n "$SPACE_REPO_OVERRIDE" ]; then
+    if [ ${#SELECTED_ENVS[@]} -ne 1 ]; then
+        error "--repo-id requires exactly one selected environment"
+    fi
+    if ! printf "%s" "$SPACE_REPO_OVERRIDE" | grep -Eq '^[^/]+/[^/]+$'; then
+        error "Invalid --repo-id '$SPACE_REPO_OVERRIDE' (expected owner/repo)"
+    fi
 fi
 
 if [ ${#SELECTED_ENVS[@]} -eq 0 ]; then
@@ -559,6 +574,7 @@ ensure_readme_front_matter_tags() {
 create_readme() {
     local env_name="$1"
     local stage_dir="$2"
+    local space_repo="$3"
     local readme_source="envs/$env_name/README.md"
     local output_readme="$stage_dir/README.md"
     local env_class="Env"
@@ -586,7 +602,7 @@ create_readme() {
 
 This Space is built from OpenEnv environment \`$env_name\`.
 
-- Space URL: \`https://huggingface.co/spaces/$HF_NAMESPACE/${env_name}${SPACE_SUFFIX}\`
+- Space URL: \`https://huggingface.co/spaces/$space_repo\`
 - OpenEnv pinned ref: \`$OPENENV_VERSION\`
 - Hub tag: \`$HUB_TAG\`
 
@@ -595,7 +611,7 @@ This Space is built from OpenEnv environment \`$env_name\`.
 \`\`\`python
 from envs.$env_name import $env_class
 
-env = $env_class(base_url="https://huggingface.co/spaces/$HF_NAMESPACE/${env_name}${SPACE_SUFFIX}")
+env = $env_class(base_url="https://huggingface.co/spaces/$space_repo")
 \`\`\`
 README_EOF
         tail -n "+$((closing_line + 1))" "$readme_source" >> "$output_readme"
@@ -613,7 +629,7 @@ tags:
 
 # ${env_name} Environment
 
-Space URL: \`https://huggingface.co/spaces/$HF_NAMESPACE/${env_name}${SPACE_SUFFIX}\`
+Space URL: \`https://huggingface.co/spaces/$space_repo\`
 
 OpenEnv pinned ref: \`$OPENENV_VERSION\`
 
@@ -637,6 +653,7 @@ README_EOF
 prepare_stage() {
     local env_name="$1"
     local stage_dir="$2"
+    local space_repo="$3"
 
     rm -rf "$stage_dir"
     mkdir -p "$stage_dir/envs"
@@ -672,13 +689,23 @@ prepare_stage() {
     pin_openenv_refs_in_pyproject "$stage_dir/envs/$env_name/pyproject.toml"
 
     create_environment_dockerfile "$env_name" "$stage_dir"
-    create_readme "$env_name" "$stage_dir"
+    create_readme "$env_name" "$stage_dir" "$space_repo"
+}
+
+resolve_space_repo() {
+    local env_name="$1"
+    if [ -n "$SPACE_REPO_OVERRIDE" ]; then
+        printf "%s" "$SPACE_REPO_OVERRIDE"
+    else
+        printf "%s/%s%s" "$HF_NAMESPACE" "$env_name" "$SPACE_SUFFIX"
+    fi
 }
 
 deploy_env() {
     local env_name="$1"
-    local stage_dir="$STAGING_DIR/$HF_NAMESPACE/$env_name$SPACE_SUFFIX"
-    local space_repo="$HF_NAMESPACE/${env_name}${SPACE_SUFFIX}"
+    local space_repo
+    space_repo=$(resolve_space_repo "$env_name")
+    local stage_dir="$STAGING_DIR/$space_repo"
 
     if ! is_deployable_env "$env_name"; then
         warn "Skipping '$env_name' (missing Dockerfile or README.md)"
@@ -687,7 +714,7 @@ deploy_env() {
     fi
 
     log "Preparing $env_name (OpenEnv ref: $OPENENV_VERSION, base image: $BASE_IMAGE_REF)"
-    prepare_stage "$env_name" "$stage_dir" || return 1
+    prepare_stage "$env_name" "$stage_dir" "$space_repo" || return 1
 
     if [ "$DRY_RUN" = true ]; then
         log "[dry-run] Would create/update space: $space_repo"

--- a/scripts/verify_private_spaces.py
+++ b/scripts/verify_private_spaces.py
@@ -9,6 +9,14 @@ from typing import Iterable, Sequence
 import requests
 from huggingface_hub import HfApi, get_token
 
+DEFAULT_SPACE_SUFFIX = "-0.2.3"
+GRADIO_HTML_MARKERS = (
+    "<gradio-app",
+    "window.gradio_config",
+    "window.__gradio_config__",
+    "gradio_api_info",
+)
+
 
 def collect_space_ids(
     api: HfApi, namespace: str, suffixes: Sequence[str], explicit: Sequence[str]
@@ -50,44 +58,229 @@ def endpoint_ok(path: str, status_code: int | None) -> bool:
     return status_code == 200
 
 
-def probe_space(base_url: str, headers: dict, timeout: float = 20.0) -> list[dict]:
-    endpoints = [
-        ("GET", "/health"),
-        ("GET", "/metadata"),
-        ("GET", "/schema"),
-        ("POST", "/mcp"),
-    ]
-    results = []
+REPL_RESET_PAYLOAD = {
+    "context": "alpha beta gamma",
+    "task_prompt": "Count the words",
+}
+REPL_STEP_PAYLOAD = {"action": {"code": "count = len(context.split())"}}
 
-    session = requests.Session()
-    for method, path in endpoints:
-        full_url = base_url.rstrip("/") + path
+
+def response_is_gradio_html(response: requests.Response, details) -> bool:
+    """Recognize a successful Gradio page after redirects."""
+    if response.status_code != 200:
+        return False
+    if "text/html" not in response.headers.get("Content-Type", ""):
+        return False
+    if not isinstance(details, str):
+        return False
+
+    normalized = details.lower()
+    return any(marker in normalized for marker in GRADIO_HTML_MARKERS)
+
+
+def extract_response_details(response: requests.Response):
+    """Return JSON when possible, otherwise trimmed text."""
+    if "application/json" in response.headers.get("Content-Type", ""):
         try:
-            response = session.request(method, full_url, headers=headers, timeout=timeout)
-            ok = endpoint_ok(path, response.status_code)
-            results.append(
-                {
-                    "path": path,
-                    "method": method,
-                    "status": response.status_code,
-                    "ok": ok,
-                    "details": response.json()
-                    if "application/json" in response.headers.get("Content-Type", "")
-                    else response.text.strip(),
-                }
-            )
-        except requests.RequestException as exc:
-            results.append(
-                {
-                    "path": path,
-                    "method": method,
-                    "status": None,
-                    "ok": False,
-                    "details": f"{exc.__class__.__name__}: {exc}",
-                }
-            )
+            return response.json()
+        except ValueError:
+            pass
+    return response.text.strip()
 
-    return results
+
+def make_probe_result(
+    method: str,
+    path: str,
+    status: int | None,
+    ok: bool,
+    details,
+    payload=None,
+) -> dict:
+    result = {
+        "path": path,
+        "method": method,
+        "status": status,
+        "ok": ok,
+        "details": details,
+    }
+    if payload is not None:
+        result["payload"] = payload
+    return result
+
+
+def run_probe_request(
+    session: requests.Session,
+    base_url: str,
+    headers: dict,
+    method: str,
+    path: str,
+    timeout: float,
+    payload=None,
+    ok_fn=None,
+) -> dict:
+    full_url = base_url.rstrip("/") + path
+    try:
+        response = session.request(
+            method,
+            full_url,
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+        )
+        details = extract_response_details(response)
+        ok = ok_fn(response, details) if ok_fn is not None else endpoint_ok(path, response.status_code)
+        return make_probe_result(method, path, response.status_code, ok, details, payload)
+    except requests.RequestException as exc:
+        return make_probe_result(
+            method,
+            path,
+            None,
+            False,
+            f"{exc.__class__.__name__}: {exc}",
+            payload,
+        )
+
+
+def probe_generic_space(
+    session: requests.Session,
+    base_url: str,
+    headers: dict,
+    timeout: float,
+) -> list[dict]:
+    endpoints = [
+        ("GET", "/health", None, None),
+        ("GET", "/metadata", None, None),
+        ("GET", "/schema", None, None),
+        ("POST", "/mcp", None, None),
+    ]
+    return [
+        run_probe_request(
+            session,
+            base_url,
+            headers,
+            method,
+            path,
+            timeout,
+            payload=payload,
+            ok_fn=ok_fn,
+        )
+        for method, path, payload, ok_fn in endpoints
+    ]
+
+
+def gradio_web_ok_html(response: requests.Response, details) -> bool:
+    return response_is_gradio_html(response, details)
+
+
+def gradio_web_ok_reset(response: requests.Response, details) -> bool:
+    return response.status_code == 200 and isinstance(details, dict) and "observation" in details
+
+
+def probe_gradio_web_space(
+    session: requests.Session,
+    base_url: str,
+    headers: dict,
+    timeout: float,
+) -> list[dict]:
+    endpoints = [
+        ("GET", "/", None, gradio_web_ok_html),
+        ("GET", "/web", None, gradio_web_ok_html),
+        ("GET", "/web/", None, gradio_web_ok_html),
+        ("GET", "/health", None, None),
+        ("GET", "/metadata", None, None),
+        ("GET", "/schema", None, None),
+        ("POST", "/reset", None, gradio_web_ok_reset),
+    ]
+    return [
+        run_probe_request(
+            session,
+            base_url,
+            headers,
+            method,
+            path,
+            timeout,
+            payload=payload,
+            ok_fn=ok_fn,
+        )
+        for method, path, payload, ok_fn in endpoints
+    ]
+
+
+def repl_web_ok_reset(response: requests.Response, details) -> bool:
+    if response.status_code != 200 or not isinstance(details, dict):
+        return False
+    observation = details.get("observation", {})
+    available_variables = observation.get("available_variables") or []
+    return (
+        observation.get("context_preview") == REPL_RESET_PAYLOAD["context"]
+        and "context" in available_variables
+    )
+
+
+def repl_web_ok_step(response: requests.Response, details) -> bool:
+    if response.status_code != 200 or not isinstance(details, dict):
+        return False
+    result = details.get("observation", {}).get("result", {})
+    locals_snapshot = result.get("locals_snapshot") or {}
+    return result.get("success") is True and str(locals_snapshot.get("count")) == "3"
+
+
+def repl_web_ok_state(response: requests.Response, details) -> bool:
+    if response.status_code != 200 or not isinstance(details, dict):
+        return False
+    namespace_keys = details.get("namespace_keys") or []
+    return (
+        details.get("context") == REPL_RESET_PAYLOAD["context"]
+        and details.get("task_prompt") == REPL_RESET_PAYLOAD["task_prompt"]
+        and "count" in namespace_keys
+    )
+
+
+def probe_repl_web_space(
+    session: requests.Session,
+    base_url: str,
+    headers: dict,
+    timeout: float,
+) -> list[dict]:
+    endpoints = [
+        ("GET", "/", None, gradio_web_ok_html),
+        ("GET", "/web", None, gradio_web_ok_html),
+        ("GET", "/web/", None, gradio_web_ok_html),
+        ("GET", "/health", None, None),
+        ("GET", "/metadata", None, None),
+        ("GET", "/schema", None, None),
+        ("POST", "/mcp", None, None),
+        ("POST", "/web/reset", REPL_RESET_PAYLOAD, repl_web_ok_reset),
+        ("POST", "/web/step", REPL_STEP_PAYLOAD, repl_web_ok_step),
+        ("GET", "/web/state", None, repl_web_ok_state),
+    ]
+    return [
+        run_probe_request(
+            session,
+            base_url,
+            headers,
+            method,
+            path,
+            timeout,
+            payload=payload,
+            ok_fn=ok_fn,
+        )
+        for method, path, payload, ok_fn in endpoints
+    ]
+
+
+def probe_space(
+    base_url: str,
+    headers: dict,
+    timeout: float = 20.0,
+    probe_profile: str = "generic",
+) -> list[dict]:
+    session = requests.Session()
+    if probe_profile == "repl_web":
+        return probe_repl_web_space(session, base_url, headers, timeout)
+    if probe_profile == "gradio_web":
+        return probe_gradio_web_space(session, base_url, headers, timeout)
+    return probe_generic_space(session, base_url, headers, timeout)
 
 
 def stage_is_healthy(stage: str | None) -> bool:
@@ -107,7 +300,10 @@ def main() -> None:
         "--suffix",
         action="append",
         default=[],
-        help="Suffix to match Spaces names (repeatable; defaults to -0.2.2 when omitted).",
+        help=(
+            "Suffix to match Spaces names "
+            f"(repeatable; defaults to {DEFAULT_SPACE_SUFFIX} when omitted)."
+        ),
     )
     parser.add_argument(
         "--space-id",
@@ -115,8 +311,20 @@ def main() -> None:
         default=[],
         help="Explicit Space id to include (repeatable).",
     )
+    parser.add_argument(
+        "--probe-profile",
+        choices=["generic", "gradio_web", "repl_web"],
+        default="generic",
+        help="Probe contract to validate (default: generic).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=20.0,
+        help="Per-request timeout in seconds (default: 20).",
+    )
     args = parser.parse_args()
-    suffixes = args.suffix or ([] if args.space_id else ["-0.2.2"])
+    suffixes = args.suffix or ([] if args.space_id else [DEFAULT_SPACE_SUFFIX])
 
     token = get_token()
     if not token:
@@ -149,7 +357,12 @@ def main() -> None:
             for candidate in domain_candidates:
                 domain_name = candidate["domain"]
                 base_url = f"https://{domain_name}"
-                checks = probe_space(base_url, headers)
+                checks = probe_space(
+                    base_url,
+                    headers,
+                    timeout=args.timeout,
+                    probe_profile=args.probe_profile,
+                )
                 success = all(check["ok"] for check in checks)
                 domain_attempts.append(
                     {
@@ -173,6 +386,7 @@ def main() -> None:
                 "domain": chosen_domain
                 or (domain_candidates[0]["domain"] if domain_candidates else None),
                 "runtime_error": error_message,
+                "probe_profile": args.probe_profile,
                 "checks": domain_attempts[-1]["checks"] if domain_attempts else [],
                 "success": space_success,
                 "domain_attempts": domain_attempts,

--- a/src/openenv/__init__.py
+++ b/src/openenv/__init__.py
@@ -14,10 +14,18 @@ __all__ = [
     "SyncEnvClient",
 ]
 
-try:
-    __version__ = metadata.version("openenv")  # type: ignore[arg-type]
-except metadata.PackageNotFoundError:  # pragma: no cover - local dev
-    __version__ = "0.0.0"
+
+def _load_package_version() -> str:
+    """Resolve the installed distribution version for the OpenEnv package."""
+    for distribution_name in ("openenv-core", "openenv"):
+        try:
+            return metadata.version(distribution_name)
+        except metadata.PackageNotFoundError:
+            continue
+    return "0.0.0"
+
+
+__version__ = _load_package_version()
 
 
 _LAZY_MODULES = {

--- a/src/openenv/core/env_server/web_interface.py
+++ b/src/openenv/core/env_server/web_interface.py
@@ -15,13 +15,15 @@ option (e.g. openenv push --enable-interface) or ENABLE_WEB_INTERFACE env var.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Type
 
 import gradio as gr
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import Body, FastAPI, HTTPException, WebSocket, WebSocketDisconnect, status
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from .gradio_theme import OPENENV_GRADIO_CSS, OPENENV_GRADIO_THEME
@@ -269,6 +271,28 @@ class WebInterfaceManager:
         # Thread pool for running sync code (e.g., Playwright sync API) in async context
         self._executor = ThreadPoolExecutor(max_workers=1)
 
+    @staticmethod
+    def _get_valid_kwargs(
+        sig: inspect.Signature,
+        kwargs: Dict[str, Any],
+        skip_params: Optional[set[str]] = None,
+    ) -> Dict[str, Any]:
+        """Filter kwargs to only those accepted by the target function."""
+        skip_params = skip_params or set()
+        valid_kwargs: Dict[str, Any] = {}
+        has_var_kwargs = any(
+            param.kind == inspect.Parameter.VAR_KEYWORD
+            for param in sig.parameters.values()
+        )
+
+        for key, value in kwargs.items():
+            if key in skip_params:
+                continue
+            if key in sig.parameters or has_var_kwargs:
+                valid_kwargs[key] = value
+
+        return valid_kwargs
+
     async def _run_sync_in_thread_pool(self, func, *args, **kwargs):
         """Run a synchronous function in the thread pool executor.
 
@@ -317,11 +341,22 @@ class WebInterfaceManager:
         for client in disconnected_clients:
             self.connected_clients.remove(client)
 
-    async def reset_environment(self) -> Dict[str, Any]:
+    async def reset_environment(
+        self, reset_kwargs: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         """Reset the environment and update state."""
-        # Run sync reset in thread pool to avoid blocking event loop
-        # and to support environments using sync libraries (e.g., Playwright)
-        observation: Observation = await self._run_sync_in_thread_pool(self.env.reset)
+        reset_kwargs = reset_kwargs or {}
+
+        is_async = self.env.reset_async.__func__ is not Environment.reset_async
+        sig = inspect.signature(self.env.reset_async if is_async else self.env.reset)
+        valid_kwargs = self._get_valid_kwargs(sig, reset_kwargs)
+
+        if is_async:
+            observation = await self.env.reset_async(**valid_kwargs)
+        else:
+            # Run sync reset in thread pool to avoid blocking event loop
+            # and to support environments using sync libraries (e.g., Playwright)
+            observation = await self._run_sync_in_thread_pool(self.env.reset, **valid_kwargs)
         state: State = self.env.state
 
         # Serialize observation once using shared utility
@@ -428,6 +463,16 @@ def create_web_interface_app(
     web_manager = WebInterfaceManager(env, action_cls, observation_cls, metadata)
 
     # Web API routes first (so they take precedence over Gradio mount at /web)
+    @app.get("/", include_in_schema=False)
+    async def web_root():
+        """Redirect the app root to the Gradio interface."""
+        return RedirectResponse(url="/web/")
+
+    @app.get("/web", include_in_schema=False)
+    async def web_root_no_slash():
+        """Redirect /web to /web/ for mounted Gradio deployments behind proxies."""
+        return RedirectResponse(url="/web/")
+
     @app.get("/web/metadata")
     async def web_metadata():
         """Get environment metadata."""
@@ -449,9 +494,9 @@ def create_web_interface_app(
             await web_manager.disconnect_websocket(websocket)
 
     @app.post("/web/reset")
-    async def web_reset():
+    async def web_reset(request: Optional[Dict[str, Any]] = Body(default=None)):
         """Reset endpoint for web interface."""
-        return await web_manager.reset_environment()
+        return await web_manager.reset_environment(request)
 
     @app.post("/web/step")
     async def web_step(request: Dict[str, Any]):
@@ -475,7 +520,13 @@ def create_web_interface_app(
     @app.get("/web/state")
     async def web_state():
         """State endpoint for web interface."""
-        return web_manager.get_state()
+        try:
+            return web_manager.get_state()
+        except RuntimeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(exc),
+            ) from exc
 
     action_fields = _extract_action_fields(action_cls)
     is_chat_env = _is_chat_env(action_cls)
@@ -505,7 +556,7 @@ def create_web_interface_app(
             )
         gradio_blocks = gr.TabbedInterface(
             [default_blocks, custom_blocks],
-            tab_names=["Playground", "Visualization"],
+            tab_names=["Playground", "Custom"],
             title=get_gradio_display_title(metadata),
         )
     else:

--- a/src/openenv/core/env_server/web_interface.py
+++ b/src/openenv/core/env_server/web_interface.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Type
 
 import gradio as gr
-from fastapi import Body, FastAPI, HTTPException, WebSocket, WebSocketDisconnect, status
+from fastapi import Body, FastAPI, HTTPException, status, WebSocket, WebSocketDisconnect
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -356,7 +356,9 @@ class WebInterfaceManager:
         else:
             # Run sync reset in thread pool to avoid blocking event loop
             # and to support environments using sync libraries (e.g., Playwright)
-            observation = await self._run_sync_in_thread_pool(self.env.reset, **valid_kwargs)
+            observation = await self._run_sync_in_thread_pool(
+                self.env.reset, **valid_kwargs
+            )
         state: State = self.env.state
 
         # Serialize observation once using shared utility

--- a/tests/core/test_package_version.py
+++ b/tests/core/test_package_version.py
@@ -1,0 +1,45 @@
+"""Tests for package version resolution."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+import openenv
+
+
+def test_load_package_version_prefers_openenv_core(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_version(distribution_name: str) -> str:
+        calls.append(distribution_name)
+        if distribution_name == "openenv-core":
+            return "0.2.3"
+        raise metadata.PackageNotFoundError
+
+    monkeypatch.setattr(openenv.metadata, "version", fake_version)
+
+    assert openenv._load_package_version() == "0.2.3"
+    assert calls == ["openenv-core"]
+
+
+def test_load_package_version_falls_back_to_openenv(monkeypatch) -> None:
+    def fake_version(distribution_name: str) -> str:
+        if distribution_name == "openenv-core":
+            raise metadata.PackageNotFoundError
+        if distribution_name == "openenv":
+            return "0.2.0"
+        raise AssertionError(f"Unexpected distribution name: {distribution_name}")
+
+    monkeypatch.setattr(openenv.metadata, "version", fake_version)
+
+    assert openenv._load_package_version() == "0.2.0"
+
+
+def test_load_package_version_returns_zero_when_uninstalled(monkeypatch) -> None:
+    monkeypatch.setattr(
+        openenv.metadata,
+        "version",
+        lambda distribution_name: (_ for _ in ()).throw(metadata.PackageNotFoundError),
+    )
+
+    assert openenv._load_package_version() == "0.0.0"

--- a/tests/core/test_web_interface.py
+++ b/tests/core/test_web_interface.py
@@ -1,0 +1,172 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the OpenEnv Gradio web interface helpers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from openenv.core.env_server.interfaces import Environment
+from openenv.core.env_server.types import Action, Observation, State
+from openenv.core.env_server.web_interface import create_web_interface_app
+
+pytest.importorskip("gradio", reason="gradio is not installed")
+pytest.importorskip("smolagents", reason="smolagents is not installed")
+
+from repl_env.models import REPLAction, REPLObservation
+from repl_env.server.repl_environment import REPLEnvironment
+
+
+class NoKwargAction(Action):
+    """Minimal action for exercising the web wrapper."""
+
+    message: str = "noop"
+
+
+class NoKwargObservation(Observation):
+    """Minimal observation for exercising the web wrapper."""
+
+    response: str
+    reward: float | None = None
+    done: bool = False
+
+
+class NoKwargState(State):
+    """Minimal state for exercising the web wrapper."""
+
+    step_count: int = 0
+    last_reset_marker: str = "default"
+
+
+class NoKwargEnvironment(Environment):
+    """Environment whose reset signature intentionally accepts no kwargs."""
+
+    def __init__(self):
+        super().__init__()
+        self._state = NoKwargState()
+
+    def reset(self) -> NoKwargObservation:
+        self._state = NoKwargState(step_count=0, last_reset_marker="default")
+        return NoKwargObservation(response="reset")
+
+    def step(self, action: NoKwargAction) -> NoKwargObservation:
+        self._state.step_count += 1
+        return NoKwargObservation(response=action.message, reward=0.0, done=False)
+
+    @property
+    def state(self) -> NoKwargState:
+        return self._state
+
+    def close(self) -> None:
+        pass
+
+
+def test_web_reset_accepts_no_body_and_ignores_unsupported_kwargs() -> None:
+    """POST /web/reset should preserve old behavior and ignore unsupported kwargs."""
+    app = create_web_interface_app(
+        NoKwargEnvironment,
+        NoKwargAction,
+        NoKwargObservation,
+    )
+    client = TestClient(app)
+
+    no_body = client.post("/web/reset")
+    assert no_body.status_code == 200
+    assert no_body.json()["observation"]["response"] == "reset"
+
+    extra_body = client.post("/web/reset", json={"unused": "value"})
+    assert extra_body.status_code == 200
+    assert extra_body.json()["observation"]["response"] == "reset"
+
+    state = client.get("/web/state")
+    assert state.status_code == 200
+    assert state.json()["last_reset_marker"] == "default"
+
+
+def test_web_root_redirects_to_gradio_interface() -> None:
+    """GET / should redirect to /web/ so HF Space embeds have a live root page."""
+    app = create_web_interface_app(
+        NoKwargEnvironment,
+        NoKwargAction,
+        NoKwargObservation,
+    )
+    client = TestClient(app)
+
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/web/"
+
+    web_response = client.get("/web", follow_redirects=False)
+    assert web_response.status_code == 307
+    assert web_response.headers["location"] == "/web/"
+
+
+def test_repl_web_state_before_reset_returns_conflict() -> None:
+    """GET /web/state should fail cleanly before reset instead of crashing."""
+    app = create_web_interface_app(
+        REPLEnvironment,
+        REPLAction,
+        REPLObservation,
+        env_name="repl_env",
+    )
+    client = TestClient(app)
+
+    response = client.get("/web/state")
+    assert response.status_code == 409
+    assert "Call reset() first" in response.json()["detail"]
+
+
+def test_repl_web_reset_passes_context_and_task_prompt_without_echoing_hf_token() -> None:
+    """The REPL web flow should accept reset kwargs and keep the token out of state."""
+    app = create_web_interface_app(
+        REPLEnvironment,
+        REPLAction,
+        REPLObservation,
+        env_name="repl_env",
+    )
+    client = TestClient(app)
+
+    reset_response = client.post(
+        "/web/reset",
+        json={
+            "context": "alpha beta gamma",
+            "task_prompt": "Count the words",
+            "hf_token": "super-secret-token",
+        },
+    )
+    assert reset_response.status_code == 200
+    reset_json = reset_response.json()
+    assert reset_json["observation"]["context_preview"] == "alpha beta gamma"
+    assert "context" in reset_json["observation"]["available_variables"]
+
+    step_response = client.post(
+        "/web/step",
+        json={"action": {"code": "count = len(context.split())"}},
+    )
+    assert step_response.status_code == 200
+    step_json = step_response.json()
+    assert step_json["observation"]["result"]["success"] is True
+    assert step_json["observation"]["result"]["locals_snapshot"]["count"] == "3"
+
+    state_response = client.get("/web/state")
+    assert state_response.status_code == 200
+    state_json = state_response.json()
+    assert state_json["context"] == "alpha beta gamma"
+    assert state_json["task_prompt"] == "Count the words"
+    assert "count" in state_json["namespace_keys"]
+
+    combined_output = json.dumps(
+        {
+            "reset": reset_json,
+            "step": step_json,
+            "state": state_json,
+        }
+    )
+    assert "super-secret-token" not in combined_output

--- a/tests/core/test_web_interface.py
+++ b/tests/core/test_web_interface.py
@@ -12,7 +12,6 @@ import json
 
 import pytest
 from fastapi.testclient import TestClient
-
 from openenv.core.env_server.interfaces import Environment
 from openenv.core.env_server.types import Action, Observation, State
 from openenv.core.env_server.web_interface import create_web_interface_app
@@ -123,7 +122,9 @@ def test_repl_web_state_before_reset_returns_conflict() -> None:
     assert "Call reset() first" in response.json()["detail"]
 
 
-def test_repl_web_reset_passes_context_and_task_prompt_without_echoing_hf_token() -> None:
+def test_repl_web_reset_passes_context_and_task_prompt_without_echoing_hf_token() -> (
+    None
+):
     """The REPL web flow should accept reset kwargs and keep the token out of state."""
     app = create_web_interface_app(
         REPLEnvironment,

--- a/tests/envs/test_repl_env.py
+++ b/tests/envs/test_repl_env.py
@@ -6,7 +6,12 @@
 
 """Tests for the REPL Environment."""
 
+import importlib
+import os
+import subprocess
+import sys
 import time
+from pathlib import Path
 
 import pytest
 
@@ -37,6 +42,50 @@ class TestPythonExecutor:
         result = executor.execute("print('hello world')")
         assert result["success"]
         assert "hello world" in result["stdout"]
+
+    def test_server_package_import_from_env_root(self, monkeypatch):
+        """Importing `server.repl_environment` from env root should work."""
+        env_root = Path(__file__).resolve().parents[2] / "envs" / "repl_env"
+        monkeypatch.syspath_prepend(str(env_root))
+
+        for module_name in [
+            "server",
+            "server.python_executor",
+            "server.repl_environment",
+        ]:
+            sys.modules.pop(module_name, None)
+
+        module = importlib.import_module("server.repl_environment")
+        assert hasattr(module, "REPLEnvironment")
+
+    def test_server_app_imports_from_env_root_without_path_rewrite(self):
+        """Importing server.app from env root should work without bundled-src hacks."""
+        env_root = Path(__file__).resolve().parents[2] / "envs" / "repl_env"
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "--project",
+                ".",
+                "python",
+                "-c",
+                (
+                    "import importlib; "
+                    "importlib.import_module('server.app'); "
+                    "print('ok')"
+                ),
+            ],
+            cwd=env_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert result.stdout.strip().splitlines()[-1] == "ok"
 
     def test_stderr_capture(self):
         """Test stderr is captured correctly via exception handling.

--- a/tests/scripts/test_manage_hf_collection.py
+++ b/tests/scripts/test_manage_hf_collection.py
@@ -370,13 +370,70 @@ class TestAddSpacesToCollection:
         assert result == 1  # Only first one succeeded
 
 
+class TestRemoveSpacesFromCollection:
+    """Tests for collection reconciliation removals."""
+
+    def test_remove_spaces_dry_run(self):
+        """Dry-run reconcile should report removals without mutating the API."""
+        mock_api = Mock()
+        current_items = []
+
+        keep_item = Mock()
+        keep_item.item_id = "openenv/repl"
+        keep_item.item_object_id = "obj-keep"
+        current_items.append(keep_item)
+
+        stale_item = Mock()
+        stale_item.item_id = "third-party/example"
+        stale_item.item_object_id = "obj-stale"
+        current_items.append(stale_item)
+
+        result = manage_hf_collection.remove_spaces_from_collection(
+            mock_api,
+            "openenv/environment-hub-test",
+            current_items=current_items,
+            target_space_ids=["openenv/repl"],
+            dry_run=True,
+        )
+
+        assert result == 1
+        mock_api.delete_collection_item.assert_not_called()
+
+    def test_remove_spaces_success(self):
+        """Reconcile should delete collection entries that are not in the target set."""
+        mock_api = Mock()
+
+        keep_item = Mock()
+        keep_item.item_id = "openenv/repl"
+        keep_item.item_object_id = "obj-keep"
+
+        stale_item = Mock()
+        stale_item.item_id = "third-party/example"
+        stale_item.item_object_id = "obj-stale"
+
+        result = manage_hf_collection.remove_spaces_from_collection(
+            mock_api,
+            "openenv/environment-hub-test",
+            current_items=[keep_item, stale_item],
+            target_space_ids=["openenv/repl"],
+            dry_run=False,
+        )
+
+        assert result == 1
+        mock_api.delete_collection_item.assert_called_once_with(
+            collection_slug="openenv/environment-hub-test",
+            item_object_id="obj-stale",
+            missing_ok=True,
+        )
+
+
 class TestMain:
     """Tests for the main function."""
 
     @patch("manage_hf_collection.setup_api")
     @patch("manage_hf_collection.resolve_collection_slug")
-    @patch("manage_hf_collection.get_collection_spaces")
-    @patch("manage_hf_collection.discover_openenv_spaces")
+    @patch("manage_hf_collection.get_collection_items")
+    @patch("manage_hf_collection.discover_canonical_openenv_spaces")
     @patch("manage_hf_collection.add_spaces_to_collection")
     @patch("sys.argv", ["manage_hf_collection.py", "--dry-run"])
     def test_main_dry_run(
@@ -391,7 +448,9 @@ class TestMain:
         mock_api = Mock()
         mock_setup_api.return_value = mock_api
         mock_resolve_slug.return_value = "openenv/environment-hub-test"
-        mock_get_collection.return_value = {"owner1/space1"}
+        mock_item = Mock()
+        mock_item.item_id = "owner1/space1"
+        mock_get_collection.return_value = [mock_item]
         mock_discover.return_value = ["owner1/space1", "owner2/space2"]
         mock_add_spaces.return_value = 1
 
@@ -404,8 +463,50 @@ class TestMain:
 
     @patch("manage_hf_collection.setup_api")
     @patch("manage_hf_collection.resolve_collection_slug")
-    @patch("manage_hf_collection.get_collection_spaces")
-    @patch("manage_hf_collection.discover_openenv_spaces")
+    @patch("manage_hf_collection.get_collection_items")
+    @patch("manage_hf_collection.discover_canonical_openenv_spaces")
+    @patch("manage_hf_collection.remove_spaces_from_collection")
+    @patch("manage_hf_collection.add_spaces_to_collection")
+    @patch("sys.argv", ["manage_hf_collection.py", "--reconcile"])
+    def test_main_reconcile_removes_stale_spaces(
+        self,
+        mock_add_spaces,
+        mock_remove_spaces,
+        mock_discover,
+        mock_get_collection_items,
+        mock_resolve_slug,
+        mock_setup_api,
+    ):
+        """Reconcile mode should remove spaces outside the resolved target set."""
+        mock_api = Mock()
+        mock_setup_api.return_value = mock_api
+        mock_resolve_slug.return_value = "openenv/environment-hub-test"
+
+        keep_item = Mock()
+        keep_item.item_id = "owner1/space1"
+        keep_item.item_object_id = "obj-keep"
+
+        stale_item = Mock()
+        stale_item.item_id = "owner2/space2"
+        stale_item.item_object_id = "obj-stale"
+
+        mock_get_collection_items.return_value = [keep_item, stale_item]
+        mock_discover.return_value = ["owner1/space1"]
+        mock_add_spaces.return_value = 0
+        mock_remove_spaces.return_value = 1
+
+        manage_hf_collection.main()
+
+        mock_remove_spaces.assert_called_once()
+        _, kwargs = mock_remove_spaces.call_args
+        assert kwargs["collection_slug"] == "openenv/environment-hub-test"
+        assert kwargs["target_space_ids"] == ["owner1/space1"]
+        assert kwargs["current_items"] == [keep_item, stale_item]
+
+    @patch("manage_hf_collection.setup_api")
+    @patch("manage_hf_collection.resolve_collection_slug")
+    @patch("manage_hf_collection.get_collection_items")
+    @patch("manage_hf_collection.discover_canonical_openenv_spaces")
     @patch("manage_hf_collection.add_spaces_to_collection")
     @patch("sys.argv", ["manage_hf_collection.py"])
     def test_main_finds_new_spaces(
@@ -420,7 +521,11 @@ class TestMain:
         mock_api = Mock()
         mock_setup_api.return_value = mock_api
         mock_resolve_slug.return_value = "openenv/environment-hub-test"
-        mock_get_collection.return_value = {"owner1/space1", "owner2/space2"}
+        item1 = Mock()
+        item1.item_id = "owner1/space1"
+        item2 = Mock()
+        item2.item_id = "owner2/space2"
+        mock_get_collection.return_value = [item1, item2]
         mock_discover.return_value = ["owner1/space1", "owner2/space2", "owner3/space3"]
         mock_add_spaces.return_value = 1
 
@@ -434,8 +539,8 @@ class TestMain:
 
     @patch("manage_hf_collection.setup_api")
     @patch("manage_hf_collection.resolve_collection_slug")
-    @patch("manage_hf_collection.get_collection_spaces")
-    @patch("manage_hf_collection.discover_openenv_spaces")
+    @patch("manage_hf_collection.get_collection_items")
+    @patch("manage_hf_collection.discover_canonical_openenv_spaces")
     @patch("manage_hf_collection.add_spaces_to_collection")
     @patch("sys.argv", ["manage_hf_collection.py", "--verbose"])
     def test_main_verbose(
@@ -450,7 +555,7 @@ class TestMain:
         mock_api = Mock()
         mock_setup_api.return_value = mock_api
         mock_resolve_slug.return_value = "openenv/environment-hub-test"
-        mock_get_collection.return_value = set()
+        mock_get_collection.return_value = []
         mock_discover.return_value = []
         mock_add_spaces.return_value = 0
 
@@ -459,14 +564,44 @@ class TestMain:
 
         mock_setup_api.assert_called_once()
 
+    @patch("manage_hf_collection.setup_api")
+    @patch("manage_hf_collection.resolve_collection_slug")
+    @patch("manage_hf_collection.get_collection_items")
+    @patch("manage_hf_collection.discover_openenv_spaces")
+    @patch("manage_hf_collection.discover_canonical_openenv_spaces")
+    @patch("manage_hf_collection.add_spaces_to_collection")
+    @patch("sys.argv", ["manage_hf_collection.py", "--global-scope", "tagged"])
+    def test_main_tagged_scope_uses_tag_discovery(
+        self,
+        mock_add_spaces,
+        mock_discover_canonical,
+        mock_discover_tagged,
+        mock_get_collection,
+        mock_resolve_slug,
+        mock_setup_api,
+    ):
+        """Tagged scope should keep the old broad-discovery behavior when requested."""
+        mock_api = Mock()
+        mock_setup_api.return_value = mock_api
+        mock_resolve_slug.return_value = "openenv/environment-hub-test"
+        mock_get_collection.return_value = []
+        mock_discover_tagged.return_value = ["owner1/space1"]
+        mock_discover_canonical.return_value = ["openenv/repl"]
+        mock_add_spaces.return_value = 1
+
+        manage_hf_collection.main()
+
+        mock_discover_tagged.assert_called_once_with(mock_api, "openenv")
+        mock_discover_canonical.assert_not_called()
+
 
 class TestIdempotency:
     """Tests to verify idempotent behavior."""
 
     @patch("manage_hf_collection.setup_api")
     @patch("manage_hf_collection.resolve_collection_slug")
-    @patch("manage_hf_collection.get_collection_spaces")
-    @patch("manage_hf_collection.discover_openenv_spaces")
+    @patch("manage_hf_collection.get_collection_items")
+    @patch("manage_hf_collection.discover_canonical_openenv_spaces")
     @patch("manage_hf_collection.add_spaces_to_collection")
     @patch("sys.argv", ["manage_hf_collection.py"])
     def test_no_new_spaces_does_nothing(
@@ -481,7 +616,11 @@ class TestIdempotency:
         mock_api = Mock()
         mock_setup_api.return_value = mock_api
         mock_resolve_slug.return_value = "openenv/environment-hub-test"
-        mock_get_collection.return_value = {"owner1/space1", "owner2/space2"}
+        item1 = Mock()
+        item1.item_id = "owner1/space1"
+        item2 = Mock()
+        item2.item_id = "owner2/space2"
+        mock_get_collection.return_value = [item1, item2]
         mock_discover.return_value = ["owner1/space1", "owner2/space2"]
         mock_add_spaces.return_value = 0
 

--- a/tests/scripts/test_prepare_hf_deployment.py
+++ b/tests/scripts/test_prepare_hf_deployment.py
@@ -1,0 +1,46 @@
+"""Tests for the Hugging Face deployment shell helper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_prepare_hf_deployment_repo_id_override(tmp_path: Path) -> None:
+    """An exact repo override should target the canonical repo and README URLs."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "prepare_hf_deployment.sh"
+    staging_dir = tmp_path / "hf-staging"
+
+    env = os.environ.copy()
+    env["OPENENV_VERSION"] = "main"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(script_path),
+            "--env",
+            "repl_env",
+            "--repo-id",
+            "openenv/repl",
+            "--dry-run",
+            "--skip-collection",
+            "--staging-dir",
+            str(staging_dir),
+        ],
+        cwd=repo_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "[dry-run] Would create/update space: openenv/repl" in result.stdout
+
+    generated_readme = staging_dir / "openenv" / "repl" / "README.md"
+    assert generated_readme.exists()
+    readme_text = generated_readme.read_text()
+    assert "https://huggingface.co/spaces/openenv/repl" in readme_text
+    assert "https://huggingface.co/spaces/openenv/repl_env" not in readme_text

--- a/tests/scripts/test_verify_private_spaces.py
+++ b/tests/scripts/test_verify_private_spaces.py
@@ -1,0 +1,93 @@
+"""Tests for the Hugging Face Space verification helper."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import Mock, patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+import verify_private_spaces
+
+
+def make_response(
+    *,
+    status_code: int = 200,
+    content_type: str = "text/html; charset=utf-8",
+) -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.headers = {"Content-Type": content_type}
+    return response
+
+
+def test_gradio_web_ok_html_accepts_gradio_markers() -> None:
+    response = make_response()
+
+    assert verify_private_spaces.gradio_web_ok_html(
+        response,
+        "<html><body><gradio-app></gradio-app></body></html>",
+    )
+
+
+def test_gradio_web_ok_html_rejects_non_gradio_html() -> None:
+    response = make_response()
+
+    assert not verify_private_spaces.gradio_web_ok_html(
+        response,
+        "<html><title>404 - Hugging Face</title><body>Not Found</body></html>",
+    )
+
+
+def test_gradio_web_ok_reset_requires_observation_payload() -> None:
+    response = make_response(content_type="application/json")
+
+    assert verify_private_spaces.gradio_web_ok_reset(response, {"observation": {"text": "ok"}})
+    assert not verify_private_spaces.gradio_web_ok_reset(response, {"state": {}})
+
+
+@patch("verify_private_spaces.run_probe_request")
+def test_probe_gradio_web_space_checks_root_and_reset(mock_run_probe_request) -> None:
+    mock_run_probe_request.side_effect = (
+        lambda session, base_url, headers, method, path, timeout, payload=None, ok_fn=None: {
+            "method": method,
+            "path": path,
+            "payload": payload,
+            "ok": True,
+        }
+    )
+
+    results = verify_private_spaces.probe_gradio_web_space(
+        Mock(),
+        "https://example.com",
+        {},
+        5.0,
+    )
+
+    assert [result["path"] for result in results] == [
+        "/",
+        "/web",
+        "/web/",
+        "/health",
+        "/metadata",
+        "/schema",
+        "/reset",
+    ]
+    assert results[-1]["method"] == "POST"
+    assert results[-1]["payload"] is None
+
+
+@patch("verify_private_spaces.probe_gradio_web_space")
+def test_probe_space_dispatches_gradio_web(mock_probe_gradio_web_space) -> None:
+    mock_probe_gradio_web_space.return_value = [{"ok": True}]
+
+    result = verify_private_spaces.probe_space(
+        "https://example.com",
+        headers={},
+        timeout=5.0,
+        probe_profile="gradio_web",
+    )
+
+    assert result == [{"ok": True}]
+    mock_probe_gradio_web_space.assert_called_once()

--- a/tests/scripts/test_verify_private_spaces.py
+++ b/tests/scripts/test_verify_private_spaces.py
@@ -43,7 +43,9 @@ def test_gradio_web_ok_html_rejects_non_gradio_html() -> None:
 def test_gradio_web_ok_reset_requires_observation_payload() -> None:
     response = make_response(content_type="application/json")
 
-    assert verify_private_spaces.gradio_web_ok_reset(response, {"observation": {"text": "ok"}})
+    assert verify_private_spaces.gradio_web_ok_reset(
+        response, {"observation": {"text": "ok"}}
+    )
     assert not verify_private_spaces.gradio_web_ok_reset(response, {"state": {}})
 
 


### PR DESCRIPTION
## Release PR: v0.2.3

### Summary
- release `openenv-core==0.2.3` from the current shared-core state
- ship the Gradio root-path fixes (`/` -> `/web/`, `/web` -> `/web/`, `/web/state` -> `409`, `/web/reset` kwargs)
- add the `gradio_web`/expanded `repl_web` Hub probes and make canonical collection sync the default global behavior
- keep the REPL Gradio control panel and canonical rollout helpers needed for the Hub sweep

### Validation
- `PYTHONPATH=src:envs uv run --with smolagents --with gradio pytest tests/core/test_web_interface.py tests/core/test_package_version.py tests/envs/test_repl_env.py tests/scripts/test_manage_hf_collection.py tests/scripts/test_prepare_hf_deployment.py tests/scripts/test_verify_private_spaces.py -q`
- `uv run python -c "import openenv; print(openenv.__version__)"` -> `0.2.3`
- `uv run --with build --with twine python -m build`
- `uv run --with twine twine check dist/*`

### Notes
- `hf-staging/` and the generated `envs/repl_env/uv.lock` are intentionally left out of this PR.
- The REPL env no longer relies on the temporary bundled-`src/openenv` bootstrap; the `0.2.3` rollout path is the shared-core release.