### PR TITLE
Stop env Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    exclude-paths:
+      - "envs/**"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds an explicit `.github/dependabot.yml` so Dependabot keeps tracking repo-level `uv` and GitHub Actions updates but stops scanning anything under `envs/**`.

It prevents new `envs/` version-update PRs from being opened while preserving root dependency maintenance for the main package and workflows.

Validation:
- `.github/dependabot.yml` parses as YAML.
