### PR TITLE
refactor CLI Hugging Face username helper

### DIFF
--- a/src/openenv/cli/_cli_utils.py
+++ b/src/openenv/cli/_cli_utils.py
@@ -15,6 +15,22 @@ from rich.console import Console
 console = Console()
 
 
+def _extract_hf_username(user_info: object) -> str | None:
+    """Extract a username from the supported Hugging Face whoami shapes."""
+    if isinstance(user_info, dict):
+        return (
+            user_info.get("name")
+            or user_info.get("fullname")
+            or user_info.get("username")
+        )
+
+    return (
+        getattr(user_info, "name", None)
+        or getattr(user_info, "fullname", None)
+        or getattr(user_info, "username", None)
+    )
+
+
 def validate_env_structure(env_dir: Path, strict: bool = False) -> List[str]:
     """
     Validate that the directory follows OpenEnv environment structure.

--- a/src/openenv/cli/commands/fork.py
+++ b/src/openenv/cli/commands/fork.py
@@ -13,7 +13,7 @@ from typing import Annotated
 import typer
 from huggingface_hub import HfApi, login, whoami
 
-from .._cli_utils import console
+from .._cli_utils import _extract_hf_username, console
 
 app = typer.Typer(
     help="Fork (duplicate) an OpenEnv environment on Hugging Face to your account"
@@ -37,19 +37,7 @@ def _parse_key_value(s: str) -> tuple[str, str]:
 def _ensure_hf_authenticated() -> str:
     """Ensure user is authenticated with Hugging Face. Returns username."""
     try:
-        user_info = whoami()
-        if isinstance(user_info, dict):
-            username = (
-                user_info.get("name")
-                or user_info.get("fullname")
-                or user_info.get("username")
-            )
-        else:
-            username = (
-                getattr(user_info, "name", None)
-                or getattr(user_info, "fullname", None)
-                or getattr(user_info, "username", None)
-            )
+        username = _extract_hf_username(whoami())
         if not username:
             raise ValueError("Could not extract username from whoami response")
         console.print(f"[bold green]✓[/bold green] Authenticated as: {username}")
@@ -60,19 +48,7 @@ def _ensure_hf_authenticated() -> str:
         )
         try:
             login()
-            user_info = whoami()
-            if isinstance(user_info, dict):
-                username = (
-                    user_info.get("name")
-                    or user_info.get("fullname")
-                    or user_info.get("username")
-                )
-            else:
-                username = (
-                    getattr(user_info, "name", None)
-                    or getattr(user_info, "fullname", None)
-                    or getattr(user_info, "username", None)
-                )
+            username = _extract_hf_username(whoami())
             if not username:
                 raise ValueError("Could not extract username from whoami response")
             console.print(f"[bold green]✓[/bold green] Authenticated as: {username}")

--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -19,7 +19,7 @@ import typer
 import yaml
 from huggingface_hub import HfApi, login, whoami
 
-from .._cli_utils import console, validate_env_structure
+from .._cli_utils import _extract_hf_username, console, validate_env_structure
 
 app = typer.Typer(help="Push an OpenEnv environment to Hugging Face Spaces")
 
@@ -241,22 +241,6 @@ def _validate_openenv_directory(directory: Path) -> tuple[str, dict]:
         raise typer.BadParameter("openenv.yaml must contain a 'name' field")
 
     return env_name, manifest
-
-
-def _extract_hf_username(user_info: object) -> str | None:
-    """Extract a username from the supported Hugging Face whoami shapes."""
-    if isinstance(user_info, dict):
-        return (
-            user_info.get("name")
-            or user_info.get("fullname")
-            or user_info.get("username")
-        )
-
-    return (
-        getattr(user_info, "name", None)
-        or getattr(user_info, "fullname", None)
-        or getattr(user_info, "username", None)
-    )
 
 
 def _get_hf_username() -> str:

--- a/tests/test_cli/test_fork.py
+++ b/tests/test_cli/test_fork.py
@@ -6,6 +6,7 @@
 
 """Tests for the openenv fork command."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from openenv.cli.__main__ import app
@@ -50,6 +51,27 @@ def test_fork_calls_duplicate_space_with_from_id() -> None:
         assert call_kwargs["private"] is False
         # HF API requires hardware; default to free cpu-basic when not specified
         assert call_kwargs["hardware"] == "cpu-basic"
+
+
+def test_fork_authenticates_object_whoami_response() -> None:
+    """Test that fork accepts object-shaped whoami responses."""
+    with (
+        patch("openenv.cli.commands.fork.whoami") as mock_whoami,
+        patch("openenv.cli.commands.fork.login") as mock_login,
+        patch("openenv.cli.commands.fork.HfApi") as mock_hf_api_class,
+    ):
+        mock_whoami.return_value = SimpleNamespace(username="testuser")
+        mock_api = MagicMock()
+        mock_api.duplicate_space.return_value = (
+            "https://huggingface.co/spaces/testuser/source-space"
+        )
+        mock_hf_api_class.return_value = mock_api
+
+        result = runner.invoke(app, ["fork", "owner/source-space"])
+
+        assert result.exit_code == 0
+        mock_login.assert_not_called()
+        mock_api.duplicate_space.assert_called_once()
 
 
 def test_fork_passes_private_and_to_id() -> None:


### PR DESCRIPTION
Refactors CLI Hugging Face username extraction into shared CLI utilities and reuses it from `openenv fork` and `openenv push`.

Validation:
- `uv run ruff check src/openenv/cli/_cli_utils.py src/openenv/cli/commands/push.py src/openenv/cli/commands/fork.py tests/test_cli/test_fork.py`
- `uv run ruff format --check src/openenv/cli/_cli_utils.py src/openenv/cli/commands/push.py src/openenv/cli/commands/fork.py tests/test_cli/test_fork.py`
- `uv run usort check src/openenv/cli/_cli_utils.py src/openenv/cli/commands/push.py src/openenv/cli/commands/fork.py tests/test_cli/test_fork.py`
- `PYTHONPATH=src:envs uv run python -m pytest tests/test_cli -q`
