### PR TITLE
[REPL_ENV] use MAX_CONCURRENT_ENVS env variable

### DIFF
--- a/envs/repl_env/server/app.py
+++ b/envs/repl_env/server/app.py
@@ -33,6 +33,7 @@ Usage:
 Environment Variables:
     HF_TOKEN: Fallback HuggingFace API token (client token takes priority)
     LLM_MODEL: Model to use for llm_query/llm_query_batched (default: Qwen/Qwen3.5-9B)
+    MAX_CONCURRENT_ENVS: Maximum concurrent WebSocket sessions (default: 8)
 """
 
 import inspect
@@ -60,6 +61,7 @@ REPL_MAX_OUTPUT_LENGTH = int(os.environ.get("REPL_MAX_OUTPUT_LENGTH", "8192"))
 REPL_CONTEXT_PREVIEW_LENGTH = int(os.environ.get("REPL_CONTEXT_PREVIEW_LENGTH", "500"))
 REPL_RLM_MAX_DEPTH = int(os.environ.get("REPL_RLM_MAX_DEPTH", "2"))
 REPL_RLM_MAX_ITERATIONS = int(os.environ.get("REPL_RLM_MAX_ITERATIONS", "30"))
+MAX_CONCURRENT_ENVS = int(os.environ.get("MAX_CONCURRENT_ENVS", "8"))
 # ==========================================
 
 _logger = logging.getLogger(__name__)
@@ -99,7 +101,7 @@ if "gradio_builder" in _sig.parameters:
         REPLAction,
         REPLObservation,
         env_name="repl_env",
-        max_concurrent_envs=8,
+        max_concurrent_envs=MAX_CONCURRENT_ENVS,
         gradio_builder=build_repl_gradio_app,
     )
 else:
@@ -112,7 +114,7 @@ else:
         REPLAction,
         REPLObservation,
         env_name="repl_env",
-        max_concurrent_envs=8,
+        max_concurrent_envs=MAX_CONCURRENT_ENVS,
     )
 
 


### PR DESCRIPTION
## Summary

Use MAX_CONCURRENT_ENVS to set the max concurrent envs variable

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [x] Refactoring

## Alignment Checklist

Before submitting, verify:
- [ ] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [ ] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [ ] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [ ] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
<!-- How can reviewers verify this works? -->

## Claude Code Review
<!-- If you used Claude Code for this PR, paste the output of /alignment-review here -->
<!-- If not applicable, write "N/A" -->
