### PR TITLE
chore(deps): roll up core Dependabot updates

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
     with:
       commit_sha: ${{ github.sha }}
       package: openenv

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
     with:
       package_name: openenv
     secrets:


### PR DESCRIPTION
Rolls up the currently open non-env Dependabot updates so maintainers can merge them as one PR.

Includes:
- #782
- #783
- #784
- #785

Scope:
- `.github/workflows/build_documentation.yml`
- `.github/workflows/build_pr_documentation.yml`
- `.github/workflows/test.yml`
- `.github/workflows/upload_pr_documentation.yml`

No `src/` changes. Tests were not run because this only updates GitHub Actions workflow references.