### PR TITLE
Bump Echo and FinQA envs to openenv-core 0.2.3

### DIFF
--- a/envs/echo_env/pyproject.toml
+++ b/envs/echo_env/pyproject.toml
@@ -15,7 +15,7 @@ description = "Echo Environment for OpenEnv - simple test environment that echoe
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/finqa_env/pyproject.toml
+++ b/envs/finqa_env/pyproject.toml
@@ -9,7 +9,7 @@ description = "FinQA Environment for OpenEnv - financial question-answering on S
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "fastmcp>=2.0.0",
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary

- update `envs/echo_env/pyproject.toml` to require `openenv-core[core]>=0.2.3`
- update `envs/finqa_env/pyproject.toml` to require `openenv-core[core]>=0.2.3`
- keep scope intentionally minimal to match issue #460

## Issue

- fixes #460

## Validation

- `git diff --check`
- editor diagnostics checked for changed TOML files

## Notes

- `openenv-core` in this repo is already at `0.2.3`, so this PR aligns the downstream env package floors with that released baseline.