### PR TITLE
[codex] fix opencode example mcp path

### DIFF
--- a/examples/opencode_env_simple.py
+++ b/examples/opencode_env_simple.py
@@ -91,8 +91,9 @@ async def main() -> int:
     print(f"Instruction:     {INSTRUCTION.splitlines()[0]} ...")
     print()
 
-    async with OpenCodeEnv(base_url=SPACE) as env:
-        await env.reset()
+    env = OpenCodeEnv(base_url=SPACE)
+    env.use_production_mode = True
+    try:
         raw = await env.call_tool(
             "run_rollout",
             endpoint="openai",  # vllm | openai | hf_router
@@ -106,6 +107,8 @@ async def main() -> int:
             agent_timeout_s=600,
         )
         result = RolloutResult.model_validate_json(_extract_text(raw))
+    finally:
+        await env.close()
 
     print("--- result ---")
     print(f"reward:    {result.reward}")


### PR DESCRIPTION
Use the hosted OpenCode Space through the MCP HTTP endpoint instead of opening the absent WebSocket path.
