### PR TITLE
Fix CARLA env done propagation and Docker env var leakage

### DIFF
--- a/envs/carla_env/client.py
+++ b/envs/carla_env/client.py
@@ -74,7 +74,9 @@ class CarlaEnv(EnvClient[CarlaAction, CarlaObservation, CarlaState]):
         """Parse JSON response to StepResult."""
         observation = CarlaObservation(**payload["observation"])
         return StepResult(
-            observation=observation, reward=payload.get("reward"), done=observation.done
+            observation=observation,
+            reward=payload.get("reward"),
+            done=payload.get("done", False),
         )
 
     def _parse_state(self, payload: Dict[str, Any]) -> CarlaState:

--- a/envs/carla_env/server/Dockerfile
+++ b/envs/carla_env/server/Dockerfile
@@ -175,7 +175,7 @@ except Exception as e:\n\
 # Start OpenEnv FastAPI server as non-root\n\
 echo "🚀 Starting OpenEnv server..."\n\
 cd /app\n\
-exec su - carla -c "cd /app && CARLA_MODE=${CARLA_MODE} CARLA_SCENARIO=${CARLA_SCENARIO} CARLA_HOST=${CARLA_HOST} CARLA_PORT=${CARLA_PORT} PYTHONPATH=/app:/opt/carla/PythonAPI/carla uvicorn carla_env.server.app:app --host 0.0.0.0 --port 8000"\n\
+exec su - carla -c "cd /app && CARLA_MODE=\"${CARLA_MODE}\" CARLA_SCENARIO=\"${CARLA_SCENARIO}\" CARLA_HOST=\"${CARLA_HOST}\" CARLA_PORT=\"${CARLA_PORT}\" PYTHONPATH=/app:/opt/carla/PythonAPI/carla uvicorn carla_env.server.app:app --host 0.0.0.0 --port 8000"\n\
 ' > /start.sh && chmod +x /start.sh
 
 CMD ["/start.sh"]

--- a/envs/carla_env/server/Dockerfile
+++ b/envs/carla_env/server/Dockerfile
@@ -175,7 +175,7 @@ except Exception as e:\n\
 # Start OpenEnv FastAPI server as non-root\n\
 echo "🚀 Starting OpenEnv server..."\n\
 cd /app\n\
-exec su - carla -c "cd /app && PYTHONPATH=/app:/opt/carla/PythonAPI/carla uvicorn carla_env.server.app:app --host 0.0.0.0 --port 8000"\n\
+exec su - carla -c "cd /app && CARLA_MODE=${CARLA_MODE} CARLA_SCENARIO=${CARLA_SCENARIO} CARLA_HOST=${CARLA_HOST} CARLA_PORT=${CARLA_PORT} PYTHONPATH=/app:/opt/carla/PythonAPI/carla uvicorn carla_env.server.app:app --host 0.0.0.0 --port 8000"\n\
 ' > /start.sh && chmod +x /start.sh
 
 CMD ["/start.sh"]


### PR DESCRIPTION
## Summary

Fix CARLA env done propagation and Docker env var leakage                                                                          

**`client.py`**: read `done` from the top-level response payload. Previously `done=observation.done` but server serialization excludes `done` from the observation dict — so clients always saw `done=False`, breaking any training loop relying on episode-end propagation.                                                                                                                       
                                                            
**`Dockerfile`**: pass `CARLA_MODE`, `CARLA_SCENARIO`, `CARLA_HOST`, `CARLA_PORT` explicitly in the `su - carla` command. `su -` resets environment; previously these silently defaulted, causing the server to run in mock mode when the user had set `CARLA_MODE=real`.

Deployed in https://huggingface.co/spaces/sergiopaniego/carla-env and https://huggingface.co/spaces/sergiopaniego/carla-env-2

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan

**`client.py` fix (done propagation):**
1. Deploy CARLA env to an HF Space (e.g. https://huggingface.co/spaces/sergiopaniego/carla-env)
2. Connect with `CarlaEnv(base_url=...)` and run a scenario until episode end (collision or timeout)
3. Verify `result.done` returns `True` when the server's `scenario_outcome` reports done — before the fix it always returned `False`

**`Dockerfile` fix (env var leakage):**
1. Build the Docker image and deploy with `CARLA_MODE=real` set as a container env var
2. Check server logs — they should report real CARLA initialization (not mock mode)
3. Before the fix, `CARLA_MODE=real` was silently dropped by `su - carla` and the server defaulted back to mock 

Both fixes verified end-to-end running a GRPO training loop against the deployed Spaces.

## Claude Code Review

### Automated Checks                                                                                                               
- **Lint**: PASS for this PR's files — `envs/carla_env/client.py` is properly formatted with `ruff format` (88-char line limit
enforced a multi-line `StepResult(...)` call). Pre-existing formatting issues in `envs/repl_env/server/gradio_ui.py` and           
`envs/repl_env/server/repl_environment.py` appear in the global hook output but exist on `origin/main` before this PR — they are
out of scope here.                                                                                                                 
**Debug code**: CLEAN — no `print`, `breakpoint`, or debugger statements introduced by this PR. The hook lists pre-existing
prints in `src/openenv/cli/commands/push.py` and `src/openenv/cli/__main__.py`, unrelated to this change.                          
  
### Open RFCs Context                                                                                                              
Scanned all RFCs (`000-project-phases`, `001-abstractions`, `002-env-spec`, `003-mcp-support`, `004-rubrics`,
`005-agentic-harnesses`): none of them touch CARLA client parsing, the `done` payload field, or the CARLA Docker startup script. No
open RFC is relevant.
                                                                                                                                 
### Tier 1: Fixes Required                                
None.

### Tier 2: Alignment Discussion

#### Principle Conflicts                                                                                                           
None identified. Both fixes preserve existing principles:
**Rewards in environment** (RFC 002): unchanged — `done` is environment-sourced; the fix only corrects how the client            
deserializes an existing wire field.                                                                                               
- **Client-server separation**: unchanged — `client.py` only touches deserialization from the already-defined JSON payload; no
server import added.                                                                                                               
- **Container isolation** / **Agent isolation**: unchanged — the `Dockerfile` fix is local to the CARLA server startup script
(propagating Docker-level env vars into the `su - carla` shell) and does not alter container boundaries, agent access, or API      
surface.
**Gymnasium API signatures**: unchanged — `reset`/`step`/`state` signatures untouched.                                           
                                                        
#### RFC Conflicts                                                                                                                 
None identified.
                                                                                                                                 
### Summary                                               
- 0 mechanical issues to fix
- 0 alignment points for human review
- 0 RFC conflicts to discuss
