### PR TITLE
Fix coding_env API compatibility and safety reward false positives

### DIFF
--- a/envs/coding_env/server/__init__.py
+++ b/envs/coding_env/server/__init__.py
@@ -4,8 +4,20 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Coding environment server components."""
+"""Coding environment server components.
 
-from .python_codeact_env import PythonCodeActEnv
+Keep imports lazy so utility modules (for example transforms) remain importable
+without pulling optional runtime dependencies like smolagents.
+"""
+
+from typing import Any
 
 __all__ = ["PythonCodeActEnv"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "PythonCodeActEnv":
+        from .python_codeact_env import PythonCodeActEnv
+
+        return PythonCodeActEnv
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/envs/coding_env/server/__init__.py
+++ b/envs/coding_env/server/__init__.py
@@ -10,9 +10,16 @@ Keep imports lazy so utility modules (for example transforms) remain importable
 without pulling optional runtime dependencies like smolagents.
 """
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .python_codeact_env import PythonCodeActEnv
 
 __all__ = ["PythonCodeActEnv"]
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *__all__})
 
 
 def __getattr__(name: str) -> Any:

--- a/envs/coding_env/server/app.py
+++ b/envs/coding_env/server/app.py
@@ -21,9 +21,10 @@ Usage:
     python -m envs.coding_env.server.app
 """
 
+from openenv.core.env_server import create_app
+
 from coding_env.models import CodeAction, CodeObservation
 from coding_env.server.python_codeact_env import PythonCodeActEnv
-from openenv.core.env_server import create_app
 
 # Create the app with web interface and README integration
 # Pass the class (factory) instead of an instance for WebSocket session support

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -89,8 +89,6 @@ class PythonCodeActEnv(Environment):
     def step(
         self,
         action: Action,
-        timeout_s: Optional[float] = None,
-        **kwargs: Any,
     ) -> Observation:
         """
         Execute code action and return observation.

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -12,6 +12,7 @@ Python code actions using PyExecutor.
 """
 
 import uuid
+from typing import Any, Optional
 
 from openenv.core.env_server.interfaces import Action, Environment, Observation
 
@@ -50,7 +51,12 @@ class PythonCodeActEnv(Environment):
         self._executor = PyExecutor()
         self._state = CodeState()
 
-    def reset(self) -> Observation:
+    def reset(
+        self,
+        seed: Optional[int] = None,
+        episode_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Observation:
         """
         Reset environment and start fresh execution session.
 
@@ -58,7 +64,10 @@ class PythonCodeActEnv(Environment):
             Initial observation with empty stdout/stderr and exit_code=0
         """
         # Initialize fresh state
-        self._state = CodeState(episode_id=str(uuid.uuid4()), step_count=0)
+        self._state = CodeState(
+            episode_id=episode_id or str(uuid.uuid4()),
+            step_count=0,
+        )
         # Add last_exit_code to state
         self._state.last_exit_code = 0
 
@@ -77,7 +86,12 @@ class PythonCodeActEnv(Environment):
 
         return self._apply_transform(observation)
 
-    def step(self, action: Action) -> Observation:
+    def step(
+        self,
+        action: Action,
+        timeout_s: Optional[float] = None,
+        **kwargs: Any,
+    ) -> Observation:
         """
         Execute code action and return observation.
 

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -89,12 +89,17 @@ class PythonCodeActEnv(Environment):
     def step(
         self,
         action: Action,
+        timeout_s: Optional[float] = None,
+        **kwargs: Any,
     ) -> Observation:
         """
         Execute code action and return observation.
 
         Args:
             action: CodeAction containing the code to execute
+            timeout_s: Optional timeout accepted for Environment API compatibility.
+                PyExecutor does not currently expose per-call timeout control.
+            **kwargs: Additional step parameters accepted for API compatibility.
 
         Returns:
             CodeObservation with execution results (stdout, stderr, exit_code)
@@ -102,6 +107,8 @@ class PythonCodeActEnv(Environment):
         Raises:
             ValueError: If action is not a CodeAction instance
         """
+        del timeout_s, kwargs
+
         if not isinstance(action, CodeAction):
             raise ValueError(f"Expected CodeAction, got {type(action)}")
 

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -12,7 +12,7 @@ Python code actions using PyExecutor.
 """
 
 import uuid
-from typing import Optional
+from typing import Any, Optional
 
 from openenv.core.env_server.interfaces import Action, Environment, Observation
 
@@ -55,13 +55,23 @@ class PythonCodeActEnv(Environment):
         self,
         seed: Optional[int] = None,
         episode_id: Optional[str] = None,
+        **kwargs: Any,
     ) -> Observation:
         """
         Reset environment and start fresh execution session.
 
+        Args:
+            seed: Accepted for API compatibility. This deterministic executor
+                has no random state to seed.
+            episode_id: Optional episode identifier override.
+            **kwargs: Forward-compatible reset parameters accepted by the base
+                Environment API but unused by this environment.
+
         Returns:
             Initial observation with empty stdout/stderr and exit_code=0
         """
+        del seed, kwargs
+
         # Initialize fresh state
         self._state = CodeState(
             episode_id=episode_id or str(uuid.uuid4()),

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -12,7 +12,7 @@ Python code actions using PyExecutor.
 """
 
 import uuid
-from typing import Any, Optional
+from typing import Optional
 
 from openenv.core.env_server.interfaces import Action, Environment, Observation
 
@@ -55,7 +55,6 @@ class PythonCodeActEnv(Environment):
         self,
         seed: Optional[int] = None,
         episode_id: Optional[str] = None,
-        **kwargs: Any,
     ) -> Observation:
         """
         Reset environment and start fresh execution session.
@@ -89,17 +88,12 @@ class PythonCodeActEnv(Environment):
     def step(
         self,
         action: Action,
-        timeout_s: Optional[float] = None,
-        **kwargs: Any,
     ) -> Observation:
         """
         Execute code action and return observation.
 
         Args:
             action: CodeAction containing the code to execute
-            timeout_s: Optional timeout accepted for Environment API compatibility.
-                PyExecutor does not currently expose per-call timeout control.
-            **kwargs: Additional step parameters accepted for API compatibility.
 
         Returns:
             CodeObservation with execution results (stdout, stderr, exit_code)
@@ -107,8 +101,6 @@ class PythonCodeActEnv(Environment):
         Raises:
             ValueError: If action is not a CodeAction instance
         """
-        del timeout_s, kwargs
-
         if not isinstance(action, CodeAction):
             raise ValueError(f"Expected CodeAction, got {type(action)}")
 

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -74,7 +74,7 @@ class PythonCodeActEnv(Environment):
 
         # Initialize fresh state
         self._state = CodeState(
-            episode_id=episode_id or str(uuid.uuid4()),
+            episode_id=episode_id if episode_id is not None else str(uuid.uuid4()),
             step_count=0,
         )
         # Add last_exit_code to state

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -74,7 +74,7 @@ class PythonCodeActEnv(Environment):
 
         # Initialize fresh state
         self._state = CodeState(
-            episode_id=episode_id if episode_id is not None else str(uuid.uuid4()),
+            episode_id=episode_id or str(uuid.uuid4()),
             step_count=0,
         )
         # Add last_exit_code to state

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -98,12 +98,18 @@ class PythonCodeActEnv(Environment):
     def step(
         self,
         action: Action,
+        timeout_s: Optional[float] = None,
+        **kwargs: Any,
     ) -> Observation:
         """
         Execute code action and return observation.
 
         Args:
             action: CodeAction containing the code to execute
+            timeout_s: Accepted for Environment API compatibility. PyExecutor
+                does not currently expose per-call timeout control.
+            **kwargs: Forward-compatible step parameters accepted by the base
+                Environment API but unused by this environment.
 
         Returns:
             CodeObservation with execution results (stdout, stderr, exit_code)
@@ -111,6 +117,8 @@ class PythonCodeActEnv(Environment):
         Raises:
             ValueError: If action is not a CodeAction instance
         """
+        del timeout_s, kwargs
+
         if not isinstance(action, CodeAction):
             raise ValueError(f"Expected CodeAction, got {type(action)}")
 

--- a/envs/coding_env/server/python_codeact_env.py
+++ b/envs/coding_env/server/python_codeact_env.py
@@ -63,7 +63,8 @@ class PythonCodeActEnv(Environment):
         Args:
             seed: Accepted for API compatibility. This deterministic executor
                 has no random state to seed.
-            episode_id: Optional episode identifier override.
+            episode_id: Optional episode identifier override. If omitted or
+                empty, a new episode ID is generated.
             **kwargs: Forward-compatible reset parameters accepted by the base
                 Environment API but unused by this environment.
 

--- a/envs/coding_env/server/transforms.py
+++ b/envs/coding_env/server/transforms.py
@@ -7,7 +7,6 @@
 """Transforms specific to coding environments."""
 
 import ast
-import re
 
 from openenv.core.env_server.base_transforms import CompositeTransform
 from openenv.core.env_server.interfaces import Transform
@@ -21,14 +20,44 @@ class CodeSafetyTransform(Transform):
 
     def __init__(self, penalty: float = -1.0):
         self.penalty = penalty
-        self.dangerous_patterns = [
-            r"import\s+os",
-            r"import\s+subprocess",
-            r"eval\(",
-            r"exec\(",
-            r"__import__",
-            r"open\(",
-        ]
+
+    def _detect_violation(self, code: str) -> str | None:
+        """
+        Detect dangerous operations using AST analysis.
+
+        AST-based detection avoids false positives from harmless string literals
+        (e.g. ``print("import os")``) or similarly named user functions
+        (e.g. ``myopen()``).
+        """
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            # Syntax quality is handled by CodeQualityTransform.
+            return None
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top_level_module = alias.name.split(".", 1)[0]
+                    if top_level_module in {"os", "subprocess"}:
+                        return f"import {top_level_module}"
+
+            if isinstance(node, ast.ImportFrom) and node.module:
+                top_level_module = node.module.split(".", 1)[0]
+                if top_level_module in {"os", "subprocess"}:
+                    return f"import {top_level_module}"
+
+            if isinstance(node, ast.Call):
+                called_name: str | None = None
+                if isinstance(node.func, ast.Name):
+                    called_name = node.func.id
+                elif isinstance(node.func, ast.Attribute):
+                    called_name = node.func.attr
+
+                if called_name in {"eval", "exec", "open", "__import__"}:
+                    return called_name
+
+        return None
 
     def __call__(self, observation: Observation) -> Observation:
         if not isinstance(observation, CodeObservation):
@@ -36,14 +65,12 @@ class CodeSafetyTransform(Transform):
 
         if "last_code" in observation.metadata:
             code = observation.metadata["last_code"]
-            for pattern in self.dangerous_patterns:
-                if re.search(pattern, code):
-                    observation.reward = self.penalty
-                    observation.metadata["safety_violation"] = pattern
-                    break
-            else:
-                if observation.reward is None:
-                    observation.reward = 0.0
+            violation = self._detect_violation(code)
+            if violation is not None:
+                observation.reward = self.penalty
+                observation.metadata["safety_violation"] = violation
+            elif observation.reward is None:
+                observation.reward = 0.0
 
         return observation
 

--- a/envs/coding_env/server/transforms.py
+++ b/envs/coding_env/server/transforms.py
@@ -48,14 +48,10 @@ class CodeSafetyTransform(Transform):
                     return f"import {top_level_module}"
 
             if isinstance(node, ast.Call):
-                called_name: str | None = None
                 if isinstance(node.func, ast.Name):
                     called_name = node.func.id
-                elif isinstance(node.func, ast.Attribute):
-                    called_name = node.func.attr
-
-                if called_name in {"eval", "exec", "open", "__import__"}:
-                    return called_name
+                    if called_name in {"eval", "exec", "open", "__import__"}:
+                        return called_name
 
         return None
 

--- a/envs/coding_env/server/transforms.py
+++ b/envs/coding_env/server/transforms.py
@@ -108,7 +108,7 @@ class CodeQualityTransform(Transform):
             # Check syntax (redundant but useful for quality assessment)
             try:
                 ast.parse(code)
-            except SyntaxError:
+            except (SyntaxError, RecursionError, ValueError):
                 quality_score += self.syntax_penalty
 
         # Add to existing reward

--- a/envs/coding_env/server/transforms.py
+++ b/envs/coding_env/server/transforms.py
@@ -32,7 +32,9 @@ class CodeSafetyTransform(Transform):
         try:
             tree = ast.parse(code)
         except SyntaxError:
-            # Syntax quality is handled by CodeQualityTransform.
+            # Intentional trade-off: once the code is syntactically invalid,
+            # this AST-only safety pass cannot reliably inspect partial code.
+            # CodeQualityTransform applies the syntax penalty instead.
             return None
 
         for node in ast.walk(tree):

--- a/envs/coding_env/server/transforms.py
+++ b/envs/coding_env/server/transforms.py
@@ -36,10 +36,11 @@ class CodeSafetyTransform(Transform):
         """
         try:
             tree = ast.parse(code)
-        except SyntaxError:
-            # Intentional trade-off: once the code is syntactically invalid,
-            # this AST-only safety pass cannot reliably inspect partial code.
-            # CodeQualityTransform applies the syntax penalty instead.
+        except (SyntaxError, RecursionError, ValueError):
+            # Intentional trade-off: once the code is syntactically invalid or
+            # pathologically nested, this AST-only safety pass cannot reliably
+            # inspect partial code. CodeQualityTransform applies the syntax
+            # penalty instead.
             return None
 
         for node in ast.walk(tree):

--- a/envs/coding_env/server/transforms.py
+++ b/envs/coding_env/server/transforms.py
@@ -16,7 +16,12 @@ from ..models import CodeObservation
 
 
 class CodeSafetyTransform(Transform):
-    """Evaluates code safety and assigns penalties for dangerous patterns."""
+    """
+    Assign penalties for obviously unsafe coding patterns.
+
+    This is a reward heuristic, not a security sandbox. Container isolation is
+    the security boundary; this transform only shapes rewards for common cases.
+    """
 
     def __init__(self, penalty: float = -1.0):
         self.penalty = penalty

--- a/envs/coding_env/server/transforms.py
+++ b/envs/coding_env/server/transforms.py
@@ -7,12 +7,17 @@
 """Transforms specific to coding environments."""
 
 import ast
+import re
 
 from openenv.core.env_server.base_transforms import CompositeTransform
 from openenv.core.env_server.interfaces import Transform
 from openenv.core.env_server.types import Observation
 
 from ..models import CodeObservation
+
+
+def _parse_code(code: str) -> ast.AST:
+    return ast.parse(code)
 
 
 class CodeSafetyTransform(Transform):
@@ -25,6 +30,20 @@ class CodeSafetyTransform(Transform):
 
     def __init__(self, penalty: float = -1.0):
         self.penalty = penalty
+        self._fallback_patterns = [
+            (re.compile(r"\bimport\s+os\b"), "import os"),
+            (re.compile(r"\bimport\s+subprocess\b"), "import subprocess"),
+            (re.compile(r"\beval\s*\("), "eval"),
+            (re.compile(r"\bexec\s*\("), "exec"),
+            (re.compile(r"\b__import__\s*\("), "__import__"),
+            (re.compile(r"\bopen\s*\("), "open"),
+        ]
+
+    def _detect_text_violation(self, code: str) -> str | None:
+        for pattern, violation in self._fallback_patterns:
+            if pattern.search(code):
+                return violation
+        return None
 
     def _detect_violation(self, code: str) -> str | None:
         """
@@ -35,13 +54,11 @@ class CodeSafetyTransform(Transform):
         (e.g. ``myopen()``).
         """
         try:
-            tree = ast.parse(code)
+            tree = _parse_code(code)
         except (SyntaxError, RecursionError, ValueError):
-            # Intentional trade-off: once the code is syntactically invalid or
-            # pathologically nested, this AST-only safety pass cannot reliably
-            # inspect partial code. CodeQualityTransform applies the syntax
-            # penalty instead.
-            return None
+            # Fall back to the previous raw-text heuristic when AST parsing
+            # cannot inspect malformed or pathologically nested code.
+            return self._detect_text_violation(code)
 
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
@@ -60,6 +77,8 @@ class CodeSafetyTransform(Transform):
                     called_name = node.func.id
                     if called_name in {"eval", "exec", "open", "__import__"}:
                         return called_name
+                if isinstance(node.func, ast.Attribute) and node.func.attr == "open":
+                    return "open"
 
         return None
 
@@ -107,7 +126,7 @@ class CodeQualityTransform(Transform):
 
             # Check syntax (redundant but useful for quality assessment)
             try:
-                ast.parse(code)
+                _parse_code(code)
             except (SyntaxError, RecursionError, ValueError):
                 quality_score += self.syntax_penalty
 

--- a/envs/coding_env/server/transforms.py
+++ b/envs/coding_env/server/transforms.py
@@ -16,10 +16,6 @@ from openenv.core.env_server.types import Observation
 from ..models import CodeObservation
 
 
-def _parse_code(code: str) -> ast.AST:
-    return ast.parse(code)
-
-
 class CodeSafetyTransform(Transform):
     """
     Assign penalties for obviously unsafe coding patterns.
@@ -37,6 +33,7 @@ class CodeSafetyTransform(Transform):
             (re.compile(r"\bexec\s*\("), "exec"),
             (re.compile(r"\b__import__\s*\("), "__import__"),
             (re.compile(r"\bopen\s*\("), "open"),
+            (re.compile(r"\.open\s*\("), "open"),
         ]
 
     def _detect_text_violation(self, code: str) -> str | None:
@@ -54,7 +51,7 @@ class CodeSafetyTransform(Transform):
         (e.g. ``myopen()``).
         """
         try:
-            tree = _parse_code(code)
+            tree = ast.parse(code)
         except (SyntaxError, RecursionError, ValueError):
             # Fall back to the previous raw-text heuristic when AST parsing
             # cannot inspect malformed or pathologically nested code.
@@ -126,7 +123,7 @@ class CodeQualityTransform(Transform):
 
             # Check syntax (redundant but useful for quality assessment)
             try:
-                _parse_code(code)
+                ast.parse(code)
             except (SyntaxError, RecursionError, ValueError):
                 quality_score += self.syntax_penalty
 

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for coding_env safety transform false-positive handling."""
+
+import os
+import sys
+from pathlib import Path
+
+# Add the project root and src to the path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from envs.coding_env.models import CodeObservation
+from envs.coding_env.server.transforms import CodeSafetyTransform
+
+
+def _apply_safety_transform(code: str) -> CodeObservation:
+    transform = CodeSafetyTransform()
+    observation = CodeObservation(
+        stdout="",
+        stderr="",
+        exit_code=0,
+        metadata={"last_code": code},
+    )
+    transformed = transform(observation)
+    assert isinstance(transformed, CodeObservation)
+    return transformed
+
+
+def test_blocks_real_dangerous_import():
+    observation = _apply_safety_transform("import os\nprint('x')")
+    assert observation.reward == -1.0
+    assert "safety_violation" in observation.metadata
+
+
+def test_blocks_builtin_open_call():
+    observation = _apply_safety_transform("with open('f.txt') as f:\n    data = f.read()")
+    assert observation.reward == -1.0
+    assert "safety_violation" in observation.metadata
+
+
+def test_does_not_flag_string_literal_with_dangerous_text():
+    observation = _apply_safety_transform("print('import os')")
+    assert observation.reward == 0.0
+    assert "safety_violation" not in observation.metadata
+
+
+def test_does_not_flag_user_defined_myopen_function():
+    observation = _apply_safety_transform(
+        "def myopen():\n    return 1\nresult = myopen()"
+    )
+    assert observation.reward == 0.0
+    assert "safety_violation" not in observation.metadata

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -55,3 +55,15 @@ def test_does_not_flag_user_defined_myopen_function():
     )
     assert observation.reward == 0.0
     assert "safety_violation" not in observation.metadata
+
+
+def test_does_not_flag_attribute_method_named_exec():
+    observation = _apply_safety_transform(
+        "class DB:\n"
+        "    def exec(self, sql):\n"
+        "        return sql\n"
+        "db = DB()\n"
+        "result = db.exec('SELECT 1')"
+    )
+    assert observation.reward == 0.0
+    assert "safety_violation" not in observation.metadata

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -37,6 +37,24 @@ def test_blocks_builtin_open_call():
     assert "safety_violation" in observation.metadata
 
 
+def test_blocks_builtin_eval_call():
+    observation = _apply_safety_transform("result = eval('1 + 1')")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "eval"
+
+
+def test_blocks_builtin_exec_call():
+    observation = _apply_safety_transform("exec('x = 1')")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "exec"
+
+
+def test_blocks_builtin_import_call():
+    observation = _apply_safety_transform("__import__('os')")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "__import__"
+
+
 def test_does_not_flag_string_literal_with_dangerous_text():
     observation = _apply_safety_transform("print('import os')")
     assert observation.reward == 0.0

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -6,16 +6,8 @@
 
 """Tests for coding_env safety transform false-positive handling."""
 
-import os
-import sys
-from pathlib import Path
-
-# Add the project root and src to the path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
-
-from envs.coding_env.models import CodeObservation
-from envs.coding_env.server.transforms import CodeSafetyTransform
+from coding_env.models import CodeObservation
+from coding_env.server.transforms import CodeSafetyTransform
 
 
 def _apply_safety_transform(code: str) -> CodeObservation:
@@ -38,7 +30,9 @@ def test_blocks_real_dangerous_import():
 
 
 def test_blocks_builtin_open_call():
-    observation = _apply_safety_transform("with open('f.txt') as f:\n    data = f.read()")
+    observation = _apply_safety_transform(
+        "with open('f.txt') as f:\n    data = f.read()"
+    )
     assert observation.reward == -1.0
     assert "safety_violation" in observation.metadata
 

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -29,6 +29,24 @@ def test_blocks_real_dangerous_import():
     assert "safety_violation" in observation.metadata
 
 
+def test_blocks_subprocess_import():
+    observation = _apply_safety_transform("import subprocess")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "import subprocess"
+
+
+def test_blocks_from_subprocess_import():
+    observation = _apply_safety_transform("from subprocess import run")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "import subprocess"
+
+
+def test_blocks_from_os_path_import():
+    observation = _apply_safety_transform("from os.path import join")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "import os"
+
+
 def test_blocks_builtin_open_call():
     observation = _apply_safety_transform(
         "with open('f.txt') as f:\n    data = f.read()"

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -61,6 +61,18 @@ def test_blocks_builtin_open_call():
     assert "safety_violation" in observation.metadata
 
 
+def test_blocks_attribute_open_call():
+    observation = _apply_safety_transform("Path('f.txt').open()")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "open"
+
+
+def test_blocks_raw_text_violation_when_parse_fails():
+    observation = _apply_safety_transform("import os\n\x00")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "import os"
+
+
 def test_blocks_builtin_eval_call():
     observation = _apply_safety_transform("result = eval('1 + 1')")
     assert observation.reward == -1.0
@@ -109,7 +121,9 @@ def test_quality_transform_handles_ast_recursion_error(monkeypatch):
     def raise_recursion_error(_code: str):
         raise RecursionError("pathologically nested code")
 
-    monkeypatch.setattr("coding_env.server.transforms.ast.parse", raise_recursion_error)
+    monkeypatch.setattr(
+        "coding_env.server.transforms._parse_code", raise_recursion_error
+    )
 
     transform = CodeQualityTransform(concise_bonus=0.0, syntax_penalty=-0.2)
     observation = CodeObservation(

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -29,6 +29,12 @@ def test_blocks_real_dangerous_import():
     assert "safety_violation" in observation.metadata
 
 
+def test_blocks_import_with_alias():
+    observation = _apply_safety_transform("import os as operating_system")
+    assert observation.reward == -1.0
+    assert observation.metadata["safety_violation"] == "import os"
+
+
 def test_blocks_subprocess_import():
     observation = _apply_safety_transform("import subprocess")
     assert observation.reward == -1.0

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -7,7 +7,7 @@
 """Tests for coding_env safety transform false-positive handling."""
 
 from coding_env.models import CodeObservation
-from coding_env.server.transforms import CodeSafetyTransform
+from coding_env.server.transforms import CodeQualityTransform, CodeSafetyTransform
 
 
 def _apply_safety_transform(code: str) -> CodeObservation:
@@ -97,3 +97,23 @@ def test_does_not_flag_attribute_method_named_exec():
     )
     assert observation.reward == 0.0
     assert "safety_violation" not in observation.metadata
+
+
+def test_quality_transform_handles_ast_recursion_error(monkeypatch):
+    def raise_recursion_error(_code: str):
+        raise RecursionError("pathologically nested code")
+
+    monkeypatch.setattr("coding_env.server.transforms.ast.parse", raise_recursion_error)
+
+    transform = CodeQualityTransform(concise_bonus=0.0, syntax_penalty=-0.2)
+    observation = CodeObservation(
+        stdout="",
+        stderr="",
+        exit_code=0,
+        metadata={"last_code": "x = 1"},
+    )
+
+    transformed = transform(observation)
+
+    assert isinstance(transformed, CodeObservation)
+    assert transformed.reward == -0.2

--- a/tests/envs/test_coding_safety_transform.py
+++ b/tests/envs/test_coding_safety_transform.py
@@ -6,6 +6,8 @@
 
 """Tests for coding_env safety transform false-positive handling."""
 
+from unittest.mock import patch
+
 from coding_env.models import CodeObservation
 from coding_env.server.transforms import CodeQualityTransform, CodeSafetyTransform
 
@@ -117,13 +119,9 @@ def test_does_not_flag_attribute_method_named_exec():
     assert "safety_violation" not in observation.metadata
 
 
-def test_quality_transform_handles_ast_recursion_error(monkeypatch):
+def test_quality_transform_handles_ast_recursion_error():
     def raise_recursion_error(_code: str):
         raise RecursionError("pathologically nested code")
-
-    monkeypatch.setattr(
-        "coding_env.server.transforms._parse_code", raise_recursion_error
-    )
 
     transform = CodeQualityTransform(concise_bonus=0.0, syntax_penalty=-0.2)
     observation = CodeObservation(
@@ -133,7 +131,8 @@ def test_quality_transform_handles_ast_recursion_error(monkeypatch):
         metadata={"last_code": "x = 1"},
     )
 
-    transformed = transform(observation)
+    with patch("coding_env.server.transforms.ast.parse", raise_recursion_error):
+        transformed = transform(observation)
 
     assert isinstance(transformed, CodeObservation)
     assert transformed.reward == -0.2

--- a/tests/envs/test_python_codeact_reset.py
+++ b/tests/envs/test_python_codeact_reset.py
@@ -166,3 +166,24 @@ def test_reset_changes_episode_id():
 
     # Episode IDs should be different
     assert episode_id_1 != episode_id_2
+
+
+def test_reset_accepts_episode_id_override():
+    """Test that reset() accepts an explicit episode_id."""
+    env = PythonCodeActEnv()
+
+    env.reset(episode_id="episode-123")
+
+    assert env.state.episode_id == "episode-123"
+    assert env.state.step_count == 0
+
+
+def test_step_accepts_timeout_parameter():
+    """Test that step() accepts timeout_s without raising TypeError."""
+    env = PythonCodeActEnv()
+    env.reset()
+
+    obs = env.step(CodeAction(code="print('ok')"), timeout_s=0.5)
+
+    assert obs.exit_code == 0
+    assert "ok" in obs.stdout

--- a/tests/envs/test_python_codeact_reset.py
+++ b/tests/envs/test_python_codeact_reset.py
@@ -176,14 +176,3 @@ def test_reset_accepts_episode_id_override():
 
     assert env.state.episode_id == "episode-123"
     assert env.state.step_count == 0
-
-
-def test_step_accepts_timeout_parameter():
-    """Test that step() accepts timeout_s without raising TypeError."""
-    env = PythonCodeActEnv()
-    env.reset()
-
-    obs = env.step(CodeAction(code="print('ok')"), timeout_s=0.5)
-
-    assert obs.exit_code == 0
-    assert "ok" in obs.stdout

--- a/tests/envs/test_python_codeact_reset.py
+++ b/tests/envs/test_python_codeact_reset.py
@@ -176,3 +176,13 @@ def test_reset_accepts_episode_id_override():
 
     assert env.state.episode_id == "episode-123"
     assert env.state.step_count == 0
+
+
+def test_reset_preserves_empty_episode_id_override():
+    """Test that reset() preserves any explicit non-None episode_id."""
+    env = PythonCodeActEnv()
+
+    env.reset(episode_id="")
+
+    assert env.state.episode_id == ""
+    assert env.state.step_count == 0

--- a/tests/envs/test_python_codeact_reset.py
+++ b/tests/envs/test_python_codeact_reset.py
@@ -188,13 +188,13 @@ def test_reset_accepts_seed_parameter():
     assert env.state.step_count == 0
 
 
-def test_reset_preserves_empty_episode_id_override():
-    """Test that reset() preserves any explicit non-None episode_id."""
+def test_reset_replaces_empty_episode_id_override():
+    """Test that reset() replaces an empty episode_id with a generated ID."""
     env = PythonCodeActEnv()
 
     env.reset(episode_id="")
 
-    assert env.state.episode_id == ""
+    assert env.state.episode_id
     assert env.state.step_count == 0
 
 

--- a/tests/envs/test_python_codeact_reset.py
+++ b/tests/envs/test_python_codeact_reset.py
@@ -178,6 +178,16 @@ def test_reset_accepts_episode_id_override():
     assert env.state.step_count == 0
 
 
+def test_reset_accepts_seed_parameter():
+    """Test that reset() accepts a seed for API compatibility."""
+    env = PythonCodeActEnv()
+
+    obs = env.reset(seed=42)
+
+    assert obs.exit_code == 0
+    assert env.state.step_count == 0
+
+
 def test_reset_preserves_empty_episode_id_override():
     """Test that reset() preserves any explicit non-None episode_id."""
     env = PythonCodeActEnv()
@@ -186,3 +196,13 @@ def test_reset_preserves_empty_episode_id_override():
 
     assert env.state.episode_id == ""
     assert env.state.step_count == 0
+
+
+def test_step_accepts_timeout_parameter():
+    """Test that step() accepts timeout_s for API compatibility."""
+    env = PythonCodeActEnv()
+    env.reset()
+
+    obs = env.step(CodeAction(code="print('ok')"), timeout_s=30.0)
+
+    assert obs.exit_code == 0


### PR DESCRIPTION
## Summary
This PR fixes multiple `coding_env` reliability issues with a focus on API compatibility and reward correctness.  
It aligns `PythonCodeActEnv` with expected optional `reset/step` parameters, removes duplicate server entrypoint execution blocks, and replaces regex-based safety checks 
with AST-based detection to prevent reward false positives.  
It also adds focused tests for the new behavior and safety-detection edge cases.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [x] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [ ] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
Reviewers can verify with:

```bash
# Lint / syntax checks for touched files
uv run ruff check envs/coding_env/server/python_codeact_env.py \
 envs/coding_env/server/app.py \
 envs/coding_env/server/transforms.py \
 envs/coding_env/server/__init__.py \
 tests/envs/test_python_codeact_reset.py \
 tests/envs/test_coding_safety_transform.py

uv run python -m py_compile \
 envs/coding_env/server/python_codeact_env.py \
 envs/coding_env/server/app.py \
 envs/coding_env/server/transforms.py \
 envs/coding_env/server/__init__.py \
 tests/envs/test_python_codeact_reset.py \
 tests/envs/test_coding_safety_transform.py

# Focused behavior tests
PYTHONPATH=src:envs uv run pytest tests/envs/test_python_codeact_reset.py -q
PYTHONPATH=src:envs uv run pytest tests/envs/test_coding_safety_transform.py -q
PYTHONPATH=src:envs uv run pytest tests/envs/test_coding_env_integration.py -q
```