### PR TITLE
refactor build arg parsing

### DIFF
--- a/src/openenv/cli/commands/build.py
+++ b/src/openenv/cli/commands/build.py
@@ -325,6 +325,23 @@ def _push_docker_image(tag: str, registry: str | None = None) -> bool:
     return result.returncode == 0
 
 
+def _parse_build_args(raw_args: list[str] | None) -> dict[str, str]:
+    """Parse Docker build args from repeated KEY=VALUE CLI options."""
+    build_args: dict[str, str] = {}
+
+    for arg in raw_args or []:
+        if "=" in arg:
+            key, value = arg.split("=", 1)
+            build_args[key] = value
+        else:
+            print(
+                f"Warning: Invalid build arg format: {arg}",
+                file=sys.stderr,
+            )
+
+    return build_args
+
+
 @app.command()
 def build(
     env_path: Annotated[
@@ -435,18 +452,7 @@ def build(
     console.print(f"[bold]Building Docker image for:[/bold] {env_path_obj.name}")
     console.print("=" * 60)
 
-    # Parse build args
-    build_args = {}
-    if build_arg:
-        for arg in build_arg:
-            if "=" in arg:
-                key, value = arg.split("=", 1)
-                build_args[key] = value
-            else:
-                print(
-                    f"Warning: Invalid build arg format: {arg}",
-                    file=sys.stderr,
-                )
+    build_args = _parse_build_args(build_arg)
 
     # Convert string paths to Path objects
     context_path_obj = Path(context) if context else None

--- a/tests/test_cli/test_build.py
+++ b/tests/test_cli/test_build.py
@@ -8,7 +8,7 @@
 
 from pathlib import Path
 
-from openenv.cli.commands.build import _detect_build_context
+from openenv.cli.commands.build import _detect_build_context, _parse_build_args
 
 
 def test_detect_build_context_uses_envs_child_as_in_repo(tmp_path: Path) -> None:
@@ -49,3 +49,19 @@ def test_detect_build_context_keeps_non_git_path_standalone(tmp_path: Path) -> N
         env_path.absolute(),
         None,
     )
+
+
+def test_parse_build_args_preserves_values_with_equals() -> None:
+    """Build arg parsing only splits on the first equals sign."""
+    assert _parse_build_args(["ENV=prod", "TOKEN=a=b=c"]) == {
+        "ENV": "prod",
+        "TOKEN": "a=b=c",
+    }
+
+
+def test_parse_build_args_warns_and_skips_invalid(capsys) -> None:
+    """Malformed build args keep the existing warning-and-skip behavior."""
+    assert _parse_build_args(["missing_equals", "ENV=prod"]) == {"ENV": "prod"}
+
+    captured = capsys.readouterr()
+    assert "Warning: Invalid build arg format: missing_equals" in captured.err


### PR DESCRIPTION
Extracts `openenv build` Docker build-arg parsing into a helper while preserving the existing warning-and-skip behavior for malformed values.

Validation:
- `uv run ruff check src/openenv/cli/commands/build.py tests/test_cli/test_build.py`
- `uv run ruff format --check src/openenv/cli/commands/build.py tests/test_cli/test_build.py`
- `uv run usort check src/openenv/cli/commands/build.py tests/test_cli/test_build.py`
- `PYTHONPATH=src:envs uv run python -m pytest tests/test_cli -q`
