### PR TITLE
[codex] Add typing_extensions to core deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     # individual environment pyproject.toml files
     "fastapi>=0.116.0",
     "pydantic>=2.0.0",
+    "typing_extensions>=4.0.0",
     "uvicorn>=0.24.0",
     "requests>=2.25.0",
     # CLI dependencies
@@ -36,6 +37,7 @@ dependencies = [
 core = [
     "fastapi>=0.116.0",
     "pydantic>=2.0.0",
+    "typing_extensions>=4.0.0",
     "uvicorn>=0.24.0",
     "requests>=2.25.0",
     "websockets>=15.0.1",


### PR DESCRIPTION
## What changed
- added `typing_extensions` to the root `openenv` package dependencies
- added the same dependency to the `openenv[core]` extra

## Why
`src/openenv/core/env_server/interfaces.py` imports `TypedDict` from `typing_extensions`, but the package metadata did not declare that dependency. Installing `openenv` and `envs/opencode_env` into a clean Hugging Face job environment therefore failed during import before the example could run.

## Impact
This fixes clean installs for environments that import `openenv.core`, including `opencode_env` in fresh job/container environments.

## Validation
- reproduced the failure in a Hugging Face job while running the `examples/opencode_env_simple.py` benchmark
- verified the targeted import path succeeds in a fresh virtualenv after the dependency change:
  - `from openenv.core.env_server.interfaces import Message`
  - `from openenv.core.env_server.mcp_types import CallToolAction`
