### PR TITLE
core: make EnvClient WebSocket keepalive configurable

### DIFF
--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -145,6 +145,8 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         max_message_size_mb: float = 100.0,
         provider: Optional["ContainerProvider | RuntimeProvider"] = None,
         mode: Optional[str] = None,
+        ping_interval_s: Optional[float] = 20.0,
+        ping_timeout_s: Optional[float] = 20.0,
     ):
         """
         Initialize environment client.
@@ -167,6 +169,14 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
                 `'production'` for MCP JSON-RPC protocol. Can also be set via the
                 `OPENENV_CLIENT_MODE` environment variable. Constructor parameter takes
                 precedence over environment variable. Case-insensitive.
+            ping_interval_s (`float`, *optional*, defaults to `20.0`):
+                Interval in seconds between WebSocket keepalive pings. Set to `None`
+                to disable client-side keepalive, which is required for sandbox
+                tunnels that do not forward ping/pong frames (e.g. some cloud
+                providers); otherwise the connection is closed on the ping timeout.
+            ping_timeout_s (`float`, *optional*, defaults to `20.0`):
+                Seconds to wait for a pong before closing the connection. Set to
+                `None` to disable the pong timeout.
         """
         # Store mode (use object.__setattr__ to bypass immutability)
         object.__setattr__(self, "_mode", _normalize_mode(mode))
@@ -181,6 +191,8 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
             max_message_size_mb * 1024 * 1024
         )  # Convert MB to bytes
         self._provider = provider
+        self._ping_interval = ping_interval_s
+        self._ping_timeout = ping_timeout_s
         self._ws: Optional[ClientConnection] = None
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -215,6 +227,8 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
                 self._ws_url,
                 open_timeout=self._connect_timeout,
                 max_size=self._max_message_size,
+                ping_interval=self._ping_interval,
+                ping_timeout=self._ping_timeout,
                 **connect_kwargs,
             )
         except Exception as e:

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -694,6 +694,46 @@ class TestGenericEnvClientConnection:
 
         assert "NO_PROXY" not in os.environ
 
+    @pytest.mark.asyncio
+    async def test_keepalive_pings_forwarded_by_default(self):
+        """ws_connect receives the default keepalive (20s) unless overridden."""
+        observed = {}
+
+        async def fake_ws_connect(*args, **kwargs):
+            observed["ping_interval"] = kwargs.get("ping_interval", "MISSING")
+            observed["ping_timeout"] = kwargs.get("ping_timeout", "MISSING")
+            return MagicMock()
+
+        client = GenericEnvClient(base_url="ws://remote.example.com:8000")
+
+        with patch("openenv.core.env_client.ws_connect", side_effect=fake_ws_connect):
+            await client.connect()
+
+        assert observed["ping_interval"] == 20.0
+        assert observed["ping_timeout"] == 20.0
+
+    @pytest.mark.asyncio
+    async def test_keepalive_can_be_disabled(self):
+        """ping_interval_s=None disables keepalive for tunnels that drop ping/pong."""
+        observed = {}
+
+        async def fake_ws_connect(*args, **kwargs):
+            observed["ping_interval"] = kwargs.get("ping_interval", "MISSING")
+            observed["ping_timeout"] = kwargs.get("ping_timeout", "MISSING")
+            return MagicMock()
+
+        client = GenericEnvClient(
+            base_url="ws://remote.example.com:8000",
+            ping_interval_s=None,
+            ping_timeout_s=None,
+        )
+
+        with patch("openenv.core.env_client.ws_connect", side_effect=fake_ws_connect):
+            await client.connect()
+
+        assert observed["ping_interval"] is None
+        assert observed["ping_timeout"] is None
+
 
 # ============================================================================
 # Integration Tests (require running server)


### PR DESCRIPTION
## Summary
Adds `ping_interval_s` / `ping_timeout_s` to `EnvClient`, forwarded to the WebSocket `ws_connect`. Default is `20.0` (the `websockets` default, so existing behavior is unchanged); passing `ping_interval_s=None` disables client-side keepalive, which sandbox tunnels that drop WebSocket ping/pong frames require to stay connected. Surfaced in #821 (Modal), where the E2E previously needed a monkeypatch of `ws_connect`.

Closes #875.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
New unit tests (no network) patch `ws_connect` and assert the keepalive args are forwarded:
- default → `ping_interval=20.0`, `ping_timeout=20.0` (behavior unchanged)
- `ping_interval_s=None` / `ping_timeout_s=None` → forwarded as `None` (keepalive disabled)

`PYTHONPATH=src:envs pytest tests/test_core/test_generic_client.py -m "not integration"` → 68 passed. Lint clean (`ruff format --check`, `ruff check`).

## Claude Code Review
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible addition to core WebSocket connect options with targeted unit tests; no auth or data-path changes.
> 
> **Overview**
> **`EnvClient`** (and subclasses like **`GenericEnvClient`**) now accept **`ping_interval_s`** and **`ping_timeout_s`**, which are passed through to **`ws_connect`** on connect. Defaults stay **20s** for both, so behavior is unchanged unless callers override.
> 
> Setting either to **`None`** turns off client-side keepalive / pong timeout—needed when sandbox tunnels (e.g. Modal) drop WebSocket ping/pong frames and would otherwise drop the session on timeout.
> 
> Unit tests patch **`ws_connect`** to assert default forwarding and **`None`** when keepalive is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3866684bc6a5ccffa9bcde7ccf04e06ddad8a39b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->