### PR TITLE
feat(cli): add --hardware flag to openenv push

### DIFF
--- a/.claude/skills/deploy-hf/SKILL.md
+++ b/.claude/skills/deploy-hf/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: deploy-hf
+description: Deploy an OpenEnv environment to HuggingFace Spaces. Use when asked to deploy, push to HuggingFace, or update a space.
+allowed-tools: Bash, Read
+---
+
+# Deploy to HuggingFace Spaces
+
+Deploy an OpenEnv environment to HuggingFace Spaces using the OpenEnv CLI.
+
+## When to Use This Skill
+
+- User asks to "deploy to HuggingFace"
+- User says "push to HuggingFace Spaces"
+- User wants to update an existing space
+- After implementing new features that need to be tested in production
+
+## Prerequisites
+
+Before deploying, ensure:
+1. The environment has an `openenv.yaml` file
+2. The environment has a `server/Dockerfile`
+3. You have HuggingFace credentials configured (automatic via huggingface-cli)
+
+## Instructions
+
+### 1. Identify the Environment
+
+Determine which environment to deploy:
+- If user specifies: use that environment (e.g., "carla_env", "browser_env")
+- If in environment directory: use current directory
+- Otherwise: ask the user
+
+### 2. Determine the Repository ID
+
+Repository ID format: `username/space-name`
+
+- If user provides full ID: use it (e.g., "sergiopaniego/carla-env-real-updated")
+- If user provides only space name: construct ID with their username
+- Check `openenv.yaml` for default repo-id
+- Otherwise: ask the user
+
+### 3. Pre-Deployment Setup
+
+**IMPORTANT**: Always run from the project root directory.
+
+Before deploying, ensure OpenEnv is installed:
+
+```bash
+cd /path/to/OpenEnv  # Navigate to project root if needed
+uv pip install -e .
+```
+
+If this fails with "does not appear to be a Python project", you're not in the project root.
+
+### 4. Run the Deployment Command
+
+Execute the deployment:
+
+```bash
+PYTHONPATH=src uv run python -m openenv.cli push <environment-dir> --repo-id <username/space-name>
+```
+
+**Parameters**:
+- `<environment-dir>`: Path to environment (e.g., `envs/carla_env`)
+- `--repo-id`: HuggingFace Spaces repository ID (e.g., `sergiopaniego/carla-env-real-updated`)
+
+**Optional flags**:
+- `--private`: Deploy as a private space
+- `--no-interface`: Disable the web interface (deploy API-only)
+- `--base-image <image>`: Override the base Docker image
+- `--hardware <hw>` / `-H <hw>`: Request HuggingFace Space hardware (e.g. `t4-medium`, `a10g-small`, `cpu-basic`)
+- `--count N` / `-n N`: Deploy N instances with auto-suffixed repo IDs (e.g. `env-1`, `env-2`). Cannot be used with `--registry` or `--create-pr`.
+
+### 5. Verify Deployment
+
+After successful deployment:
+1. Note the Space URL returned by the command
+2. **Wait for build to complete:**
+   - CPU environments: ~5 minutes
+   - GPU environments (CARLA): ~30-60 minutes
+3. Check the space status at the URL
+4. Test with a simple health check once build completes:
+   ```bash
+   curl https://<username>-<space-name>.hf.space/health
+   ```
+
+## Example Usage
+
+### Deploy carla_env to existing space
+
+```bash
+PYTHONPATH=src uv run python -m openenv.cli push envs/carla_env --repo-id sergiopaniego/carla-env-real-updated
+```
+
+### Deploy echo_env as private space
+
+```bash
+PYTHONPATH=src uv run python -m openenv.cli push envs/echo_env --repo-id username/my-echo-env --private
+```
+
+### Deploy with GPU hardware
+
+```bash
+PYTHONPATH=src uv run python -m openenv.cli push envs/carla_env --repo-id username/carla-env --hardware t4-medium
+```
+
+### Deploy 3 instances of echo_env
+
+```bash
+PYTHONPATH=src uv run python -m openenv.cli push envs/echo_env --repo-id username/echo-env --count 3
+```
+
+### Deploy with custom base image
+
+```bash
+PYTHONPATH=src uv run python -m openenv.cli push envs/browser_env --repo-id username/browser-env --base-image nvidia/cuda:11.8.0-runtime-ubuntu22.04
+```
+
+## Output Format
+
+Report deployment status:
+
+```
+## HuggingFace Deployment
+
+### Environment
+- Environment: <env-name>
+- Directory: <path>
+- Dockerfile: <path-to-dockerfile>
+
+### Deployment
+- Repository ID: <username/space-name>
+- Space URL: <https://huggingface.co/spaces/username/space-name>
+- Status: ✓ Deployed successfully
+
+### Next Steps
+1. Wait for space to build (5 min for CPU, 30-60 min for GPU/CARLA)
+2. Visit space URL to check build status
+3. Test environment once build completes
+
+### Testing Commands
+```bash
+# Health check
+curl https://<username>-<space-name>.hf.space/health
+
+# Reset environment
+curl -X POST https://<username>-<space-name>.hf.space/reset
+
+# Step action
+curl -X POST https://<username>-<space-name>.hf.space/step \
+  -H "Content-Type: application/json" \
+  -d '{"action_type": "observe"}'
+```
+```
+
+## Troubleshooting
+
+### Error: "ModuleNotFoundError: No module named 'openenv'"
+
+**Solution**: Install OpenEnv first (must be run from project root):
+```bash
+cd /path/to/OpenEnv  # Navigate to project root
+uv pip install -e .
+```
+
+### Error: "does not appear to be a Python project"
+
+**Cause**: You're not in the project root directory.
+
+**Solution**: Navigate to the OpenEnv project root where `pyproject.toml` exists:
+```bash
+cd /Users/sergiopaniegoblanco/Documents/Projects/OpenEnv  # Adjust path
+uv pip install -e .
+```
+
+### Error: "Directory does not exist"
+
+**Solution**: Ensure you're passing the correct environment directory path:
+```bash
+# Correct
+PYTHONPATH=src uv run python -m openenv.cli push envs/carla_env --repo-id ...
+
+# Incorrect
+PYTHONPATH=src uv run python -m openenv.cli push carla_env --repo-id ...
+```
+
+### Error: "Authentication required"
+
+**Solution**: Login to HuggingFace CLI first:
+```bash
+huggingface-cli login
+```
+
+### Space build fails
+
+**Solutions**:
+1. Check Dockerfile syntax and dependencies
+2. Verify hardware requirements (GPU spaces need `--hardware` setting on HF)
+3. Check space logs on HuggingFace for detailed errors
+4. Ensure `openenv.yaml` is valid
+
+## Common Environments
+
+| Environment | Path | Typical Repo ID | Hardware |
+|-------------|------|-----------------|----------|
+| carla_env (standalone) | envs/carla_env | username/carla-env-real | GPU (T4/A10G) |
+| carla_env (mock) | envs/carla_env | username/carla-env-mock | CPU |
+| echo_env | envs/echo_env | username/echo-env | CPU |
+| browser_env | envs/browser_env | username/browser-env | CPU |
+| tbench2_env | envs/tbench2_env | username/tbench2-env | CPU |
+
+## Notes
+
+- Deployment requires HuggingFace authentication (automatic if `huggingface-cli` is logged in)
+- By default, spaces are **public** (use `--private` for private spaces)
+- By default, **web interface is enabled** (use `--no-interface` for API-only)
+- GPU spaces can request hardware via `--hardware` (e.g. `--hardware t4-medium`)
+- Build times vary: CPU (~5 min), GPU with CARLA (~30-60 min)
+- The CLI automatically moves Dockerfile to repository root for HuggingFace compatibility
+
+## Related Documentation
+
+- [DEPLOYMENT_GUIDE.md](../../envs/carla_env/DEPLOYMENT_GUIDE.md) - Detailed deployment modes
+- [README.md](../../README.md) - OpenEnv overview
+- HuggingFace Spaces Docs: https://huggingface.co/docs/hub/spaces

--- a/.claude/skills/deploy-hf/SKILL.md
+++ b/.claude/skills/deploy-hf/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: deploy-hf
-description: Deploy an OpenEnv environment to HuggingFace Spaces. Use when asked to deploy, push to HuggingFace, or update a space.
+description: Deploy an OpenEnv environment to Hugging Face Spaces. Use when asked to deploy, push to Hugging Face, or update a space.
 allowed-tools: Bash, Read
 ---
 
-# Deploy to HuggingFace Spaces
+# Deploy to Hugging Face Spaces
 
-Deploy an OpenEnv environment to HuggingFace Spaces using the OpenEnv CLI.
+Deploy an OpenEnv environment to Hugging Face Spaces using the OpenEnv CLI.
 
 ## When to Use This Skill
 
-- User asks to "deploy to HuggingFace"
-- User says "push to HuggingFace Spaces"
+- User asks to "deploy to Hugging Face"
+- User says "push to Hugging Face Spaces"
 - User wants to update an existing space
 - After implementing new features that need to be tested in production
 
@@ -20,7 +20,7 @@ Deploy an OpenEnv environment to HuggingFace Spaces using the OpenEnv CLI.
 Before deploying, ensure:
 1. The environment has an `openenv.yaml` file
 2. The environment has a `server/Dockerfile`
-3. You have HuggingFace credentials configured (automatic via huggingface-cli)
+3. You have Hugging Face credentials configured (automatic via huggingface-cli)
 
 ## Instructions
 
@@ -63,13 +63,13 @@ PYTHONPATH=src uv run python -m openenv.cli push <environment-dir> --repo-id <us
 
 **Parameters**:
 - `<environment-dir>`: Path to environment (e.g., `envs/carla_env`)
-- `--repo-id`: HuggingFace Spaces repository ID (e.g., `sergiopaniego/carla-env-real-updated`)
+- `--repo-id`: Hugging Face Spaces repository ID (e.g., `sergiopaniego/carla-env-real-updated`)
 
 **Optional flags**:
 - `--private`: Deploy as a private space
 - `--no-interface`: Disable the web interface (deploy API-only)
 - `--base-image <image>`: Override the base Docker image
-- `--hardware <hw>` / `-H <hw>`: Request HuggingFace Space hardware (e.g. `t4-medium`, `a10g-small`, `cpu-basic`)
+- `--hardware <hw>` / `-H <hw>`: Request Hugging Face Space hardware (e.g. `t4-medium`, `a10g-small`, `cpu-basic`)
 - `--count N` / `-n N`: Deploy N instances with auto-suffixed repo IDs (e.g. `env-1`, `env-2`). Cannot be used with `--registry` or `--create-pr`.
 
 ### 5. Verify Deployment
@@ -122,7 +122,7 @@ PYTHONPATH=src uv run python -m openenv.cli push envs/browser_env --repo-id user
 Report deployment status:
 
 ```
-## HuggingFace Deployment
+## Hugging Face Deployment
 
 ### Environment
 - Environment: <env-name>
@@ -187,7 +187,7 @@ PYTHONPATH=src uv run python -m openenv.cli push carla_env --repo-id ...
 
 ### Error: "Authentication required"
 
-**Solution**: Login to HuggingFace CLI first:
+**Solution**: Login to Hugging Face CLI first:
 ```bash
 huggingface-cli login
 ```
@@ -197,7 +197,7 @@ huggingface-cli login
 **Solutions**:
 1. Check Dockerfile syntax and dependencies
 2. Verify hardware requirements (GPU spaces need `--hardware` setting on HF)
-3. Check space logs on HuggingFace for detailed errors
+3. Check space logs on Hugging Face for detailed errors
 4. Ensure `openenv.yaml` is valid
 
 ## Common Environments
@@ -212,15 +212,15 @@ huggingface-cli login
 
 ## Notes
 
-- Deployment requires HuggingFace authentication (automatic if `huggingface-cli` is logged in)
+- Deployment requires Hugging Face authentication (automatic if `huggingface-cli` is logged in)
 - By default, spaces are **public** (use `--private` for private spaces)
 - By default, **web interface is enabled** (use `--no-interface` for API-only)
 - GPU spaces can request hardware via `--hardware` (e.g. `--hardware t4-medium`)
 - Build times vary: CPU (~5 min), GPU with CARLA (~30-60 min)
-- The CLI automatically moves Dockerfile to repository root for HuggingFace compatibility
+- The CLI automatically moves Dockerfile to repository root for Hugging Face compatibility
 
 ## Related Documentation
 
 - [DEPLOYMENT_GUIDE.md](../../envs/carla_env/DEPLOYMENT_GUIDE.md) - Detailed deployment modes
 - [README.md](../../README.md) - OpenEnv overview
-- HuggingFace Spaces Docs: https://huggingface.co/docs/hub/spaces
+- Hugging Face Spaces Docs: https://huggingface.co/docs/hub/spaces

--- a/.claude/skills/deploy-hf/SKILL.md
+++ b/.claude/skills/deploy-hf/SKILL.md
@@ -70,7 +70,6 @@ PYTHONPATH=src uv run python -m openenv.cli push <environment-dir> --repo-id <us
 - `--no-interface`: Disable the web interface (deploy API-only)
 - `--base-image <image>`: Override the base Docker image
 - `--hardware <hw>` / `-H <hw>`: Request Hugging Face Space hardware (e.g. `t4-medium`, `a10g-small`, `cpu-basic`)
-- `--count N` / `-n N`: Deploy N instances with auto-suffixed repo IDs (e.g. `env-1`, `env-2`). Cannot be used with `--registry` or `--create-pr`.
 
 ### 5. Verify Deployment
 
@@ -103,12 +102,6 @@ PYTHONPATH=src uv run python -m openenv.cli push envs/echo_env --repo-id usernam
 
 ```bash
 PYTHONPATH=src uv run python -m openenv.cli push envs/carla_env --repo-id username/carla-env --hardware t4-medium
-```
-
-### Deploy 3 instances of echo_env
-
-```bash
-PYTHONPATH=src uv run python -m openenv.cli push envs/echo_env --repo-id username/echo-env --count 3
 ```
 
 ### Deploy with custom base image

--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -407,18 +407,22 @@ def _create_hf_space(
     repo_id: str,
     api: HfApi,
     private: bool = False,
+    hardware: str | None = None,
 ) -> None:
     """Create a Hugging Face Space if it doesn't exist."""
     console.print(f"[bold cyan]Creating/verifying space: {repo_id}[/bold cyan]")
 
     try:
-        api.create_repo(
-            repo_id=repo_id,
-            repo_type="space",
-            space_sdk="docker",
-            private=private,
-            exist_ok=True,
-        )
+        create_kwargs: dict = {
+            "repo_id": repo_id,
+            "repo_type": "space",
+            "space_sdk": "docker",
+            "private": private,
+            "exist_ok": True,
+        }
+        if hardware is not None:
+            create_kwargs["space_hardware"] = hardware
+        api.create_repo(**create_kwargs)
         console.print(f"[bold green]✓[/bold green] Space {repo_id} is ready")
     except Exception as e:
         # Space might already exist, which is okay with exist_ok=True
@@ -532,6 +536,14 @@ def push(
             help="Optional additional ignore file with newline-separated glob patterns to exclude from Hugging Face uploads",
         ),
     ] = None,
+    hardware: Annotated[
+        str | None,
+        typer.Option(
+            "--hardware",
+            "-H",
+            help="Request hardware for HuggingFace Space (e.g. t4-medium, cpu-basic). See HF docs for options.",
+        ),
+    ] = None,
 ) -> None:
     """
     Push an OpenEnv environment to Hugging Face Spaces or a custom Docker registry.
@@ -570,6 +582,9 @@ def push(
 
         # Push privately with custom base image
         $ openenv push --private --base-image ghcr.io/meta-pytorch/openenv-base:latest
+
+        # Push with GPU hardware
+        $ openenv push --hardware t4-medium
     """
     # Handle interface flag logic
     if no_interface and interface:
@@ -701,7 +716,7 @@ def push(
 
         # Create/verify space (no-op if exists; needed when pushing to own new repo)
         if not create_pr:
-            _create_hf_space(repo_id, api, private=private)
+            _create_hf_space(repo_id, api, private=private, hardware=hardware)
         # When create_pr we rely on upload_folder to create branch and PR
 
         # Upload files

--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -541,7 +541,7 @@ def push(
         typer.Option(
             "--hardware",
             "-H",
-            help="Request hardware for HuggingFace Space (e.g. t4-medium, cpu-basic). See HF docs for options.",
+            help="Request hardware for Hugging Face Space (e.g. t4-medium, cpu-basic). See HF docs for options.",
         ),
     ] = None,
 ) -> None:

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -293,6 +293,60 @@ def test_push_uses_private_option(tmp_path: Path) -> None:
         assert call_args.kwargs["private"] is True
 
 
+def test_push_uses_hardware_option(tmp_path: Path) -> None:
+    """Test that push respects --hardware option."""
+    _create_test_openenv_env(tmp_path)
+
+    with (
+        patch("openenv.cli.commands.push.whoami") as mock_whoami,
+        patch("openenv.cli.commands.push.login") as mock_login,
+        patch("openenv.cli.commands.push.HfApi") as mock_hf_api_class,
+    ):
+        mock_whoami.return_value = {"name": "testuser"}
+        mock_login.return_value = None  # Prevent actual login prompt
+        mock_api = MagicMock()
+        mock_hf_api_class.return_value = mock_api
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(str(tmp_path))
+            result = runner.invoke(app, ["push", "--hardware", "t4-medium"])
+        finally:
+            os.chdir(old_cwd)
+
+        # Verify create_repo was called with space_hardware="t4-medium"
+        mock_api.create_repo.assert_called_once()
+        call_kwargs = mock_api.create_repo.call_args[1]
+        assert call_kwargs["space_hardware"] == "t4-medium"
+
+
+def test_push_default_hardware_is_none(tmp_path: Path) -> None:
+    """Test that push does not pass space_hardware when --hardware is not specified."""
+    _create_test_openenv_env(tmp_path)
+
+    with (
+        patch("openenv.cli.commands.push.whoami") as mock_whoami,
+        patch("openenv.cli.commands.push.login") as mock_login,
+        patch("openenv.cli.commands.push.HfApi") as mock_hf_api_class,
+    ):
+        mock_whoami.return_value = {"name": "testuser"}
+        mock_login.return_value = None  # Prevent actual login prompt
+        mock_api = MagicMock()
+        mock_hf_api_class.return_value = mock_api
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(str(tmp_path))
+            result = runner.invoke(app, ["push"])
+        finally:
+            os.chdir(old_cwd)
+
+        # Verify create_repo was called without space_hardware
+        mock_api.create_repo.assert_called_once()
+        call_kwargs = mock_api.create_repo.call_args[1]
+        assert "space_hardware" not in call_kwargs
+
+
 def test_push_uses_base_image_option(tmp_path: Path) -> None:
     """Test that push respects --base-image option."""
     _create_test_openenv_env(tmp_path)

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -316,7 +316,7 @@ def test_push_uses_hardware_option(tmp_path: Path) -> None:
 
         # Verify create_repo was called with space_hardware="t4-medium"
         mock_api.create_repo.assert_called_once()
-        call_kwargs = mock_api.create_repo.call_args[1]
+        call_kwargs = mock_api.create_repo.call_args.kwargs
         assert call_kwargs["space_hardware"] == "t4-medium"
 
 
@@ -343,7 +343,7 @@ def test_push_default_hardware_is_none(tmp_path: Path) -> None:
 
         # Verify create_repo was called without space_hardware
         mock_api.create_repo.assert_called_once()
-        call_kwargs = mock_api.create_repo.call_args[1]
+        call_kwargs = mock_api.create_repo.call_args.kwargs
         assert "space_hardware" not in call_kwargs
 
 


### PR DESCRIPTION
## Summary                                                                                                                                             
                                                                                                                                                       
Add `--hardware` / `-H` flag to `openenv push` so users can select HuggingFace Space hardware (e.g. `t4-medium`, `a10g-small`, `cpu-basic`) at deploy  
time. Previously this required manual configuration in the HF UI after deployment.                                                                     
                                                                                                                                                       
## Type of Change                                                                                                                                    
- [x] New feature 

## Alignment Checklist
                                                                                                                                                       
Before submitting, verify:                                                                                                                           
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated                                                                       
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues
                                                                                                                                                       
## RFC Status                                             
- [x] Not required (bug fix, docs, minor refactoring) 

## Test Plan                                              
                                                                                                                                                       
- `test_push_uses_hardware_option`: verifies `--hardware t4-medium` passes `space_hardware="t4-medium"` to `create_repo`                               
- `test_push_default_hardware_is_none`: verifies omitting `--hardware` does not include `space_hardware` in kwargs
- All 30 tests pass: `PYTHONPATH=src uv run pytest tests/test_cli/test_push.py -v`                                                                     

## Claude Code Review

Additive CLI flag only. Wires through existing `huggingface_hub` `space_hardware` parameter. No core APIs, invariants, or architectural boundaries affected.