### PR TITLE
[codex] Match Dependabot root-only config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,8 @@ updates:
       interval: "weekly"
     exclude-paths:
       - "envs/**"
-    groups:
-      root-uv:
-        applies-to: version-updates
-        patterns:
-          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      root-actions:
-        applies-to: version-updates
-        patterns:
-          - "*"


### PR DESCRIPTION
## Summary
- Remove Dependabot grouping blocks from the root uv and GitHub Actions update entries.
- Keep the root uv updater scoped to `/` with `exclude-paths: envs/**`, matching the intended config.

## Why
The env-specific Dependabot PRs should not be recreated from the root uv updater. Keeping this config minimal makes the intended scan scope explicit.

## Validation
- Parsed `.github/dependabot.yml` with PyYAML.
- Ran `git diff --check`.
