### PR TITLE
Improve PyPI release automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -11,15 +11,16 @@
 - [ ] `test` passes on Python 3.11
 - [ ] `test` passes on Python 3.12
 - [ ] `lint` passes (usort + ruff)
+- [ ] `Package CI` builds, checks, and smoke-tests wheel/sdist installs
 
 ### TestPyPI validation (before merging)
-- [ ] Manual dispatch of `publish-pypi.yml` with `use_test_pypi=true` from this branch
-- [ ] `pip install --index-url https://test.pypi.org/simple/ openenv==X.Y.Z` installs cleanly
-- [ ] `python -c "import openenv; print(openenv.__version__)"` prints `X.Y.Z`
+- [ ] Manual dispatch of `publish-testpypi.yml` from this branch
+- [ ] TestPyPI workflow published a unique pre/dev version such as `X.Y.Z.devN` or `X.Y.ZrcN`
+- [ ] TestPyPI workflow verified `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ openenv==X.Y.Z.devN`
 
 ### Post-merge steps (author only)
 - [ ] Tag `vX.Y.Z` pushed: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`
-- [ ] GitHub Release published (triggers real PyPI publish via `release: published`)
-- [ ] PyPI publish Actions job completed successfully
+- [ ] `publish-pypi.yml` completed successfully from the tag
+- [ ] GitHub Release was created by the successful PyPI publish workflow
 - [ ] `pip install openenv==X.Y.Z` from production PyPI verified
 - [ ] `auto-bump-version.yml` created `bump/X.Y.(Z+1).dev0` PR

--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -1,4 +1,4 @@
-name: Auto-bump version after release
+name: Auto-bump version after PyPI release
 
 on:
   release:
@@ -22,6 +22,10 @@ jobs:
         id: released
         run: |
           TAG="${{ github.event.release.tag_name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: release tag must be stable and match vX.Y.Z"
+            exit 1
+          fi
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -50,6 +54,39 @@ jobs:
             echo "ERROR: pyproject.toml is '$CURRENT' but release tag is '$EXPECTED'"
             exit 1
           fi
+
+      - name: Verify release exists on PyPI
+        run: |
+          VERSION="${{ steps.released.outputs.version }}"
+          for attempt in 1 2 3 4 5; do
+            if python3 - <<'PY'
+          import os
+          import urllib.error
+          import urllib.request
+
+          version = os.environ["VERSION"]
+          url = f"https://pypi.org/pypi/openenv/{version}/json"
+          try:
+              with urllib.request.urlopen(url, timeout=30) as response:
+                  if response.status == 200:
+                      raise SystemExit(0)
+          except urllib.error.HTTPError as exc:
+              if exc.code != 404:
+                  raise
+          raise SystemExit(1)
+          PY
+            then
+              echo "openenv ${VERSION} is available on PyPI"
+              exit 0
+            fi
+            echo "openenv ${VERSION} is not visible on PyPI yet; retrying..."
+            sleep 30
+          done
+
+          echo "ERROR: openenv ${VERSION} is not available on PyPI; refusing post-release bump"
+          exit 1
+        env:
+          VERSION: ${{ steps.released.outputs.version }}
 
       - name: Create bump branch and edit pyproject.toml
         env:

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -1,0 +1,76 @@
+name: Package CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Build and smoke-test package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package metadata
+        run: python -m twine check dist/*
+
+      - name: List package contents
+        run: tar -tzf dist/*.tar.gz | head -40
+
+      - name: Smoke-test wheel install
+        run: |
+          python -m venv .pkg-smoke-wheel
+          . .pkg-smoke-wheel/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          import importlib.metadata
+          import openenv
+
+          installed = importlib.metadata.version("openenv")
+          assert openenv.__version__ == installed, (openenv.__version__, installed)
+          print(f"openenv {installed}")
+          PY
+          openenv --help
+
+      - name: Smoke-test source distribution install
+        run: |
+          python -m venv .pkg-smoke-sdist
+          . .pkg-smoke-sdist/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.tar.gz
+          python - <<'PY'
+          import importlib.metadata
+          import openenv
+
+          installed = importlib.metadata.version("openenv")
+          assert openenv.__version__ == installed, (openenv.__version__, installed)
+          print(f"openenv {installed}")
+          PY
+          openenv --help

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,74 +1,153 @@
 name: Publish OpenEnv to PyPI
 
+# Requires a PyPI Trusted Publisher for:
+# - repository: huggingface/OpenEnv
+# - workflow: publish-pypi.yml
+# - environment: pypi
 on:
-  release:
-    types: [published]
-  # Allow manual trigger for testing
-  workflow_dispatch:
-    inputs:
-      use_test_pypi:
-        description: 'Publish to Test PyPI instead of PyPI'
-        required: false
-        default: 'true'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+env:
+  PACKAGE_NAME: openenv
 
 jobs:
-  build-and-publish:
+  build:
+    name: Build release distribution
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-    - name: Validate version matches release tag
-      if: github.event_name == 'release'
-      run: |
-        PKG_VERSION=$(python3 -c "
-        import tomllib
-        with open('pyproject.toml', 'rb') as f:
-            d = tomllib.load(f)
-        print(d['project']['version'])
-        ")
-        TAG_VERSION="${GITHUB_REF_NAME#v}"
-        echo "pyproject.toml: $PKG_VERSION  |  tag: $TAG_VERSION"
-        if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-          echo "ERROR: version mismatch — bump pyproject.toml before creating the release"
-          exit 1
-        fi
-        echo "Version confirmed: $PKG_VERSION"
+      - name: Validate release tag
+        id: version
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: release tag must be stable and match vX.Y.Z"
+            exit 1
+          fi
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.11'
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-    - name: Install build dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
+          PYPROJECT_VERSION=$(python3 - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              print(tomllib.load(f)["project"]["version"])
+          PY
+          )
 
-    - name: Build package
-      run: python -m build
+          echo "pyproject.toml: ${PYPROJECT_VERSION} | tag: ${VERSION}"
+          if [ "${PYPROJECT_VERSION}" != "${VERSION}" ]; then
+            echo "ERROR: version mismatch; bump pyproject.toml before tagging"
+            exit 1
+          fi
 
-    - name: Check package
-      run: twine check dist/*
+      - name: Verify tag commit is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "ERROR: release tag commit must be reachable from origin/main"
+            exit 1
+          fi
 
-    - name: List package contents
-      run: tar -tzf dist/*.tar.gz | head -20
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
 
-    - name: Publish to Test PyPI
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.use_test_pypi == 'true'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      run: twine upload --repository testpypi dist/*
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
 
-    - name: Publish to PyPI
-      if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.use_test_pypi == 'false')
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/*
+      - name: Build package
+        run: python -m build
+
+      - name: Check package metadata
+        run: python -m twine check dist/*
+
+      - name: Smoke-test built wheel
+        run: |
+          python -m venv .pkg-smoke
+          . .pkg-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          import importlib.metadata
+          import openenv
+
+          installed = importlib.metadata.version("openenv")
+          assert openenv.__version__ == installed, (openenv.__version__, installed)
+          print(f"openenv {installed}")
+          PY
+          openenv --help
+
+      - name: Upload release distribution artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: openenv-${{ steps.version.outputs.version }}-dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/openenv/${{ needs.build.outputs.version }}/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download release distribution artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: openenv-${{ needs.build.outputs.version }}-dist
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  create-github-release:
+    name: Create GitHub Release
+    needs:
+      - build
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download release distribution artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: openenv-${{ needs.build.outputs.version }}-dist
+          path: dist/
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" dist/* \
+              --repo "${GITHUB_REPOSITORY}" \
+              --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" dist/* \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes
+          fi

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,167 @@
+name: Publish OpenEnv to TestPyPI
+
+# Requires a TestPyPI Trusted Publisher for:
+# - repository: huggingface/OpenEnv
+# - workflow: publish-testpypi.yml
+# - environment: testpypi
+on:
+  workflow_dispatch:
+    inputs:
+      version_suffix:
+        description: "PEP 440 suffix for the TestPyPI build, for example .dev123 or rc1. Defaults to .dev<run_number><run_attempt>."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  PACKAGE_NAME: openenv
+
+jobs:
+  build:
+    name: Build TestPyPI distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Prepare TestPyPI version
+        id: version
+        env:
+          VERSION_SUFFIX: ${{ inputs.version_suffix }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+          import tomllib
+
+          pyproject = pathlib.Path("pyproject.toml")
+          data = tomllib.loads(pyproject.read_text())
+          current = data["project"]["version"]
+          base = current.split("+", 1)[0]
+          base = re.sub(r"(a|b|rc)\d+$", "", base)
+          base = re.sub(r"\.dev\d+$", "", base)
+
+          suffix = os.environ["VERSION_SUFFIX"].strip()
+          if not suffix:
+              suffix = f".dev{os.environ['GITHUB_RUN_NUMBER']}{os.environ['GITHUB_RUN_ATTEMPT']}"
+
+          if not re.fullmatch(r"(a|b|rc|\.dev)\d+", suffix):
+              raise SystemExit(
+                  "version_suffix must be a PEP 440 pre/dev suffix like "
+                  ".dev123, rc1, a1, or b1"
+              )
+
+          version = f"{base}{suffix}"
+          text = pyproject.read_text()
+          text = re.sub(
+              r'^version\s*=\s*"[^"]+"',
+              f'version = "{version}"',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          pyproject.write_text(text)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"version={version}", file=output)
+
+          print(f"Prepared TestPyPI version: {version}")
+          PY
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package metadata
+        run: python -m twine check dist/*
+
+      - name: Smoke-test built wheel
+        run: |
+          python -m venv .pkg-smoke
+          . .pkg-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          import importlib.metadata
+          import openenv
+
+          installed = importlib.metadata.version("openenv")
+          assert openenv.__version__ == installed, (openenv.__version__, installed)
+          print(f"openenv {installed}")
+          PY
+          openenv --help
+
+      - name: Upload TestPyPI distribution artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: openenv-${{ steps.version.outputs.version }}-testpypi-dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/openenv/${{ needs.build.outputs.version }}/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download TestPyPI distribution artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: openenv-${{ needs.build.outputs.version }}-testpypi-dist
+          path: dist/
+
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Verify install from TestPyPI
+        run: |
+          python -m venv .testpypi-verify
+          . .testpypi-verify/bin/activate
+          python -m pip install --upgrade pip
+
+          for attempt in 1 2 3 4 5; do
+            if python -m pip install \
+              --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple/ \
+              "openenv==${{ needs.build.outputs.version }}"; then
+              break
+            fi
+            echo "Package is not visible on TestPyPI yet; retrying..."
+            sleep 30
+          done
+
+          python - <<'PY'
+          import importlib.metadata
+          import openenv
+
+          expected = "${{ needs.build.outputs.version }}"
+          installed = importlib.metadata.version("openenv")
+          assert installed == expected, (installed, expected)
+          assert openenv.__version__ == expected, (openenv.__version__, expected)
+          print(f"openenv {installed}")
+          PY


### PR DESCRIPTION
This PR improves OpenEnv's PyPI release automation by separating package validation, TestPyPI publishing, and production PyPI publishing into explicit workflows.

## Changes

- Adds Package CI for PR/main package builds, twine metadata checks, and wheel/sdist smoke installs.
- Reworks production PyPI publishing to run from stable `vX.Y.Z` tag pushes only, validate the tag and version, publish through Trusted Publishing, and create/update the GitHub Release only after PyPI succeeds.
- Adds a manual TestPyPI workflow that rewrites the build to a unique PEP 440 pre/dev version, publishes through Trusted Publishing, and verifies installation from TestPyPI with PyPI as the dependency fallback.
- Updates the post-release version bump to verify the release exists on PyPI before opening the next `.dev0` bump PR.
- Updates the release PR checklist to match the new flow.

## Test plan

- Parsed all GitHub workflow YAML files with Ruby's YAML parser.
- Ran `bash -n` against every embedded workflow `run:` block after substituting GitHub expressions.
- Ran `git diff --check`.
- Built the package locally and ran `twine check`.
- Smoke-installed both wheel and sdist locally and verified `openenv.__version__` plus `openenv --help`.
- Ran the pytest command from `.claude/hooks/test.sh` without the unavailable GNU `timeout` wrapper on macOS: `1234 passed, 85 skipped, 35 deselected`.

## Notes

- `bash .claude/hooks/lint.sh` currently reports formatting drift in existing `envs/` Python files outside this PR. I did not include a broad unrelated formatting pass in this release automation change.
- `bash .claude/hooks/test.sh` cannot run directly on this machine because macOS does not provide GNU `timeout`; the equivalent pytest command was run directly instead.
- Trusted Publishing must be configured for `publish-pypi.yml` / `pypi` and `publish-testpypi.yml` / `testpypi` before those publishing jobs can succeed.