### PR TITLE
[codex] refactor build context detection

### DIFF
--- a/src/openenv/cli/commands/build.py
+++ b/src/openenv/cli/commands/build.py
@@ -35,6 +35,15 @@ def _is_openenv_runtime_dependency(dep: str) -> bool:
     )
 
 
+def _is_in_repo_env_path(env_path: Path, repo_root: Path) -> bool:
+    """Return whether env_path points to an environment below repo_root/envs."""
+    try:
+        rel_path = env_path.relative_to(repo_root)
+    except ValueError:
+        return False
+    return len(rel_path.parts) > 1 and rel_path.parts[0] == "envs"
+
+
 def _detect_build_context(env_path: Path) -> tuple[str, Path, Path | None]:
     """
     Detect whether we're building a standalone or in-repo environment.
@@ -61,19 +70,8 @@ def _detect_build_context(env_path: Path) -> tuple[str, Path, Path | None]:
         # Not in a git repo = standalone
         return "standalone", env_path, None
 
-    # Check if environment is under envs/ (in-repo pattern)
-    try:
-        rel_path = env_path.relative_to(repo_root)
-        rel_str = str(rel_path)
-        if (
-            rel_str.startswith("envs/")
-            or rel_str.startswith("envs\\")
-            or rel_str.startswith("envs/")
-        ):
-            # In-repo environment
-            return "in-repo", repo_root, repo_root
-    except ValueError:
-        pass
+    if _is_in_repo_env_path(env_path, repo_root):
+        return "in-repo", repo_root, repo_root
 
     # Otherwise, it's standalone (environment outside repo structure)
     return "standalone", env_path, None

--- a/tests/test_cli/test_build.py
+++ b/tests/test_cli/test_build.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for openenv build helpers."""
+
+from pathlib import Path
+
+from openenv.cli.commands.build import _detect_build_context
+
+
+def test_detect_build_context_uses_envs_child_as_in_repo(tmp_path: Path) -> None:
+    """An environment below repo_root/envs uses the repository as build context."""
+    repo_root = tmp_path / "repo"
+    env_path = repo_root / "envs" / "example_env"
+    env_path.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+
+    assert _detect_build_context(env_path) == (
+        "in-repo",
+        repo_root.absolute(),
+        repo_root.absolute(),
+    )
+
+
+def test_detect_build_context_keeps_repo_sibling_standalone(tmp_path: Path) -> None:
+    """A repo-local directory outside envs/ remains a standalone environment."""
+    repo_root = tmp_path / "repo"
+    env_path = repo_root / "examples" / "example_env"
+    env_path.mkdir(parents=True)
+    (repo_root / ".git").mkdir()
+
+    assert _detect_build_context(env_path) == (
+        "standalone",
+        env_path.absolute(),
+        None,
+    )
+
+
+def test_detect_build_context_keeps_non_git_path_standalone(tmp_path: Path) -> None:
+    """A path outside any repository remains a standalone environment."""
+    env_path = tmp_path / "example_env"
+    env_path.mkdir()
+
+    assert _detect_build_context(env_path) == (
+        "standalone",
+        env_path.absolute(),
+        None,
+    )


### PR DESCRIPTION
Refactors the build context path check into a small helper that uses Path.parts instead of repeated string prefixes. Adds focused coverage for in-repo and standalone build-context detection.