### PR TITLE
Group root Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,18 @@ updates:
       interval: "weekly"
     exclude-paths:
       - "envs/**"
+    groups:
+      root-uv:
+        applies-to: version-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      root-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR keeps `envs/**` excluded from Dependabot and adds grouping for the remaining root-level ecosystems.

After this merges, Dependabot should consolidate root `uv` updates into one grouped PR and root GitHub Actions updates into one grouped PR, instead of opening one PR per dependency.

Validation:
- `.github/dependabot.yml` parses as YAML.
