### PR TITLE
docs(echo): link echo-rl, Prime Intellect, and TerminalBench citations

### DIFF
--- a/examples/echo_world_model/README.md
+++ b/examples/echo_world_model/README.md
@@ -14,7 +14,8 @@ builds, almost for free.
 
 During agent RL we normally **mask out** the environment's response tokens and
 only train on the agent's actions. **ECHO** ([arXiv 2605.24517](https://arxiv.org/abs/2605.24517),
-`microsoft/echo-rl`; and Prime Intellect's *"True Agents Model the World"*) adds
+[`microsoft/echo-rl`](https://github.com/microsoft/echo-rl); and Prime Intellect's
+[*"True Agents Model the World"*](https://www.primeintellect.ai/blog/true-agents-model-the-world)) adds
 a tiny cross-entropy loss that makes the policy **predict the environment's
 observation tokens** too:
 
@@ -26,7 +27,7 @@ The model already conditions on those observation tokens and already computes
 their logits in the same forward pass — so the extra world-modeling signal is
 **~free**: no extra rollouts, no teacher, no separate world model, just a
 different mask over logits you already have. Reported: **~2.3× faster** RL,
-TerminalBench-2.0 pass@1 ~**doubles**, recovers **50–104%** of expert-SFT with
+[TerminalBench-2.0](https://www.tbench.ai/) pass@1 ~**doubles**, recovers **50–104%** of expert-SFT with
 no teacher, and even **verifier-free** (reward off) improves held-out tasks.
 
 ## Why OpenEnv needs a small change


### PR DESCRIPTION
## Summary
The ECHO example README cites `microsoft/echo-rl`, Prime Intellect's *"True Agents Model the World"*, and TerminalBench-2.0 by name, but only the arXiv reference was a clickable link. This adds links to the other
three sources, so the performance claims in the intro (~2.3× faster, pass@1 doubling, 50–104% expert-SFT recovery) point at verifiable sources.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues — docs-only, no code paths touched

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
Markdown-only change to `examples/echo_world_model/README.md`. The three added links resolve: `github.com/microsoft/echo-rl`, `primeintellect.ai/blog/true-agents-model-the-world`, `tbench.ai`. No code changed.

## Claude Code Review

N/A