### PR TITLE
[codex] governance docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -6,6 +6,7 @@
 - [ ] `pyproject.toml` version changed from `X.Y.Z.dev0` → `X.Y.Z` (no `.dev0` suffix)
 - [ ] `hf-staging/` is NOT in this PR's diff
 - [ ] No `print()`, `breakpoint()`, or `TODO` in release-critical paths
+- [ ] Release notes updated for user-facing changes, including project coordination or governance changes
 
 ### CI gates (must be green before merge)
 - [ ] `test` passes on Python 3.11

--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ In addition to making it easier for researchers and RL framework writers, we als
 
 The OpenEnv CLI (`openenv`) provides commands to initialize new environments and deploy them to Hugging Face Spaces.
 
+OpenEnv is openly governed by a technical committee that includes Hugging Face, Unsloth, Reflection, and Meta PyTorch. The committee coordinates project direction, major technical decisions, RFCs, and release planning through the public issue tracker, pull requests, and RFC process.
+
 > ⚠️ **Early Development Warning** OpenEnv is currently in an experimental
 > stage. You should expect bugs, incomplete features, and APIs that may change
-> in future versions. The project welcomes bugfixes, but to make sure things are
-> well coordinated you should discuss any significant change before starting the
-> work. It's recommended that you signal your intention to contribute in the
-> issue tracker, either by filing a new issue or by claiming an existing one.
+> in future versions. The project welcomes bugfixes, but significant changes
+> should be discussed before implementation so the technical committee and
+> community can coordinate scope, compatibility, and release timing. It's
+> recommended that you signal your intention to contribute in the issue tracker,
+> either by filing a new issue or by claiming an existing one.
 
 ### RFCs
 
@@ -380,9 +383,9 @@ See the [Oumi example](https://github.com/oumi-ai/oumi/blob/main/notebooks/Oumi%
 > Browse the full catalog of community environments at [meta-pytorch.org/OpenEnv/environments](https://meta-pytorch.org/OpenEnv/environments.html).
 
 ## Community Support & Acknowledgments
-This is an open and community-centric project. If you would like to add your name here, please put up a pull request and tag @jspisak for review. Ty!!
+This is an open and community-centric project, governed in public by a technical committee that includes Hugging Face, Unsloth, Reflection, and Meta PyTorch. If you would like to add your project or organization here, please open a pull request for maintainer review.
 
-Supporters include: Meta-PyTorch, Hugging Face, [Scaler AI Labs](https://scalerailabs.com), [Patronus AI](https://patronus.ai), [Surge AI](https://surgehq.ai), [LastMile AI](https://www.lastmileai.dev), Unsloth AI, Reflection AI, vLLM, SkyRL (UC-Berkeley), LightningAI, Axolotl AI, Stanford Scaling Intelligence Lab, Mithril, [OpenMined](https://openmined.org/), [Fleet AI](https://fleetai.com), [Halluminate](https://halluminate.ai/), [Turing](https://www.turing.com/), [Scale AI](https://scale.com/), [Scorecard](https://www.scorecard.io/) ..
+Supporters include: Meta-PyTorch, Hugging Face, [Scaler AI Labs](https://scalerailabs.com), [Patronus AI](https://patronus.ai), [Surge AI](https://surgehq.ai), [LastMile AI](https://www.lastmileai.dev), Unsloth, Reflection, vLLM, SkyRL (UC-Berkeley), LightningAI, Axolotl AI, Stanford Scaling Intelligence Lab, Mithril, [OpenMined](https://openmined.org/), [Fleet AI](https://fleetai.com), [Halluminate](https://halluminate.ai/), [Turing](https://www.turing.com/), [Scale AI](https://scale.com/), [Scorecard](https://www.scorecard.io/) ..
 
 And we'd also like to acknowledge the team at Farama Foundation as the OpenEnv API was heavily inspired by the work you all have done on Gymnasium. Cheers!
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -72,6 +72,10 @@ ruff check .
 
 ## Coordination
 
+OpenEnv is openly governed by a technical committee that includes Hugging Face,
+Unsloth, Reflection, and Meta PyTorch. The committee coordinates project
+direction, major technical decisions, RFCs, and release planning in public.
+
 Use the [OpenEnv repository](https://github.com/meta-pytorch/OpenEnv) to file
 issues, discuss substantial changes, and submit pull requests.
 

--- a/docs/source/getting_started/README.rst
+++ b/docs/source/getting_started/README.rst
@@ -5,7 +5,7 @@ This section provides a hands-on introduction to reinforcement learning (RL) and
 
 **What is OpenEnv?**
 
-OpenEnv is a collaborative effort between **Meta, Hugging Face, Unsloth, GPU Mode, Reflection**, and other industry leaders to standardize reinforcement learning environments. Our goal is to make environment creation as easy and standardized as model sharing on Hugging Face.
+OpenEnv is a collaborative effort to standardize reinforcement learning environments and make environment creation as easy and standardized as model sharing on Hugging Face. The project is openly governed by a technical committee that includes **Hugging Face, Unsloth, Reflection, and Meta PyTorch**.
 
 Learning Path
 -------------

--- a/docs/source/getting_started/plot_01_introduction_quickstart.py
+++ b/docs/source/getting_started/plot_01_introduction_quickstart.py
@@ -34,8 +34,8 @@ nest_asyncio.apply()
 # ----------------
 #
 # OpenEnv is a **unified framework for building, sharing, and interacting with
-# reinforcement learning environments**. It's a collaborative effort between
-# Meta, Hugging Face, Unsloth, GPU Mode, and other industry leaders.
+# reinforcement learning environments**. It is openly governed by a technical
+# committee that includes Hugging Face, Unsloth, Reflection, and Meta PyTorch.
 #
 # **The Goal**: Make environment creation as easy and standardized as model
 # sharing on Hugging Face.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -52,10 +52,12 @@ New to OpenEnv? Follow our recommended learning path:
 
 ## How Can I Contribute?
 
-We welcome contributions from the community! If you find a bug, have a feature request, or want to contribute a new environment, please open an issue or submit a pull request. The repository is hosted on GitHub at [meta-pytorch/OpenEnv](https://github.com/meta-pytorch/OpenEnv).
+We welcome contributions from the community! OpenEnv is openly governed by a technical committee that includes Hugging Face, Unsloth, Reflection, and Meta PyTorch. The committee coordinates project direction, major technical decisions, RFCs, and release planning through the public repository.
+
+If you find a bug, have a feature request, or want to contribute a new environment, please open an issue or submit a pull request. The repository is hosted on GitHub at [meta-pytorch/OpenEnv](https://github.com/meta-pytorch/OpenEnv).
 
 ```{warning}
-OpenEnv is currently in an experimental stage. You should expect bugs, incomplete features, and APIs that may change in future versions. The project welcomes bug fixes, but to ensure coordination, please discuss significant changes before starting work. Signal your intention to contribute in the issue tracker by filing a new issue or claiming an existing one.
+OpenEnv is currently in an experimental stage. You should expect bugs, incomplete features, and APIs that may change in future versions. The project welcomes bug fixes, but significant changes should be discussed before implementation so the technical committee and community can coordinate scope, compatibility, and release timing. Signal your intention to contribute in the issue tracker by filing a new issue or claiming an existing one.
 ```
 
 ```{toctree}
@@ -96,4 +98,13 @@ environments
 :hidden:
 
 reference/index
+```
+
+```{toctree}
+:maxdepth: 1
+:caption: Project
+:hidden:
+
+contributing
+release-notes
 ```

--- a/docs/source/release-notes.md
+++ b/docs/source/release-notes.md
@@ -1,0 +1,18 @@
+# Release Notes
+
+## Governance Update
+
+OpenEnv is openly governed by a technical committee that includes Hugging Face,
+Unsloth, Reflection, and Meta PyTorch. The committee coordinates project
+direction, major technical decisions, RFCs, and release planning through the
+public issue tracker, pull requests, and RFC process.
+
+This governance model keeps OpenEnv community-centered while preserving a clear
+technical coordination path. OpenEnv standardizes how environments are
+packaged, deployed, and consumed by agents. Reward definitions, scoring
+rubrics, and trainer-specific logic can continue to live in the libraries that
+specialize in them.
+
+For substantial changes, open an issue or RFC before implementation so the
+technical committee and community can discuss scope, compatibility, and release
+timing.

--- a/docs/source/tutorials/openenv-tutorial.md
+++ b/docs/source/tutorials/openenv-tutorial.md
@@ -1244,13 +1244,18 @@ OpenEnv includes 3 complete examples:
 
 ### 🎓 Community & Support
 
-**Supported by amazing organizations:**
+**Openly governed by a technical committee including:**
 
-- 🔥 Meta PyTorch
 - 🤗 Hugging Face
-- ⚡ Unsloth AI
-- 🌟 Reflection AI
+- ⚡ Unsloth
+- 🌟 Reflection
+- 🔥 Meta PyTorch
+
+**Supported by amazing organizations and contributors.**
+
 - 🚀 And many more!
+
+Technical direction, RFCs, and release planning are coordinated in public through the OpenEnv repository.
 
 **License**: BSD 3-Clause (very permissive!)
 

--- a/src/openenv/core/README.md
+++ b/src/openenv/core/README.md
@@ -4,16 +4,19 @@ An e2e framework for creating, deploying and using isolated execution environmen
 
 In addition to making it easier for researchers and RL framework writers, we also provide tools for environment creators making it easier for them to create richer environments and make them available over familiar protocols like HTTP and packaged using canonical technologies like docker. Environment creators can use the OpenEnv framework to create environments that are isolated, secure, and easy to deploy and use.
 
+OpenEnv is openly governed by a technical committee that includes Hugging Face, Unsloth, Reflection, and Meta PyTorch. The committee coordinates project direction, major technical decisions, RFCs, and release planning through the public issue tracker, pull requests, and RFC process.
+
 
 ## Overview
 `openenv.core` provides the foundational building blocks for creating and interacting with containerized environments over HTTP. It enables you to build agent environments that can be deployed as Docker containers and accessed via a simple HTTP API.
 
 > ⚠️ **Early Development Warning** OpenEnv is currently in an experimental
 > stage. You should expect bugs, incomplete features, and APIs that may change
-> in future versions. The project welcomes bugfixes, but to make sure things are
-> well coordinated you should discuss any significant change before starting the
-> work. It's recommended that you signal your intention to contribute in the
-> issue tracker, either by filing a new issue or by claiming an existing one.
+> in future versions. The project welcomes bugfixes, but significant changes
+> should be discussed before implementation so the technical committee and
+> community can coordinate scope, compatibility, and release timing. It's
+> recommended that you signal your intention to contribute in the issue tracker,
+> either by filing a new issue or by claiming an existing one.
 
 
 # OpenEnv Core

--- a/tutorial/01-environments.md
+++ b/tutorial/01-environments.md
@@ -1117,13 +1117,18 @@ OpenEnv includes 3 complete examples:
 
 ### 🎓 Community & Support
 
-**Supported by amazing organizations:**
+**Openly governed by a technical committee including:**
 
-- 🔥 Meta PyTorch
 - 🤗 Hugging Face
-- ⚡ Unsloth AI
-- 🌟 Reflection AI
+- ⚡ Unsloth
+- 🌟 Reflection
+- 🔥 Meta PyTorch
+
+**Supported by amazing organizations and contributors.**
+
 - 🚀 And many more!
+
+Technical direction, RFCs, and release planning are coordinated in public through the OpenEnv repository.
 
 **License**: BSD 3-Clause (very permissive!)
 
@@ -1138,4 +1143,3 @@ OpenEnv includes 3 complete examples:
 3. 🎮 **Explore** other OpenSpiel games
 4. 🛠️ **Build** your own environment integration
 5. 💬 **Share** what you build with the community!
-


### PR DESCRIPTION
This PR clarifies that OpenEnv is openly governed by a technical committee including Hugging Face, Unsloth, Reflection, and Meta PyTorch.

## Changes
- Add explicit technical committee governance language to the top-level README, package README, docs landing page, contributing page, and tutorial surfaces.
- Add a release-notes page for the governance update and link it from the docs Project navigation.
- Add a release PR checklist item to keep release notes current for governance and coordination changes.

## Validation
- `git diff --check` passed after the naming corrections.
- `uv run --extra docs sphinx-build -D plot_gallery=0 -b html docs/source docs/_build/html` succeeded. Sphinx reported existing warnings from unrelated docs/docstrings and missing cross-reference targets; gallery examples were not executed.