### PR TITLE
fix: support concurrent BrowserGym sessions with shared single-thread executor

### DIFF
--- a/envs/browsergym_env/pyproject.toml
+++ b/envs/browsergym_env/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "requests>=2.25.0",
     "browsergym-core>=0.2.0",
     "browsergym-miniwob>=0.2.0",
-    "browsergym-webarena>=0.2.0",
     "gymnasium>=0.29.0",
     "playwright>=1.40.0",
     "greenlet>=3.1.0",  # Required for Python 3.13 compatibility

--- a/envs/browsergym_env/server/Dockerfile
+++ b/envs/browsergym_env/server/Dockerfile
@@ -19,8 +19,8 @@ COPY . .
 # Make start script executable
 RUN chmod +x /app/env/server/start.sh
 
-# Install Python dependencies using pip install -e . (from pyproject.toml)
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir uv
+RUN uv pip install --system --no-cache -e .
 
 # Install MiniWoB++ from a pinned snapshot to avoid flaky Hub-time git clones.
 ARG MINIWOB_COMMIT=7fd85d71a4b60325c6585396ec4f48377d049838

--- a/envs/browsergym_env/server/app.py
+++ b/envs/browsergym_env/server/app.py
@@ -1,6 +1,7 @@
 """FastAPI server for the BrowserGym environment."""
 
 import os
+from functools import partial
 
 from browsergym_env.models import BrowserGymAction, BrowserGymObservation
 from browsergym_env.server.browsergym_environment import BrowserGymEnvironment
@@ -15,27 +16,22 @@ viewport_height = int(os.environ.get("BROWSERGYM_VIEWPORT_HEIGHT", "720"))
 timeout = float(os.environ.get("BROWSERGYM_TIMEOUT", "10000"))
 port = int(os.environ.get("BROWSERGYM_PORT", "8000"))
 
+max_concurrent = int(os.environ.get("MAX_CONCURRENT_ENVS", "8"))
 
-# Factory function to create BrowserGymEnvironment instances
-def create_browsergym_environment():
-    """Factory function that creates BrowserGymEnvironment with config."""
-    return BrowserGymEnvironment(
+app = create_app(
+    partial(
+        BrowserGymEnvironment,
         benchmark=benchmark,
         task_name=task_name,
         headless=headless,
         viewport_width=viewport_width,
         viewport_height=viewport_height,
         timeout=timeout,
-    )
-
-
-# Create the FastAPI app
-# Pass the factory function instead of an instance for WebSocket session support
-app = create_app(
-    create_browsergym_environment,
+    ),
     BrowserGymAction,
     BrowserGymObservation,
     env_name="browsergym_env",
+    max_concurrent_envs=max_concurrent,
 )
 
 

--- a/envs/browsergym_env/server/browsergym_environment.py
+++ b/envs/browsergym_env/server/browsergym_environment.py
@@ -95,6 +95,9 @@ class BrowserGymEnvironment(Environment):
     provide unified access to multiple web navigation benchmarks.
     """
 
+    SUPPORTS_CONCURRENT_SESSIONS = True
+    REQUIRES_SINGLE_THREAD_EXECUTOR = True
+
     def __init__(
         self,
         benchmark: str = "miniwob",
@@ -382,4 +385,7 @@ class BrowserGymEnvironment(Environment):
     def close(self) -> None:
         """Clean up environment resources."""
         if hasattr(self, "gym_env"):
-            self.gym_env.close()
+            try:
+                self.gym_env.close()
+            except Exception as e:
+                logger.warning("BrowserGym close() failed: %s", e)

--- a/src/openenv/core/env_server/http_server.py
+++ b/src/openenv/core/env_server/http_server.py
@@ -218,6 +218,11 @@ class HTTPEnvServer:
         # This is needed for environments using sync libraries (e.g., Playwright)
         self._executor = ThreadPoolExecutor(max_workers=32)
 
+        self._requires_single_thread_executor = self._detect_single_thread_requirement()
+        self._shared_session_executor: Optional[ThreadPoolExecutor] = None
+        if self._requires_single_thread_executor:
+            self._shared_session_executor = ThreadPoolExecutor(max_workers=1)
+
         # Idle session reaper configuration.
         # Timeout is taken from ConcurrencyConfig.session_timeout;
         # None means no timeout (default — reaper is a no-op).
@@ -234,11 +239,17 @@ class HTTPEnvServer:
             ConcurrencyConfigurationError: If max_concurrent_envs > 1 for an
                 environment that is not marked as SUPPORTS_CONCURRENT_SESSIONS.
         """
+        import functools
+
         if self._max_concurrent_envs <= 1:
             return
 
-        if inspect.isclass(self._env_factory):
-            env_cls = self._env_factory
+        factory = self._env_factory
+        if isinstance(factory, functools.partial):
+            factory = factory.func
+
+        if inspect.isclass(factory):
+            env_cls = factory
         else:
             _temp_env = self._env_factory()
             env_cls = type(_temp_env)
@@ -250,6 +261,16 @@ class HTTPEnvServer:
                 environment_name=env_cls.__name__,
                 max_concurrent_envs=self._max_concurrent_envs,
             )
+
+    def _detect_single_thread_requirement(self) -> bool:
+        import functools
+
+        factory = self._env_factory
+        if isinstance(factory, functools.partial):
+            factory = factory.func
+        if inspect.isclass(factory):
+            return getattr(factory, "REQUIRES_SINGLE_THREAD_EXECUTOR", False)
+        return False
 
     def get_capacity_status(self) -> ServerCapacityStatus:
         """
@@ -316,7 +337,10 @@ class HTTPEnvServer:
 
             # Create executor and reserve slot so capacity is not exceeded while
             # we create the env outside the lock (avoids blocking other sessions)
-            executor = ThreadPoolExecutor(max_workers=1)
+            if self._shared_session_executor is not None:
+                executor = self._shared_session_executor
+            else:
+                executor = ThreadPoolExecutor(max_workers=1)
             self._session_executors[session_id] = executor
             self._sessions[session_id] = None  # placeholder until env is ready
 
@@ -326,7 +350,8 @@ class HTTPEnvServer:
             env = await loop.run_in_executor(executor, self._env_factory)
         except Exception as e:
             async with self._session_lock:
-                executor.shutdown(wait=False)
+                if executor is not self._shared_session_executor:
+                    executor.shutdown(wait=False)
                 self._session_executors.pop(session_id, None)
                 self._sessions.pop(session_id, None)
             factory_name = getattr(
@@ -421,8 +446,7 @@ class HTTPEnvServer:
                 except Exception:
                     pass  # Best effort cleanup
 
-        # Shutdown executor after close is done
-        if executor is not None:
+        if executor is not None and executor is not self._shared_session_executor:
             executor.shutdown(wait=False)
 
     def _update_session_activity(
@@ -568,6 +592,8 @@ class HTTPEnvServer:
 
         async def _stop_session_reaper() -> None:
             server_ref._stop_reaper()
+            if server_ref._shared_session_executor is not None:
+                server_ref._shared_session_executor.shutdown(wait=True)
 
         if not getattr(app.router, "_openenv_reaper_registered", False):
             app.router.on_startup.append(_start_session_reaper)

--- a/src/openenv/core/env_server/interfaces.py
+++ b/src/openenv/core/env_server/interfaces.py
@@ -127,6 +127,8 @@ class Environment(ABC, Generic[ActT, ObsT, StateT]):
     # Class-level flag indicating whether this environment supports concurrent sessions
     SUPPORTS_CONCURRENT_SESSIONS: bool = False
 
+    REQUIRES_SINGLE_THREAD_EXECUTOR: bool = False
+
     # Optional rubric for reward computation
     rubric: Optional["Rubric"]
 


### PR DESCRIPTION
## Summary                                                                                                                                                                              
                                                                                                                                                                                          
BrowserGym uses Playwright's sync API which relies on a process-global singleton and greenlets bound to the creating thread. When multiple WebSocket sessions each get their own `ThreadPoolExecutor` (the current default), Playwright crashes with `greenlet.error: Cannot switch to a different thread` or `Selectors.set_test_id_attribute: no running event loop`. This is triggered when clients like TRL's `environment_factory` open multiple concurrent connections to the same server.                                                                
                                                                                                                                                                                    
This PR adds a `REQUIRES_SINGLE_THREAD_EXECUTOR` flag to the `Environment` base class. When set, all sessions share a single `ThreadPoolExecutor` so all Playwright greenlets live in the same thread. The flag is opt-in (default `False`) and does not affect other environments.
                                                                                                                                                                                      
## Type of Change                                                                                                                                                                     
- [x] Bug fix
                                                                                                                                                                                      
## Changes
                                                                                                                                                                                      
**openenv-core:**                                                                                                                                                                     
- `interfaces.py`: new `REQUIRES_SINGLE_THREAD_EXECUTOR` class attribute (default `False`)
- `http_server.py`: when the flag is set, create a shared executor for all sessions instead of one per session. Unwraps `functools.partial` to inspect class-level flags. Skips executor shutdown on session cleanup when using the shared executor.                                                                                                                            
                                                                                                                                                                                      
**browsergym_env:**                                                                                                                                                                     
- `browsergym_environment.py`: set `SUPPORTS_CONCURRENT_SESSIONS = True` and `REQUIRES_SINGLE_THREAD_EXECUTOR = True`. Wrap `close()` in try/except.                                  
- `app.py`: use `functools.partial(BrowserGymEnvironment, ...)` instead of a wrapper function so the server can inspect class flags. Add configurable `MAX_CONCURRENT_ENVS` env var (default 8).                                                                                                                                                                            
- `Dockerfile`: use `uv` instead of `pip` for dependency resolution (pip hits resolution-too-deep with browsergym's dependency tree).                                                   
- `pyproject.toml`: remove `browsergym-webarena` — `libwebarena` pins `beartype==0.12.0` which conflicts with `fastmcp>=3.0.0` (requires `beartype>=0.20.0` via `py-key-value-aio`). Re-add once libwebarena drops the pin.                                                                                                                                                  
                                                                                                                                                                                      
**Note:** `openenv-core` version in `pyproject.toml` remains `>=0.2.2`. Once this PR is merged and released, bump accordingly.                                                          
                                                                                                                                                                                    
## Why not async?                                                                                                                                                                       
                                                                                                                                                                                    
BrowserGym deliberately uses Playwright's sync API. Their `_get_global_playwright()` singleton makes it impossible to use async Playwright without upstream changes.
                                                                                                                                                                                      
## Alignment Checklist                                                                                                                                                                

- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles                                                                                                   
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run lint on the changed files (`ruff format --check` and `ruff check` pass). Note: `lint.sh` reports pre-existing format issues in `repl_env/` (unrelated to this PR).     
                                                                                                                                                                                      
## RFC Status                                                                                                                                                                           
- [x] Not required (bug fix, opt-in flag, backward compatible)                                                                                                                          
                                                                                                                                                                                      
## Test Plan
                                                                                                                                                                                      
1. Deploy browsergym_env Space with these changes (https://huggingface.co/spaces/sergiopaniego/browsergym_env_updated_fixed) 
2. Run TRL's `browsergym_llm.py` with `num_generations=4` (4 concurrent WebSocket sessions)
3. Server logs show 4 sessions created and closed cleanly (no greenlet errors)                                                                                                          
4. Training starts without `RuntimeError`                                                                                                                                               
                                                                                                                                                                                      
Tested with `Qwen/Qwen3-0.6B` on `miniwob/click-test`.                                                                                                                                  
                                                                                                                                                                                      
## Claude Code Review                                                                                                                                                                   
                                                                                                                                                                                    
**Invariants checked:**                                                                                                                                                                 
- Gymnasium API signatures (`reset`/`step`/`state`): unchanged ✅
- Generic type safety: unchanged ✅                                                                                                                                                     
- Agent isolation: no new exposure ✅                                                                                                                                                   
- Client-server separation: no cross-boundary imports ✅
- Dual API boundary: not affected ✅                                                                                                                                                    
                                                                                                                                                                                      
No alignment flags raised.