### PR TITLE
fix(auto): use proper URL parsing in _is_local_url

### DIFF
--- a/src/openenv/auto/auto_env.py
+++ b/src/openenv/auto/auto_env.py
@@ -31,12 +31,14 @@ Example:
 from __future__ import annotations
 
 import importlib
+import ipaddress
 import logging
 import os
 import shutil
 import subprocess
 import sys
 from typing import Any, Dict, Optional, TYPE_CHECKING
+from urllib.parse import urlparse
 
 import requests
 from openenv.core.utils import run_async_safely
@@ -199,8 +201,18 @@ class AutoEnv:
             >>> AutoEnv._is_local_url("https://example.com")
             False
         """
-        url_lower = url.lower()
-        return "localhost" in url_lower or "127.0.0.1" in url_lower
+        try:
+            hostname = urlparse(url).hostname or ""
+        except Exception:
+            return False
+        if not hostname:
+            return False
+        if hostname in ("localhost", "0.0.0.0"):
+            return True
+        try:
+            return ipaddress.ip_address(hostname).is_loopback
+        except ValueError:
+            return False
 
     @classmethod
     def _check_server_availability(cls, base_url: str, timeout: float = 2.0) -> bool:

--- a/tests/envs/test_auto_env.py
+++ b/tests/envs/test_auto_env.py
@@ -272,6 +272,46 @@ class TestAutoEnvHubDetection:
 
 
 # ============================================================================
+# _is_local_url Tests
+# ============================================================================
+
+
+class TestIsLocalUrl:
+    """Test AutoEnv._is_local_url() uses proper URL parsing, not substring matching."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:8000",
+            "http://localhost",
+            "http://127.0.0.1:8000",
+            "http://127.0.0.1",
+            "http://127.5.5.5",  # rest of 127.0.0.0/8 loopback range
+            "http://[::1]:8000",  # IPv6 loopback with port
+            "http://[::1]",  # IPv6 loopback bare
+            "http://0.0.0.0:8000",
+            "http://0.0.0.0",
+        ],
+    )
+    def test_local_urls_return_true(self, url):
+        assert AutoEnv._is_local_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost.evil.com",  # headline false-positive bug
+            "http://my-127.0.0.1.io",  # 127.0.0.1 as substring in domain
+            "https://example.com",
+            "https://example.com/path?q=localhost",  # only in query string
+            "not-a-url",
+            "",
+        ],
+    )
+    def test_non_local_urls_return_false(self, url):
+        assert AutoEnv._is_local_url(url) is False
+
+
+# ============================================================================
 # Git+ URL Installation Tests
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Replace the naive substring matching in `AutoEnv._is_local_url` with `urllib.parse.urlparse`-based hostname extraction, fixing three classes of failure:

- **False positive** - `http://localhost.evil.com` returned `True` because `"localhost"` appeared as a substring; the proxy-bypass logic then applied to a hostile host.
- **Missing 0.0.0.0** - was not checked at all.
- **Missing full loopback range** - only `127.0.0.1` was matched; `127.x.x.x` and the IPv6 loopback `::1` were not covered.

The new implementation:
1. Parses the URL with `urlparse` to extract the hostname (handles bracketed IPv6 automatically).
2. Exact-matches `"localhost"` and `"0.0.0.0"`.
3. Uses `ipaddress.ip_address(hostname).is_loopback` for all numeric addresses, covering `127.0.0.0/8` and `::1`.
4. Wraps everything in `try/except` so malformed URLs return `False`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan

New parametrized tests added to `tests/envs/test_auto_env.py` under `TestIsLocalUrl`:

| URL | Expected |
|-----|----------|
| `http://localhost:8000` | `True` |
| `http://127.0.0.1:8000` | `True` |
| `http://127.5.5.5` | `True` (rest of 127.0.0.0/8) |
| `http://[::1]:8000` | `True` (IPv6 loopback) |
| `http://0.0.0.0:8000` | `True` |
| `http://localhost.evil.com` | `False` (headline bug) |
| `http://my-127.0.0.1.io` | `False` |
| `https://example.com` | `False` |
| `not-a-url` | `False` |

```bash
PYTHONPATH=src:envs uv run pytest tests/envs/test_auto_env.py::TestIsLocalUrl -v
# 15 passed

PYTHONPATH=src:envs uv run pytest tests/ -v --ignore=tests/envs
# 867 passed, 12 skipped

uv run ruff format src/ tests/ --check
# 157 files already formatted
```

## Claude Code Review
N/A