### PR TITLE
[tbench2] update deps and fix evaluate reward always returning 0

### DIFF
--- a/envs/tbench2_env/pyproject.toml
+++ b/envs/tbench2_env/pyproject.toml
@@ -15,22 +15,19 @@ description = "Tbench2 Env environment for OpenEnv"
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv runtime (provides FastAPI server + HTTP client types)
-    # install from github
-    "openenv-core[core]>=0.2.2",
-    "pytest>=8.4.0",
+    "openenv-core[core]>=0.2.3",
     # Environment-specific dependencies
-    # Add all dependencies needed for your environment here
-    "camel-ai",
+    "camel-ai>=0.2.90",
     # Docker-backed mode (optional, for full TB2.0 compatibility)
-    "docker>=7.0.0",
-     # TOML parsing (tomllib for Python 3.11+, tomli for older versions)
-    "tomli>=2.0.0; python_version < '3.11'",
+    "docker>=7.1.0",
+    # TOML parsing (tomllib for Python 3.11+, tomli for older versions)
+    "tomli>=2.4.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0.0",
-    "pytest-cov>=4.0.0",
+    "pytest>=9.0.0",
+    "pytest-cov>=7.0.0",
 ]
 
 [project.scripts]

--- a/envs/tbench2_env/server/app.py
+++ b/envs/tbench2_env/server/app.py
@@ -26,6 +26,10 @@ Usage:
 
     # Or run directly:
     python -m server.app
+
+Environment Variables:
+    TB2_MODE: Execution mode - "local" (default), "docker", or "auto"
+    MAX_CONCURRENT_ENVS: Maximum concurrent WebSocket sessions (default: 8)
 """
 
 import os
@@ -67,12 +71,14 @@ else:
 
 
 # Create the app with web interface and README integration
+max_concurrent = int(os.getenv("MAX_CONCURRENT_ENVS", "8"))
+
 app = create_app(
     _DEFAULT_ENVIRONMENT,
     Tbench2Action,
     Tbench2Observation,
     env_name="tbench2_env" + _ENV_SUFFIX,
-    max_concurrent_envs=1,  # increase this number to allow more concurrent WebSocket sessions
+    max_concurrent_envs=max_concurrent,
 )
 
 

--- a/envs/tbench2_env/server/tbench2_env_environment.py
+++ b/envs/tbench2_env/server/tbench2_env_environment.py
@@ -150,6 +150,7 @@ class Tbench2Environment(Environment[Tbench2Action, Tbench2Observation, Tbench2S
             use_docker_backend=False,
             session_logs_dir=session_logs_dir,
             safe_mode=self.safe_mode,
+            install_dependencies=["pytest"],
         )
 
         self._state = Tbench2State(


### PR DESCRIPTION
- Bump dependency versions to current releases (openenv-core>=0.2.3, camel-ai>=0.2.90, docker>=7.1.0, pytest>=9.0.0, pytest-cov>=7.0.0)
- Move pytest from core deps to dev-only (was duplicated)
- Fix _evaluate_task by passing install_dependencies=["pytest"] to TerminalToolkit so the sandbox venv has pytest available — previously the minimal .initial_env lacked pytest, causing all evaluations to fail with exit code 1

## Summary
<!-- 1-3 sentences describing what this PR does -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [ ] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
<!-- How can reviewers verify this works? -->

## Claude Code Review
<!-- If you used Claude Code for this PR, paste the output of /alignment-review here -->
<!-- If not applicable, write "N/A" -->
