### PR TITLE
[codex] refactor get endpoint registration

### DIFF
--- a/src/openenv/core/env_server/route_config.py
+++ b/src/openenv/core/env_server/route_config.py
@@ -30,6 +30,17 @@ class GetEndpointConfig:
     description: str
 
 
+def _make_get_endpoint(
+    handler: Callable[[], BaseModel | dict],
+) -> Callable[[], BaseModel | dict]:
+    """Wrap a sync GET handler in the async endpoint FastAPI expects."""
+
+    async def endpoint() -> BaseModel | dict:
+        return handler()
+
+    return endpoint
+
+
 def register_get_endpoints(app: FastAPI, configs: List[GetEndpointConfig]) -> None:
     """
     Register multiple GET endpoints from configuration.
@@ -41,19 +52,10 @@ def register_get_endpoints(app: FastAPI, configs: List[GetEndpointConfig]) -> No
             List of GET endpoint configurations.
     """
     for config in configs:
-        # Capture handler in a closure to avoid non-serializable default parameter
-        def make_endpoint(
-            handler: Callable[[], BaseModel | dict],
-        ) -> Callable[[], BaseModel | dict]:
-            async def endpoint() -> BaseModel | dict:
-                return handler()
-
-            return endpoint
-
         app.get(
             config.path,
             response_model=config.response_model,
             tags=[config.tag],
             summary=config.summary,
             description=config.description,
-        )(make_endpoint(config.handler))
+        )(_make_get_endpoint(config.handler))

--- a/tests/core/test_route_config.py
+++ b/tests/core/test_route_config.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for declarative route registration helpers."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from openenv.core.env_server.route_config import (
+    GetEndpointConfig,
+    register_get_endpoints,
+)
+from pydantic import BaseModel
+
+
+class _RouteResponse(BaseModel):
+    value: str
+
+
+def test_register_get_endpoints_binds_each_handler() -> None:
+    """Each configured endpoint keeps its own handler binding."""
+    app = FastAPI()
+
+    register_get_endpoints(
+        app,
+        [
+            GetEndpointConfig(
+                path="/first",
+                handler=lambda: _RouteResponse(value="first"),
+                response_model=_RouteResponse,
+                tag="test",
+                summary="First",
+                description="First endpoint",
+            ),
+            GetEndpointConfig(
+                path="/second",
+                handler=lambda: _RouteResponse(value="second"),
+                response_model=_RouteResponse,
+                tag="test",
+                summary="Second",
+                description="Second endpoint",
+            ),
+        ],
+    )
+
+    client = TestClient(app)
+
+    assert client.get("/first").json() == {"value": "first"}
+    assert client.get("/second").json() == {"value": "second"}


### PR DESCRIPTION
Hoists the GET endpoint wrapper out of the registration loop so route_config keeps the loop focused on route metadata. Adds focused coverage that multiple configured endpoints retain their own handlers.