### PR TITLE
fix(pr-review-bot): only review PRs I was mentioned/review-requested on

### DIFF
--- a/scripts/PR_REVIEW_BOT.md
+++ b/scripts/PR_REVIEW_BOT.md
@@ -1,6 +1,8 @@
 # PR Review Bot
 
-Automated PR review system using Claude Code. Runs as a cron job to review open PRs.
+Automated PR review system using Claude Code. Runs as a cron job to review **only
+the PRs the maintainer was pinged on** — i.e. PRs with a GitHub notification whose
+reason is `mention` or `review_requested`. It does **not** review every open PR.
 
 ## Architecture
 
@@ -13,8 +15,8 @@ Automated PR review system using Claude Code. Runs as a cron job to review open 
                             ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                      Claude Code                            │
-│  1. Calls pr_tracker.py --list --since 6h                   │
-│  2. Spawns alignment-reviewer subagent for each PR          │
+│  1. pr_tracker.py --list --since 6h  (mention/review-req)   │
+│  2. Spawns alignment-reviewer subagent for each pinged PR   │
 │  3. Posts reviews via pr_tracker.post_review()              │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -39,10 +41,10 @@ pip install PyGithub
 ### 2. Test the Tracker
 
 ```bash
-# List PRs updated in last 6 hours
+# List PRs you were mentioned / review-requested on in the last 6 hours
 python3 scripts/pr_tracker.py --list --since 6h
 
-# List PRs updated in last day
+# ...in the last day
 python3 scripts/pr_tracker.py --list --since 1d
 
 # Get details for a specific PR
@@ -75,10 +77,10 @@ from scripts.pr_tracker import (
     parse_since,
 )
 
-# Get PRs updated in last 6 hours
+# Get PRs you were pinged on (mention / review_requested) in the last 6 hours
 since = parse_since("6h")
 prs = get_prs_needing_review(since=since)
-# Returns: [{"number": 123, "title": "...", "updated_at": "...", ...}]
+# Returns: [{"number": 123, "repo": "...", "reason": "mention", ...}]
 
 # Get detailed info about a PR
 details = get_pr_details(123)
@@ -90,13 +92,26 @@ post_review(pr_number=123, verdict="approve", body="LGTM!")
 
 ## Filtering
 
-PRs are filtered by update time using `--since`:
-- `6h` - last 6 hours
-- `1d` - last day
-- `2w` - last 2 weeks
-- `2024-01-13T00:00:00Z` - since specific timestamp
+A PR is reviewed **only** when the authenticated user (the bot's token owner) has
+a GitHub notification for it whose reason is one of:
 
-The cron job runs every 6 hours with `--since 6h`, so it reviews any PR that was updated since the last run.
+- `mention` — you were @-mentioned in the PR body or a comment
+- `review_requested` — you were added as a requested reviewer
+
+This is enforced in `get_prs_needing_review()`, which reads the notifications API
+(not the full open-PR list). `--since` only bounds how far back to look for those
+notifications; it never widens the set to PRs you weren't pinged on:
+
+- `6h` - pings in the last 6 hours
+- `1d` - pings in the last day
+- `2024-01-13T00:00:00Z` - pings since a specific timestamp
+
+The cron runs every 6 hours with `--since 6h --use-state`. `--use-state` records
+each reviewed head SHA so an unread ping isn't re-reviewed every run.
+
+> **History:** the bot originally filtered by update time alone, so it reviewed
+> *every* open PR touched in the window — spamming unrelated PRs. The
+> notification-reason filter above replaces that behaviour.
 
 ## Review Model
 

--- a/scripts/pr-review-cron-wrapper.sh
+++ b/scripts/pr-review-cron-wrapper.sh
@@ -33,10 +33,13 @@ echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Starting PR review..."
 
 # Invoke Claude to handle the reviews
 exec claude --print --dangerously-skip-permissions --max-budget-usd 100.00 "
-Review PRs updated in the last 6 hours.
+Review ONLY the PRs I was pinged on in the last 6 hours (i.e. where I was
+@-mentioned or added as a reviewer). Do NOT review PRs I wasn't pinged on.
 
-1. Run: python3 scripts/pr_tracker.py --list --since 6h
-   This returns JSON with open PRs updated in the last 6 hours.
+1. Run: python3 scripts/pr_tracker.py --list --since 6h --use-state
+   This returns JSON for ONLY the open PRs where I have a GitHub notification
+   with reason 'mention' or 'review_requested'. Each item has a 'number',
+   'repo', and 'reason'. If the list is empty, stop — there is nothing to do.
 
 2. For each PR, spawn a subagent (alignment-reviewer) to review it.
    The subagent should:
@@ -44,7 +47,9 @@ Review PRs updated in the last 6 hours.
    - Apply the two-tier review model (Tier 1: bugs/lint, Tier 2: alignment)
    - Determine verdict: approve, comment, or request_changes
 
-3. After each review, use pr_tracker.post_review() to post the GitHub review.
+3. After each review, call pr_tracker.post_review(pr_number, verdict, body) to
+   post it, then pr_tracker.record_review(pr_number, head_sha, verdict) so the
+   same commit is not re-reviewed on the next run.
 
 Run subagent reviews in parallel when possible.
 "

--- a/scripts/pr_tracker.py
+++ b/scripts/pr_tracker.py
@@ -5,12 +5,13 @@ PR Tracker - Fetches PRs that need review using GitHub API.
 This module provides data about open PRs. Claude handles orchestration,
 review logic, and posting reviews.
 
-Usage:
-    # Get PRs updated in the last 6 hours
-    python3 scripts/pr_tracker.py --list --since 6h
+Only PRs where the authenticated user was pinged are listed — i.e. a GitHub
+notification with reason ``mention`` or ``review_requested`` — never every open
+PR in the repo.
 
-    # Get PRs updated since a specific time
-    python3 scripts/pr_tracker.py --list --since 2024-01-13T00:00:00Z
+Usage:
+    # Get PRs you were mentioned / review-requested on in the last 6 hours
+    python3 scripts/pr_tracker.py --list --since 6h
 
     # Get details for a specific PR
     python3 scripts/pr_tracker.py --details 123
@@ -92,63 +93,109 @@ def parse_since(since_str: str) -> datetime:
     )
 
 
+# Notification reasons that mean "the maintainer was pinged on this PR".
+# https://docs.github.com/en/rest/activity/notifications#about-notification-reasons
+REVIEW_REASONS = ("mention", "review_requested")
+
+
 def get_prs_needing_review(
     repo: str = DEFAULT_REPO,
     since: Optional[datetime] = None,
     state_file: Optional[Path] = None,
+    reasons: tuple[str, ...] = REVIEW_REASONS,
 ) -> list[dict]:
     """
-    Get list of PRs that need review.
+    Get open PRs the authenticated user was *pinged* on.
+
+    A PR is returned only when GitHub delivered a notification for it whose
+    ``reason`` is in ``reasons`` (by default ``mention`` or ``review_requested``).
+    This is the whole point of the bot: review PRs where the maintainer was
+    explicitly @-mentioned or added as a reviewer — never every open PR in the
+    repo (the previous behaviour, which spammed unrelated PRs).
 
     Args:
-        repo: Repository name (owner/repo)
-        since: Only return PRs updated after this time
-        state_file: Optional state file for SHA-based tracking (legacy)
+        repo (`str`):
+            Repository name (``owner/repo``). Org-transfer redirects are followed.
+        since (`datetime`, *optional*):
+            Only consider notifications updated after this time.
+        state_file (`Path`, *optional*):
+            When provided, skip PRs whose current head SHA was already reviewed
+            (recorded via :func:`record_review`), so a still-unread ping is not
+            re-reviewed on every run.
+        reasons (`tuple[str, ...]`, *optional*):
+            Notification reasons that trigger a review. Defaults to
+            ``("mention", "review_requested")``.
 
     Returns:
-        List of dicts with PR info:
-        - number: PR number
-        - title: PR title
-        - author: Author username
-        - url: PR URL
-        - head_sha: Current commit SHA
-        - updated_at: Last update time (ISO format)
+        `list[dict]`: One dict per PR with keys ``number``, ``repo``, ``title``,
+        ``author``, ``url``, ``head_sha``, ``updated_at`` and ``reason``.
     """
     gh = _get_github_client()
     repo_obj = gh.get_repo(repo)
+    repo_full = repo_obj.full_name  # canonical name (follows org-transfer redirects)
 
     # Load state for SHA tracking if provided
     repo_state = {}
     if state_file and state_file.exists():
         try:
             state = json.loads(state_file.read_text())
-            repo_state = state.get(repo, {})
+            repo_state = state.get(repo_full, state.get(repo, {}))
         except json.JSONDecodeError:
             pass
 
+    wanted = set(reasons)
+    # Unread notifications only (``all=False``) so handled pings drop off; combined
+    # with ``since`` this is the set of fresh pings since the last run.
+    kwargs = {"all": False}
+    if since is not None:
+        kwargs["since"] = since
+    notifications = gh.get_user().get_notifications(**kwargs)
+
     prs = []
-    for pr in repo_obj.get_pulls(state="open"):
-        if pr.draft:
+    seen: set[int] = set()
+    for note in notifications:
+        # 1. Only act on pings (mention / review_requested) — this is the fix.
+        if note.reason not in wanted:
             continue
-
-        # Filter by update time if 'since' provided
-        if since and pr.updated_at < since:
+        subject = note.subject
+        if subject is None or subject.type != "PullRequest":
             continue
+        # 2. Scope to the target repo (compare canonical full names).
+        if (
+            note.repository is None
+            or note.repository.full_name.lower() != repo_full.lower()
+        ):
+            continue
+        # 3. Subject URL looks like .../repos/<owner>/<repo>/pulls/<number>
+        match = re.search(r"/pulls/(\d+)$", subject.url or "")
+        if not match:
+            continue
+        pr_number = int(match.group(1))
+        if pr_number in seen:
+            continue
+        seen.add(pr_number)
 
-        # If using state file, skip already-reviewed commits
+        pr = repo_obj.get_pull(pr_number)
+        if pr.draft or pr.state != "open":
+            continue
+        # 4. Skip if this exact commit was already reviewed.
         if state_file:
-            pr_state = repo_state.get(str(pr.number), {})
-            if pr_state.get("last_reviewed_sha") == pr.head.sha:
+            if (
+                repo_state.get(str(pr_number), {}).get("last_reviewed_sha")
+                == pr.head.sha
+            ):
                 continue
 
         prs.append(
             {
                 "number": pr.number,
+                "repo": repo_full,
                 "title": pr.title,
                 "author": pr.user.login,
                 "url": pr.html_url,
                 "head_sha": pr.head.sha,
                 "updated_at": pr.updated_at.isoformat(),
+                "reason": note.reason,
             }
         )
 
@@ -257,27 +304,31 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # PRs updated in last 6 hours
+  # PRs you were mentioned / review-requested on in the last 6 hours
   python3 pr_tracker.py --list --since 6h
 
-  # PRs updated in last day
+  # ...in the last day
   python3 pr_tracker.py --list --since 1d
 
-  # PRs updated since specific time
+  # ...since a specific time
   python3 pr_tracker.py --list --since 2024-01-13T00:00:00Z
 
   # Get details for PR #123
   python3 pr_tracker.py --details 123
 """,
     )
-    parser.add_argument("--list", action="store_true", help="List PRs needing review")
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List PRs you were mentioned / review-requested on",
+    )
     parser.add_argument(
         "--details", type=int, metavar="PR", help="Get details for specific PR"
     )
     parser.add_argument(
         "--since",
         type=str,
-        help="Only PRs updated since (e.g., 6h, 1d, 2024-01-13T00:00:00Z)",
+        help="Only pings since (e.g., 6h, 1d, 2024-01-13T00:00:00Z)",
     )
     parser.add_argument(
         "--repo", default=DEFAULT_REPO, help="Repository (default: %(default)s)"


### PR DESCRIPTION
The cron review bot filtered PRs by update time alone (get_prs_needing_review iterated every open PR and kept those updated within --since). It therefore auto-reviewed *every* PR touched in the window, repo-wide, posting an automated 'Claude Code' review on unrelated PRs — spam.

Replace time-based filtering with GitHub notification-reason filtering: a PR is returned only when the authenticated user has a notification for it whose reason is 'mention' or 'review_requested'. --since now only bounds how far back to look for those pings; it never widens the set. Each result also carries 'repo' and 'reason', and head-SHA state tracking (--use-state) prevents re-reviewing an unread ping every run.

Also updates the cron prompt and PR_REVIEW_BOT.md to match.

Offline-validated: ruff format/lint clean; mocked unit test covers reason, repo-scope, draft/closed, dedup, and SHA-state filtering.

## Summary
<!-- 1-3 sentences describing what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [ ] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [ ] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [ ] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [ ] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
<!-- How can reviewers verify this works? -->

## Claude Code Review
<!-- If you used Claude Code for this PR, paste the output of /alignment-review here -->
<!-- If not applicable, write "N/A" -->
