### PR TITLE
[codex] remove meta cla check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,6 @@ We actively welcome your pull requests.
 5. Make sure your code lints: `uv run ruff format src/ tests/ --check`
 6. For significant changes, write an RFC first (see `rfcs/README.md`)
 
-## Contributor License Agreement ("CLA")
-
-In order to accept your pull request, we need you to submit a CLA. You only need to do this once to work on any of Meta's open source projects.
-
-Complete your CLA here: <https://code.facebook.com/cla>
-
 ## Issues
 
 We use GitHub issues to track public bugs. Please ensure your description is clear and has sufficient instructions to reproduce the issue.


### PR DESCRIPTION
This PR removes the contributor-facing Meta CLA requirement from CONTRIBUTING.md after the Meta CLA GitHub ruleset was removed from repository settings.

Validation:
- `rg -n -i "contributor license agreement|code\.facebook\.com/cla|meta cla|facebook cla|cla assistant|cla-assistant|cla check|\bCLA\b" --glob '!**/.git/**'`\n- `git diff --check --cached` before commit\n\nNo full test suite was run because this is a docs-only change.