### PR TITLE
chore: bump dev version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openenv"
-version = "0.3.1"
+version = "0.3.2.dev0"
 description = "A unified framework for reinforcement learning environments"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR bumps the package version to 0.3.2.dev0 after publishing 0.3.1 to PyPI.