### PR TITLE
docs: list all RFCs in README and rfcs index (add RFC 000 and 010)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ The OpenEnv CLI (`openenv`) provides commands to initialize new environments and
 
 Below is a list of active and historical RFCs for OpenEnv. RFCs are proposals for major changes or features. Please review and contribute!
 
+- [RFC 000: Project Phases and Design Principles](https://github.com/huggingface/OpenEnv/pull/44)
 - [RFC 001: Baseline API and Interface Specifications](https://github.com/huggingface/OpenEnv/pull/26)
 - [RFC 002: Discoverability of environment tools by agents](https://github.com/huggingface/OpenEnv/pull/32)
 - [RFC 003: Add MCP (Model Context Protocol) support](https://github.com/huggingface/OpenEnv/pull/224)
 - [RFC 004: Add delayed rewards support for trajectory-based scoring](https://github.com/huggingface/OpenEnv/pull/337)
 - [RFC 005: Agentic Harness Integration](https://github.com/huggingface/OpenEnv/pull/387)
+- [RFC 010: Env-token World Modeling (ECHO)](https://github.com/huggingface/OpenEnv/pull/819)
 
 ## Architecture
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -93,6 +93,9 @@ Each RFC should include the following sections:
 ### Agentic Harnesses
 - [005-agentic-harnesses.md](./005-agentic-harnesses.md) - Agentic Harness Integration (OpenClaw, Claude Code, etc.)
 
+### World Modeling
+- [010-echo-env-token-world-model.md](./010-echo-env-token-world-model.md) - Env-token World Modeling (ECHO): trajectory token-role masks + an optimizer world-loss seam
+
 ## Questions?
 
 For questions about the RFC process, reach out to the core team or open a discussion in the project repository.


### PR DESCRIPTION
## Summary

The RFC indexes were out of sync with the `rfcs/` directory. The root `README.md` list was missing **RFC 000** (Project Phases) and **RFC 010** (ECHO); `rfcs/README.md` was missing **RFC 010**. This adds the
missing entries so both indexes list every RFC file in `rfcs/`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues — docs-only, no code paths touched

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
Markdown-only change to `README.md` and `rfcs/README.md`. Verified `rfcs/` contains 000–005 and 010, and both indexes now list all of them. New PR links: RFC 000 → #44, RFC 010 → #819 (matching the existing
PR-link style in the root README).

## Claude Code Review

N/A
