### PR TITLE
Documentation fix

### DIFF
--- a/tutorial/02-deployment.md
+++ b/tutorial/02-deployment.md
@@ -410,7 +410,7 @@ from echo_env import EchoEnv, EchoAction
 
 # Async (recommended)
 async def main():
-    async with EchoEnv(base_url="http://localhost:8000") as env:
+    async with EchoEnv(base_url="http://localhost:7860") as env:
         result = await env.reset()
         print(result.observation)
         result = await env.step(EchoAction(message="Hello"))

--- a/tutorial/02-deployment.md
+++ b/tutorial/02-deployment.md
@@ -419,7 +419,7 @@ async def main():
 asyncio.run(main())
 
 # Sync (using .sync() wrapper)
-with EchoEnv(base_url="http://localhost:8000").sync() as env:
+with EchoEnv(base_url="http://localhost:7860").sync() as env:
     result = env.reset()
     print(result.observation)
     result = env.step(EchoAction(message="Hello"))


### PR DESCRIPTION
## Summary

Fixes a documentation inconsistency where the Docker example exposes port `7860` but the Python client connects to `localhost:8000`. Updated the client examples to use the correct port so they match the Docker configuration.

Fixes #501

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Documentation
* [ ] New environment
* [ ] Refactoring

## Alignment Checklist

Before submitting, verify:

* [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
* [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
* [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status

* [x] Not required (bug fix, docs, minor refactoring)
* [ ] RFC exists: #___
* [ ] RFC needed (will create before merge)

## Test Plan

1. Run the Docker container:

   ```bash
   docker run -it -p 7860:7860 registry.hf.space/openenv-echo-env:latest
   ```
2. Verify the server is running:

   ```bash
   curl http://localhost:7860/health
   ```
3. Run the Python example with:

   ```python
   EchoEnv(base_url="http://localhost:7860")
   ```
4. Confirm that `reset()` and `step()` work without connection errors.

## Claude Code Review

N/A
