### PR TITLE
[codex] refactor MCP list tools helpers

### DIFF
--- a/src/openenv/core/env_server/mcp_environment.py
+++ b/src/openenv/core/env_server/mcp_environment.py
@@ -107,6 +107,33 @@ def get_server_tools(mcp_server: Any) -> Dict[str, Any]:
     return {}
 
 
+def _tool_from_server_tool(tool: Any) -> Tool:
+    """Convert a FastMCP tool object into OpenEnv's Tool model."""
+    return Tool(
+        name=tool.name,
+        description=tool.description or "",
+        input_schema=tool.inputSchema if hasattr(tool, "inputSchema") else {},
+    )
+
+
+def _tool_from_mode_schema(schema: Dict[str, Any]) -> Tool:
+    """Convert a stored mode-aware schema into OpenEnv's Tool model."""
+    return Tool(
+        name=schema["name"],
+        description=schema["description"],
+        input_schema=schema["input_schema"],
+    )
+
+
+def _schema_for_mode(
+    mode_schemas: Dict[Optional[str], Dict[str, Any]], current_mode: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """Return the schema visible for the current mode, if any."""
+    if None in mode_schemas:
+        return mode_schemas[None]
+    return mode_schemas.get(current_mode)
+
+
 class MCPEnvironment(Environment):
     """
     Base class for environments that expose tools via MCP (Model Context Protocol).
@@ -474,34 +501,11 @@ class MCPEnvironment(Environment):
             tools = []
             for tool in tools_result:
                 if tool.name not in self._mode_tool_schemas:
-                    tools.append(
-                        Tool(
-                            name=tool.name,
-                            description=tool.description or "",
-                            input_schema=tool.inputSchema
-                            if hasattr(tool, "inputSchema")
-                            else {},
-                        )
-                    )
-            for tool_name, mode_schemas in self._mode_tool_schemas.items():
-                if None in mode_schemas:
-                    schema = mode_schemas[None]
-                    tools.append(
-                        Tool(
-                            name=schema["name"],
-                            description=schema["description"],
-                            input_schema=schema["input_schema"],
-                        )
-                    )
-                elif current_mode in mode_schemas:
-                    schema = mode_schemas[current_mode]
-                    tools.append(
-                        Tool(
-                            name=schema["name"],
-                            description=schema["description"],
-                            input_schema=schema["input_schema"],
-                        )
-                    )
+                    tools.append(_tool_from_server_tool(tool))
+            for mode_schemas in self._mode_tool_schemas.values():
+                schema = _schema_for_mode(mode_schemas, current_mode)
+                if schema is not None:
+                    tools.append(_tool_from_mode_schema(schema))
             return ListToolsObservation(tools=tools)
         except Exception as e:
             return ListToolsObservation(


### PR DESCRIPTION
Summary
- Extract MCP list_tools tool construction and mode schema selection helpers.

Tests
- uv run ruff check src/openenv/core/env_server/mcp_environment.py
- uv run ruff format --check src/openenv/core/env_server/mcp_environment.py
- uv run usort check src/openenv/core/env_server/mcp_environment.py
- PYTHONPATH=src:envs uv run python -m pytest tests/core/test_mcp/test_mode_aware_tools.py tests/core/test_mcp/test_mcp_environment.py -q
- PYTHONPATH=src:envs uv run python -m pytest tests/core/test_mcp/test_mcp_client.py tests/core/test_production_mode_mcp.py -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of list-tools assembly with no API or routing changes; behavior should match prior logic and is covered by existing MCP tests.
> 
> **Overview**
> Refactors **`ListToolsAction`** handling in `MCPEnvironment` by pulling duplicated `Tool` construction and mode-schema selection into module-level helpers (`_tool_from_server_tool`, `_tool_from_mode_schema`, `_schema_for_mode`).
> 
> **`_async_handle_list_tools`** now builds the tool list through those helpers instead of inline `Tool(...)` blocks, and walks **`_mode_tool_schemas.values()`** while **`_schema_for_mode`** picks the schema for the current mode (all-modes entry vs mode-specific). Intended behavior for server tools and mode-aware tools is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a41f9323fe3d18ffb2aa34a403e6b29a00e39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->