### PR TITLE
chore: release 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openenv"
-version = "0.3.0"
+version = "0.3.1"
 description = "A unified framework for reinforcement learning environments"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR bumps the OpenEnv package version from 0.3.0 to 0.3.1 for a patch PyPI release.\n\nLocal validation completed:\n- Built sdist and wheel with python -m build\n- Ran twine check on both artifacts\n- Installed the built wheel in a clean venv\n- Verified importlib.metadata/openenv.__version__ == 0.3.1\n- Verified openenv --help runs