### PR TITLE
Align all environment openenv-core floors to 0.2.3

### DIFF
--- a/envs/atari_env/pyproject.toml
+++ b/envs/atari_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "Atari Environment for OpenEnv - Atari 2600 games via ALE"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/browsergym_env/pyproject.toml
+++ b/envs/browsergym_env/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "BrowserGym Environment for OpenEnv - Web automation using Playwright"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",

--- a/envs/calendar_env/pyproject.toml
+++ b/envs/calendar_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "Calendar environment for OpenEnv with MCP tool access"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core>=0.2.0",
+    "openenv-core>=0.2.3",
     "openenv>=0.1.13",
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.27.0",

--- a/envs/carla_env/pyproject.toml
+++ b/envs/carla_env/pyproject.toml
@@ -15,7 +15,7 @@ description = "CARLA environment for OpenEnv - embodied evaluation with temporal
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/chat_env/pyproject.toml
+++ b/envs/chat_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "Chat Environment for OpenEnv - LLM-powered conversational agent"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/chess_env/pyproject.toml
+++ b/envs/chess_env/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Chess Environment for OpenEnv"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.24.0",

--- a/envs/coding_env/pyproject.toml
+++ b/envs/coding_env/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Coding Environment for OpenEnv"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.24.0",

--- a/envs/connect4_env/pyproject.toml
+++ b/envs/connect4_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "Connect4 Environment for OpenEnv - classic two-player board game"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/dipg_safety_env/pyproject.toml
+++ b/envs/dipg_safety_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "DIPG Safety Environment for OpenEnv - diagnostic safety evaluation"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.24.0",

--- a/envs/echo_env/pyproject.toml
+++ b/envs/echo_env/pyproject.toml
@@ -15,7 +15,7 @@ description = "Echo Environment for OpenEnv - simple test environment that echoe
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/finqa_env/pyproject.toml
+++ b/envs/finqa_env/pyproject.toml
@@ -9,7 +9,7 @@ description = "FinQA Environment for OpenEnv - financial question-answering on S
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "fastmcp>=2.0.0",
     "pydantic>=2.0.0",

--- a/envs/finrl_env/pyproject.toml
+++ b/envs/finrl_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "FinRL Environment for OpenEnv - stock trading via FinRL"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/git_env/pyproject.toml
+++ b/envs/git_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "Git Environment for OpenEnv - task-based git operations via Gitea"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "smolagents>=1.0.0",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",

--- a/envs/grid_world_env/pyproject.toml
+++ b/envs/grid_world_env/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Yuv Raj Pant", email = "yuvrajpant5@gmail.com"},
 ]
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "gymnasium",
     "numpy",
     # Server dependencies copied from echo_env

--- a/envs/julia_env/pyproject.toml
+++ b/envs/julia_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "Julia Environment for OpenEnv - Julia code execution with test tracking and reward calculation"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.24.0",

--- a/envs/kernrl/pyproject.toml
+++ b/envs/kernrl/pyproject.toml
@@ -15,7 +15,7 @@ description = "GPU kernel optimization environment for OpenEnv - trains LLMs to 
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/maze_env/pyproject.toml
+++ b/envs/maze_env/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv runtime (provides FastAPI server + HTTP client types)
     # install from github
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     # Environment-specific dependencies
     # Add all dependencies needed for your environment here
     "numpy>=1.19.0",

--- a/envs/openspiel_env/pyproject.toml
+++ b/envs/openspiel_env/pyproject.toml
@@ -15,7 +15,7 @@ description = "OpenSpiel Environment for OpenEnv - integration with DeepMind's g
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/reasoning_gym_env/pyproject.toml
+++ b/envs/reasoning_gym_env/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # Core OpenEnv runtime (provides FastAPI server + HTTP client types)
     # install from github
     # "openenv-core[core] @ git+https://github.com/meta-pytorch/OpenEnv.git",
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     # Environment-specific dependencies
     # Add all dependencies needed for your environment here
     "reasoning-gym>=0.1.24"

--- a/envs/repl_env/pyproject.toml
+++ b/envs/repl_env/pyproject.toml
@@ -15,7 +15,7 @@ description = "Recursive Language Model REPL Environment for OpenEnv"
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/snake_env/pyproject.toml
+++ b/envs/snake_env/pyproject.toml
@@ -15,7 +15,7 @@ description = "Snake Environment for OpenEnv - multi-agent snake game based on m
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.24.0",

--- a/envs/sumo_rl_env/pyproject.toml
+++ b/envs/sumo_rl_env/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 description = "SUMO-RL Environment for OpenEnv - traffic signal control via SUMO"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/tbench2_env/pyproject.toml
+++ b/envs/tbench2_env/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv runtime (provides FastAPI server + HTTP client types)
     # install from github
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "pytest>=8.4.0",
     # Environment-specific dependencies
     # Add all dependencies needed for your environment here

--- a/envs/textarena_env/pyproject.toml
+++ b/envs/textarena_env/pyproject.toml
@@ -15,7 +15,7 @@ description = "TextArena environment for OpenEnv"
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn>=0.24.0",

--- a/envs/websearch_env/pyproject.toml
+++ b/envs/websearch_env/pyproject.toml
@@ -15,7 +15,7 @@ description = "Web Search environment for OpenEnv"
 requires-python = ">=3.10"
 dependencies = [
     # Core OpenEnv dependencies (required for server functionality)
-    "openenv-core[core]>=0.2.2",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.24.0",

--- a/envs/wildfire_env/pyproject.toml
+++ b/envs/wildfire_env/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Wildfire Environment for OpenEnv - autonomous wildfire-control simulation for reinforcement learning"
 requires-python = ">=3.10"
 dependencies = [
-    "openenv-core[core]>=0.2.0",
+    "openenv-core[core]>=0.2.3",
     "fastapi>=0.115.0",
     "pydantic>=2.0.0",
     "uvicorn[standard]>=0.24.0",


### PR DESCRIPTION
## Summary

- update all `envs/*/pyproject.toml` files that still pin `openenv-core` below `0.2.3`
- standardize dependency floors to `openenv-core[core]>=0.2.3` (and `openenv-core>=0.2.3` where core extra is not used)
- keep this as a dependency-only consistency pass with no behavior changes

## Context

- follow-up to #525 Greptile consistency comment about mixed env dependency floors

## Validation

- `git diff --check`
- repo-wide grep confirms no env `openenv-core` floor remains below `0.2.3`