### PR TITLE
fix(cli): accept bare repo-name in openenv push --repo-id

### DIFF
--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -540,7 +540,7 @@ def push(
         typer.Option(
             "--repo-id",
             "-r",
-            help="Repository ID in format 'username/repo-name' (defaults to 'username/env-name' from openenv.yaml)",
+            help="Repository ID as 'username/repo-name' or bare 'repo-name' (expanded using authenticated username). Defaults to 'username/env-name' from openenv.yaml.",
         ),
     ] = None,
     base_image: Annotated[

--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -818,8 +818,10 @@ def push(
     if not repo_id:
         repo_id = f"{username}/{env_name}"
 
-    # Validate repo_id format
-    if "/" not in repo_id or repo_id.count("/") != 1:
+    # Accept bare repo-name and prepend the authenticated username
+    if "/" not in repo_id:
+        repo_id = f"{username}/{repo_id}"
+    elif repo_id.count("/") != 1:
         raise typer.BadParameter(
             f"Invalid repo-id format: {repo_id}. Expected format: 'username/repo-name'"
         )

--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -540,7 +540,7 @@ def push(
         typer.Option(
             "--repo-id",
             "-r",
-            help="Repository ID as 'username/repo-name' or bare 'repo-name' (expanded using authenticated username). Defaults to 'username/env-name' from openenv.yaml.",
+            help="Repository ID as 'repo_name' or 'namespace/repo_name'. Defaults to 'username/env-name' from openenv.yaml.",
         ),
     ] = None,
     base_image: Annotated[
@@ -818,13 +818,12 @@ def push(
     if not repo_id:
         repo_id = f"{username}/{env_name}"
 
-    # Accept bare repo-name and prepend the authenticated username
+    if repo_id.count("/") > 1:
+        raise typer.BadParameter(
+            f"Invalid repo-id format: {repo_id!r}. Repo id must be in the form 'repo_name' or 'namespace/repo_name'."
+        )
     if "/" not in repo_id:
         repo_id = f"{username}/{repo_id}"
-    elif repo_id.count("/") != 1:
-        raise typer.BadParameter(
-            f"Invalid repo-id format: {repo_id}. Expected format: 'username/repo-name'"
-        )
 
     # Initialize Hugging Face API
     api = HfApi()

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -551,7 +551,6 @@ def test_push_bare_repo_id_prepends_username(tmp_path: Path) -> None:
         mock_whoami.return_value = {"name": "testuser"}
         mock_login.return_value = None
         mock_hf_api_class.return_value = MagicMock()
-        mock_stage.return_value = tmp_path
         mock_create.return_value = None
         mock_upload.return_value = None
 

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -546,7 +546,7 @@ def test_push_bare_repo_id_prepends_username(tmp_path: Path) -> None:
         patch("openenv.cli.commands.push.HfApi") as mock_hf_api_class,
         patch("openenv.cli.commands.push._upload_to_hf_space") as mock_upload,
         patch("openenv.cli.commands.push._create_hf_space") as mock_create,
-        patch("openenv.cli.commands.push._prepare_staging_directory") as mock_stage,
+        patch("openenv.cli.commands.push._prepare_staging_directory") as _mock_stage,
     ):
         mock_whoami.return_value = {"name": "testuser"}
         mock_login.return_value = None

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -536,8 +536,8 @@ def test_push_validates_repo_id_format(tmp_path: Path) -> None:
         assert "repo-id" in result.output.lower() or "format" in result.output.lower()
 
 
-def test_push_bare_repo_id_prepends_username(tmp_path: Path) -> None:
-    """Bare repo-name (no slash) should be expanded to username/repo-name."""
+def test_push_bare_repo_id_expands_to_username(tmp_path: Path) -> None:
+    """Bare repo-name (no slash) is expanded to username/repo-name before push."""
     _create_test_openenv_env(tmp_path)
 
     with (
@@ -561,9 +561,9 @@ def test_push_bare_repo_id_prepends_username(tmp_path: Path) -> None:
         finally:
             os.chdir(old_cwd)
 
-        # Must not error on format validation
         assert "Invalid repo-id format" not in result.output
-        # Should have expanded to testuser/my-env
+        mock_create.assert_called_once()
+        assert mock_create.call_args.args[0] == "testuser/my-env"
         assert "testuser/my-env" in result.output
 
 

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -513,7 +513,7 @@ def test_push_initializes_hf_api_without_token(tmp_path: Path) -> None:
 
 
 def test_push_validates_repo_id_format(tmp_path: Path) -> None:
-    """Test that push validates repo-id format."""
+    """Test that push rejects repo-ids with more than one slash."""
     _create_test_openenv_env(tmp_path)
 
     with (
@@ -522,21 +522,50 @@ def test_push_validates_repo_id_format(tmp_path: Path) -> None:
         patch("openenv.cli.commands.push.HfApi") as mock_hf_api_class,
     ):
         mock_whoami.return_value = {"name": "testuser"}
-        mock_login.return_value = None  # Prevent actual login prompt
-        # Mock HfApi to prevent actual API calls
-        mock_api = MagicMock()
-        mock_hf_api_class.return_value = mock_api
+        mock_login.return_value = None
+        mock_hf_api_class.return_value = MagicMock()
 
         old_cwd = os.getcwd()
         try:
             os.chdir(str(tmp_path))
-            # Invalid format (no slash)
-            result = runner.invoke(app, ["push", "--repo-id", "invalid-repo-id"])
+            result = runner.invoke(app, ["push", "--repo-id", "org/repo/extra"])
         finally:
             os.chdir(old_cwd)
 
         assert result.exit_code != 0
         assert "repo-id" in result.output.lower() or "format" in result.output.lower()
+
+
+def test_push_bare_repo_id_prepends_username(tmp_path: Path) -> None:
+    """Bare repo-name (no slash) should be expanded to username/repo-name."""
+    _create_test_openenv_env(tmp_path)
+
+    with (
+        patch("openenv.cli.commands.push.whoami") as mock_whoami,
+        patch("openenv.cli.commands.push.login") as mock_login,
+        patch("openenv.cli.commands.push.HfApi") as mock_hf_api_class,
+        patch("openenv.cli.commands.push._upload_to_hf_space") as mock_upload,
+        patch("openenv.cli.commands.push._create_hf_space") as mock_create,
+        patch("openenv.cli.commands.push._prepare_staging_directory") as mock_stage,
+    ):
+        mock_whoami.return_value = {"name": "testuser"}
+        mock_login.return_value = None
+        mock_hf_api_class.return_value = MagicMock()
+        mock_stage.return_value = tmp_path
+        mock_create.return_value = None
+        mock_upload.return_value = None
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(str(tmp_path))
+            result = runner.invoke(app, ["push", "--repo-id", "my-env"])
+        finally:
+            os.chdir(old_cwd)
+
+        # Must not error on format validation
+        assert "Invalid repo-id format" not in result.output
+        # Should have expanded to testuser/my-env
+        assert "testuser/my-env" in result.output
 
 
 def test_push_validates_manifest_is_dict(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`openenv push --repo-id my-env` now accepts a bare repo name and expands it to `username/my-env` using the already-authenticated user's name. Previously this raised a format error even though the CLI had all the information needed to resolve the name. The `username/repo-name` form and the multi-slash error case are unchanged.

## Type of Change
- [x] Bug fix

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)

## Test Plan

```bash
# Run the two affected tests
uv run pytest tests/test_cli/test_push.py::test_push_validates_repo_id_format \
              tests/test_cli/test_push.py::test_push_bare_repo_id_prepends_username -v
```

Manual smoke test (requires HF auth):
```bash
# Should now succeed and push to sergiopaniego/my-env-test
openenv push --repo-id my-env-test
```

## Claude Code Review

## Alignment Review Report

### Automated Checks
- Lint: FAIL — 5 files need formatting, none in this diff (`envs/agent_world_model_env/server/web_ui.py`, `envs/chat_env/models.py`, `envs/chat_env/server/chat_environment.py`, `envs/repl_env/server/repl_environment.py`, `envs/textarena_env/server/gradio_ui.py`). Pre-existing, not introduced by this change.
- Debug code: CLEAN for this diff — all flagged hits are pre-existing docstring examples and a manual test script.

### Tier 1: Fixes Required

None. The 6-line change and its two tests are mechanically correct:

- `username` is guaranteed non-None at the point of use (set two lines above by `_ensure_hf_authenticated()`).
- The branch logic is sound: bare name expands, well-formed `owner/repo` passes through unchanged, anything with more than one slash still raises `BadParameter`.
- `test_push_bare_repo_id_prepends_username` correctly patches the three internal helpers so the test exercises only the validation logic.
- `test_push_validates_repo_id_format` now uses `org/repo/extra` as the invalid input, which is the correct representative of the remaining error branch.

### Tier 2: Alignment Discussion

None identified. This change lives entirely in the CLI layer and has no contact with environment API boundaries, agent-facing MCP tools, client-server separation, or reward computation. No RFC governs CLI UX conventions.

### Summary
- 0 mechanical issues to fix in this diff
- 0 alignment points for human review
