### PR TITLE
feat(cli): add --count flag to openenv push for multi-instance deploy

### DIFF
--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -536,6 +536,7 @@ def push(
             help="Optional additional ignore file with newline-separated glob patterns to exclude from Hugging Face uploads",
         ),
     ] = None,
+<<<<<<< HEAD
     hardware: Annotated[
         str | None,
         typer.Option(
@@ -544,6 +545,17 @@ def push(
             help="Request hardware for Hugging Face Space (e.g. t4-medium, cpu-basic). See HF docs for options.",
         ),
     ] = None,
+=======
+    count: Annotated[
+        int,
+        typer.Option(
+            "--count",
+            "-n",
+            help="Number of Space instances to deploy. Each gets a numeric suffix (e.g. env-1, env-2).",
+            min=1,
+        ),
+    ] = 1,
+>>>>>>> b6dc1b61 (feat(cli): add --count flag to openenv push for multi-instance deploy)
 ) -> None:
     """
     Push an OpenEnv environment to Hugging Face Spaces or a custom Docker registry.
@@ -586,6 +598,19 @@ def push(
         # Push with GPU hardware
         $ openenv push --hardware t4-medium
     """
+    # Validate --count flag combinations
+    if count > 1 and registry:
+        console.print(
+            "[bold red]Error:[/bold red] --count cannot be used with --registry",
+        )
+        raise typer.Exit(1)
+
+    if count > 1 and create_pr:
+        console.print(
+            "[bold red]Error:[/bold red] --count cannot be used with --create-pr",
+        )
+        raise typer.Exit(1)
+
     # Handle interface flag logic
     if no_interface and interface:
         console.print(
@@ -714,20 +739,53 @@ def push(
             enable_interface=enable_interface,
         )
 
+<<<<<<< HEAD
         # Create/verify space (no-op if exists; needed when pushing to own new repo)
         if not create_pr:
             _create_hf_space(repo_id, api, private=private, hardware=hardware)
         # When create_pr we rely on upload_folder to create branch and PR
+=======
+        if count > 1:
+            base_repo_id = repo_id
+            for i in range(1, count + 1):
+                instance_repo_id = f"{base_repo_id}-{i}"
+                console.print(
+                    f"\n[bold cyan][{i}/{count}] Deploying {instance_repo_id}...[/bold cyan]"
+                )
+                _create_hf_space(instance_repo_id, api, private=private)
+                _upload_to_hf_space(
+                    instance_repo_id,
+                    staging_dir,
+                    api,
+                    private=private,
+                    create_pr=False,
+                    ignore_patterns=ignore_patterns,
+                )
+            console.print(
+                f"\n[bold green]✓ All {count} instances deployed![/bold green]"
+            )
+            for i in range(1, count + 1):
+                console.print(
+                    f"Visit instance {i}: https://huggingface.co/spaces/{base_repo_id}-{i}"
+                )
+        else:
+            # Create/verify space (no-op if exists; needed when pushing to own new repo)
+            if not create_pr:
+                _create_hf_space(repo_id, api, private=private)
+            # When create_pr we rely on upload_folder to create branch and PR
+>>>>>>> b6dc1b61 (feat(cli): add --count flag to openenv push for multi-instance deploy)
 
-        # Upload files
-        _upload_to_hf_space(
-            repo_id,
-            staging_dir,
-            api,
-            private=private,
-            create_pr=create_pr,
-            ignore_patterns=ignore_patterns,
-        )
+            # Upload files
+            _upload_to_hf_space(
+                repo_id,
+                staging_dir,
+                api,
+                private=private,
+                create_pr=create_pr,
+                ignore_patterns=ignore_patterns,
+            )
 
-        console.print("\n[bold green]✓ Deployment complete![/bold green]")
-        console.print(f"Visit your space at: https://huggingface.co/spaces/{repo_id}")
+            console.print("\n[bold green]✓ Deployment complete![/bold green]")
+            console.print(
+                f"Visit your space at: https://huggingface.co/spaces/{repo_id}"
+            )

--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -536,7 +536,6 @@ def push(
             help="Optional additional ignore file with newline-separated glob patterns to exclude from Hugging Face uploads",
         ),
     ] = None,
-<<<<<<< HEAD
     hardware: Annotated[
         str | None,
         typer.Option(
@@ -545,7 +544,6 @@ def push(
             help="Request hardware for Hugging Face Space (e.g. t4-medium, cpu-basic). See HF docs for options.",
         ),
     ] = None,
-=======
     count: Annotated[
         int,
         typer.Option(
@@ -555,7 +553,6 @@ def push(
             min=1,
         ),
     ] = 1,
->>>>>>> b6dc1b61 (feat(cli): add --count flag to openenv push for multi-instance deploy)
 ) -> None:
     """
     Push an OpenEnv environment to Hugging Face Spaces or a custom Docker registry.
@@ -739,12 +736,6 @@ def push(
             enable_interface=enable_interface,
         )
 
-<<<<<<< HEAD
-        # Create/verify space (no-op if exists; needed when pushing to own new repo)
-        if not create_pr:
-            _create_hf_space(repo_id, api, private=private, hardware=hardware)
-        # When create_pr we rely on upload_folder to create branch and PR
-=======
         if count > 1:
             base_repo_id = repo_id
             for i in range(1, count + 1):
@@ -752,7 +743,9 @@ def push(
                 console.print(
                     f"\n[bold cyan][{i}/{count}] Deploying {instance_repo_id}...[/bold cyan]"
                 )
-                _create_hf_space(instance_repo_id, api, private=private)
+                _create_hf_space(
+                    instance_repo_id, api, private=private, hardware=hardware
+                )
                 _upload_to_hf_space(
                     instance_repo_id,
                     staging_dir,
@@ -761,18 +754,18 @@ def push(
                     create_pr=False,
                     ignore_patterns=ignore_patterns,
                 )
-                console.print(
-                    f"  Visit: https://huggingface.co/spaces/{instance_repo_id}"
-                )
             console.print(
                 f"\n[bold green]✓ All {count} instances deployed![/bold green]"
             )
+            for i in range(1, count + 1):
+                console.print(
+                    f"Visit instance {i}: https://huggingface.co/spaces/{base_repo_id}-{i}"
+                )
         else:
             # Create/verify space (no-op if exists; needed when pushing to own new repo)
             if not create_pr:
-                _create_hf_space(repo_id, api, private=private)
+                _create_hf_space(repo_id, api, private=private, hardware=hardware)
             # When create_pr we rely on upload_folder to create branch and PR
->>>>>>> b6dc1b61 (feat(cli): add --count flag to openenv push for multi-instance deploy)
 
             # Upload files
             _upload_to_hf_space(

--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -761,13 +761,12 @@ def push(
                     create_pr=False,
                     ignore_patterns=ignore_patterns,
                 )
+                console.print(
+                    f"  Visit: https://huggingface.co/spaces/{instance_repo_id}"
+                )
             console.print(
                 f"\n[bold green]✓ All {count} instances deployed![/bold green]"
             )
-            for i in range(1, count + 1):
-                console.print(
-                    f"Visit instance {i}: https://huggingface.co/spaces/{base_repo_id}-{i}"
-                )
         else:
             # Create/verify space (no-op if exists; needed when pushing to own new repo)
             if not create_pr:

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -905,3 +905,140 @@ def test_push_create_pr_sets_upload_flag_and_skips_create_repo(tmp_path: Path) -
         assert call_kwargs.get("create_pr") is True
         # When create_pr we do not create the repo (target repo must exist)
         mock_api.create_repo.assert_not_called()
+
+
+def test_push_count_deploys_multiple_spaces(tmp_path: Path) -> None:
+    """Test that --count 3 calls create_repo and upload_folder 3 times with suffixed repo IDs."""
+    _create_test_openenv_env(tmp_path)
+
+    with (
+        patch("openenv.cli.commands.push.whoami") as mock_whoami,
+        patch("openenv.cli.commands.push.login") as mock_login,
+        patch("openenv.cli.commands.push.HfApi") as mock_hf_api_class,
+    ):
+        mock_whoami.return_value = {"name": "testuser"}
+        mock_login.return_value = None
+        mock_api = MagicMock()
+        mock_hf_api_class.return_value = mock_api
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(str(tmp_path))
+            result = runner.invoke(
+                app,
+                ["push", "--repo-id", "testuser/my-env", "--count", "3"],
+            )
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0
+
+        # Verify create_repo was called 3 times with suffixed repo IDs
+        assert mock_api.create_repo.call_count == 3
+        create_repo_ids = [
+            call.kwargs["repo_id"] for call in mock_api.create_repo.call_args_list
+        ]
+        assert create_repo_ids == [
+            "testuser/my-env-1",
+            "testuser/my-env-2",
+            "testuser/my-env-3",
+        ]
+
+        # Verify upload_folder was called 3 times with suffixed repo IDs
+        assert mock_api.upload_folder.call_count == 3
+        upload_repo_ids = [
+            call.kwargs["repo_id"] for call in mock_api.upload_folder.call_args_list
+        ]
+        assert upload_repo_ids == [
+            "testuser/my-env-1",
+            "testuser/my-env-2",
+            "testuser/my-env-3",
+        ]
+
+        # Verify progress messages in output
+        assert "[1/3]" in result.output
+        assert "[2/3]" in result.output
+        assert "[3/3]" in result.output
+        assert "All 3 instances deployed" in result.output
+
+
+def test_push_count_one_is_default_behavior(tmp_path: Path) -> None:
+    """Test that --count 1 behaves exactly like no flag (no suffix)."""
+    _create_test_openenv_env(tmp_path)
+
+    with (
+        patch("openenv.cli.commands.push.whoami") as mock_whoami,
+        patch("openenv.cli.commands.push.login") as mock_login,
+        patch("openenv.cli.commands.push.HfApi") as mock_hf_api_class,
+    ):
+        mock_whoami.return_value = {"name": "testuser"}
+        mock_login.return_value = None
+        mock_api = MagicMock()
+        mock_hf_api_class.return_value = mock_api
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(str(tmp_path))
+            result = runner.invoke(
+                app,
+                ["push", "--repo-id", "testuser/my-env", "--count", "1"],
+            )
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0
+
+        # Verify create_repo was called once without suffix
+        mock_api.create_repo.assert_called_once()
+        assert mock_api.create_repo.call_args.kwargs["repo_id"] == "testuser/my-env"
+
+        # Verify upload_folder was called once without suffix
+        mock_api.upload_folder.assert_called_once()
+        assert mock_api.upload_folder.call_args.kwargs["repo_id"] == "testuser/my-env"
+
+
+def test_push_count_with_registry_errors(tmp_path: Path) -> None:
+    """Test that --count 2 --registry fails with error."""
+    _create_test_openenv_env(tmp_path)
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(str(tmp_path))
+        result = runner.invoke(
+            app,
+            ["push", "--count", "2", "--registry", "docker.io/user"],
+        )
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code != 0
+    assert "--count" in result.output.lower() or "count" in result.output.lower()
+    assert "--registry" in result.output.lower() or "registry" in result.output.lower()
+
+
+def test_push_count_with_create_pr_errors(tmp_path: Path) -> None:
+    """Test that --count 2 --create-pr fails with error."""
+    _create_test_openenv_env(tmp_path)
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(str(tmp_path))
+        result = runner.invoke(
+            app,
+            [
+                "push",
+                "--repo-id",
+                "testuser/my-env",
+                "--count",
+                "2",
+                "--create-pr",
+            ],
+        )
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code != 0
+    assert "--count" in result.output.lower() or "count" in result.output.lower()
+    assert (
+        "--create-pr" in result.output.lower() or "create-pr" in result.output.lower()
+    )


### PR DESCRIPTION
## Summary

Add `--count` / `-n` flag to `openenv push` to deploy N replicas of the same environment to N HuggingFace Spaces with auto-suffixed repo IDs (e.g. `user/env-1`, `user/env-2`, `user/env-3`). Staging is done once and reused across all instances. Incompatible with `--registry` and `--create-pr`.
                                                                                                                                                       
## Type of Change
- [x] New feature

## Alignment Checklist                                                                                                                                 
 
Before submitting, verify:                                                                                                                             
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues
                                                                                                                                                       
## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)                                                                                                  
- [ ] RFC exists: #___                                    
- [ ] RFC needed (will create before merge)
                                                                                                                                                       
## Test Plan
                                                                                                                                                       
- `test_push_count_deploys_multiple_spaces`: verifies `--count 3` calls `create_repo` and `upload_folder` 3x with suffixed IDs (`-1`, `-2`, `-3`)      
- `test_push_count_one_is_default_behavior`: verifies `--count 1` preserves original behavior (no suffix)
- `test_push_count_with_registry_errors`: verifies `--count 2 --registry` fails                                                                        
- `test_push_count_with_create_pr_errors`: verifies `--count 2 --create-pr` fails                                                                      
- All 32 tests pass: `PYTHONPATH=src uv run pytest tests/test_cli/test_push.py -v`
                                                                                                                                                       
## Claude Code Review                                     
                                                                                                                                                       
Additive CLI flag only. No core APIs, invariants, or architectural boundaries affected. The `--count` flag is validated early and errors when combined 
with incompatible flags (`--registry`, `--create-pr`).