### PR TITLE
fix(envs): enable concurrent sessions for textarena, openspiel and echo

### DIFF
--- a/envs/echo_env/server/app.py
+++ b/envs/echo_env/server/app.py
@@ -21,6 +21,8 @@ Usage:
     uv run --project . server
 """
 
+import os
+
 # Support both in-repo and standalone imports
 try:
     # In-repo imports (when running from OpenEnv repository)
@@ -37,8 +39,14 @@ except ImportError:
 # Create the app with web interface and README integration
 # Pass the class (factory) instead of an instance for WebSocket session support
 # Use MCP types for action/observation since this is a pure MCP environment
+max_concurrent = int(os.getenv("MAX_CONCURRENT_ENVS", "8"))
+
 app = create_app(
-    EchoEnvironment, CallToolAction, CallToolObservation, env_name="echo_env"
+    EchoEnvironment,
+    CallToolAction,
+    CallToolObservation,
+    env_name="echo_env",
+    max_concurrent_envs=max_concurrent,
 )
 
 

--- a/envs/echo_env/server/echo_environment.py
+++ b/envs/echo_env/server/echo_environment.py
@@ -66,6 +66,8 @@ class EchoEnvironment(MCPEnvironment):
         ...     print(result)
     """
 
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
     def __init__(self):
         """Initialize the echo environment with MCP server and tools."""
         # Create MCP server and define tools inline

--- a/envs/openspiel_env/server/app.py
+++ b/envs/openspiel_env/server/app.py
@@ -24,6 +24,7 @@ Environment variables:
     OPENSPIEL_GAME: Game name to serve (default: "catch")
     OPENSPIEL_AGENT_PLAYER: Agent player ID (default: 0)
     OPENSPIEL_OPPONENT_POLICY: Opponent policy (default: "random")
+    MAX_CONCURRENT_ENVS: Maximum concurrent WebSocket sessions (default: 8)
 """
 
 import os

--- a/envs/openspiel_env/server/app.py
+++ b/envs/openspiel_env/server/app.py
@@ -46,6 +46,7 @@ except ImportError:
 game_name = os.getenv("OPENSPIEL_GAME", "catch")
 agent_player = int(os.getenv("OPENSPIEL_AGENT_PLAYER", "0"))
 opponent_policy = os.getenv("OPENSPIEL_OPPONENT_POLICY", "random")
+max_concurrent = int(os.getenv("MAX_CONCURRENT_ENVS", "8"))
 
 
 # Factory function to create OpenSpielEnvironment instances
@@ -65,6 +66,7 @@ app = create_app(
     OpenSpielAction,
     OpenSpielObservation,
     env_name="openspiel_env",
+    max_concurrent_envs=max_concurrent,
 )
 
 

--- a/envs/openspiel_env/server/openspiel_environment.py
+++ b/envs/openspiel_env/server/openspiel_environment.py
@@ -66,6 +66,8 @@ class OpenSpielEnvironment(Environment):
         >>> print(obs.reward)
     """
 
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
     def __init__(
         self,
         game_name: str = "catch",

--- a/envs/textarena_env/server/app.py
+++ b/envs/textarena_env/server/app.py
@@ -45,6 +45,7 @@ max_turns = int(max_turns_env) if max_turns_env is not None else None
 download_nltk = os.getenv("TEXTARENA_DOWNLOAD_NLTK", "1") in {"1", "true", "True"}
 
 extra_kwargs = _parse_env_kwargs()
+max_concurrent = int(os.getenv("MAX_CONCURRENT_ENVS", "8"))
 
 
 # Factory function to create TextArenaEnvironment instances
@@ -71,6 +72,7 @@ if "gradio_builder" in _sig.parameters:
         TextArenaAction,
         TextArenaObservation,
         env_name="textarena_env",
+        max_concurrent_envs=max_concurrent,
         gradio_builder=build_textarena_gradio_app,
     )
 else:
@@ -83,6 +85,7 @@ else:
         TextArenaAction,
         TextArenaObservation,
         env_name="textarena_env",
+        max_concurrent_envs=max_concurrent,
     )
 
 

--- a/envs/textarena_env/server/environment.py
+++ b/envs/textarena_env/server/environment.py
@@ -87,6 +87,8 @@ def _import_textarena() -> Any:
 class TextArenaEnvironment(Environment):
     """Wrap any TextArena game behind the OpenEnv ``Environment`` API."""
 
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
     def __init__(
         self,
         env_id: str = "Wordle-v0",


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                
textarena_env, openspiel_env and echo_env lack `SUPPORTS_CONCURRENT_SESSIONS` and `max_concurrent_envs`, so they default to 1 session. Clients that open multiple WebSocket connections (e.g. TRL's `environment_factory` with `num_generations > 1`) get `SessionCapacityError` on the second connection. These environments are stateless across instances and safe to run concurrently. For context, GRPO in TRL needs `num_generations > 2` for running since it needs at least 2 generations to compute the advantages that are needed for training
                                                                                                                                        
## Type of Change                                         
- [x] Bug fix

## Alignment Checklist

- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles                                                                                                                         
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues                                                                                                        
                                                                                                                                                                                                              
## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)                                                                                                                                                         
                                                          
## Test Plan

1. Deploy each env to a Space ✅
2. Run TRL's corresponding example script with `num_generations=4` ✅
3. Verify 4 WebSocket sessions are accepted without `SessionCapacityError` ✅                                                                                                                     
 
Tested with wordle.py, catch.py and echo.py.                                                                                                                                                                  
                                                          
## Claude Code Review

**Invariants checked:**
- Gymnasium API signatures (`reset`/`step`/`state`): unchanged ✅
- Generic type safety: unchanged ✅                                                                                                                                                                           
- Agent isolation: no new exposure, `SUPPORTS_CONCURRENT_SESSIONS` is infrastructure-only ✅
- Client-server separation: no cross-boundary imports ✅                                                                                                                                                      
- Dual API boundary: not affected ✅                      
                                                                                                                                                                                                              
No alignment flags raised. 


@kashif