### PR TITLE
[codex] refactor skills agent target selection

### DIFF
--- a/src/openenv/cli/commands/skills.py
+++ b/src/openenv/cli/commands/skills.py
@@ -62,6 +62,8 @@ LOCAL_TARGETS = {
     "opencode": Path(".opencode/skills"),
 }
 
+_AGENT_TARGET_ORDER = ("claude", "codex", "cursor", "opencode")
+
 app = typer.Typer(help="Manage OpenEnv skills for AI assistants")
 
 
@@ -130,6 +132,12 @@ def _create_symlink(
     return link_path
 
 
+def _selected_agent_targets(
+    targets: dict[str, Path], selected_agents: dict[str, bool]
+) -> list[Path]:
+    return [targets[agent] for agent in _AGENT_TARGET_ORDER if selected_agents[agent]]
+
+
 @app.command("preview")
 def skills_preview() -> None:
     """Print generated SKILL.md content."""
@@ -191,16 +199,15 @@ def skills_add(
     )
 
     targets = GLOBAL_TARGETS if global_ else LOCAL_TARGETS
-    agent_targets: list[Path] = []
-
-    if claude:
-        agent_targets.append(targets["claude"])
-    if codex:
-        agent_targets.append(targets["codex"])
-    if cursor:
-        agent_targets.append(targets["cursor"])
-    if opencode:
-        agent_targets.append(targets["opencode"])
+    agent_targets = _selected_agent_targets(
+        targets,
+        {
+            "claude": claude,
+            "codex": codex,
+            "cursor": cursor,
+            "opencode": opencode,
+        },
+    )
 
     for agent_target in agent_targets:
         link_path = _create_symlink(agent_target, central_skill_path, force)

--- a/tests/test_cli/test_skills.py
+++ b/tests/test_cli/test_skills.py
@@ -82,3 +82,20 @@ def test_skills_add_creates_agent_symlink(tmp_path: Path) -> None:
     target_path = tmp_path / ".agents" / "skills" / "openenv-cli"
     assert link_path.is_symlink()
     assert link_path.resolve() == target_path.resolve()
+
+
+def test_skills_add_creates_multiple_agent_symlinks(tmp_path: Path) -> None:
+    """Multiple assistant flags create symlinks to the same central skill."""
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(app, ["skills", "add", "--claude", "--codex"])
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == 0
+    target_path = tmp_path / ".agents" / "skills" / "openenv-cli"
+    for agent_dir in (".claude", ".codex"):
+        link_path = tmp_path / agent_dir / "skills" / "openenv-cli"
+        assert link_path.is_symlink()
+        assert link_path.resolve() == target_path.resolve()


### PR DESCRIPTION
Moves assistant target selection for `openenv skills add` into one ordered helper.

Checks: ruff, usort, focused skills tests, full CLI tests.
