### PR TITLE
fix: address modal provider review feedback

### DIFF
--- a/examples/modal_echo_env.py
+++ b/examples/modal_echo_env.py
@@ -14,9 +14,12 @@ Requires:
 """
 
 import asyncio
+import logging
 
 from echo_env import EchoEnv
 from openenv.core.containers.runtime.modal_provider import ModalProvider
+
+logger = logging.getLogger(__name__)
 
 
 async def _interact(base_url: str) -> None:
@@ -25,31 +28,25 @@ async def _interact(base_url: str) -> None:
         await env.reset()
 
         tools = await env.list_tools()
-        print("Available tools:", [t.name for t in tools])
+        logger.info("Available tools: %s", [t.name for t in tools])
 
         echoed = await env.call_tool("echo_message", message="Hello, World!")
-        print("echo_message ->", echoed)
+        logger.info("echo_message -> %s", echoed)
 
 
 def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
     image = ModalProvider.image_from_dockerfile("envs/echo_env/server/Dockerfile")
 
-    # Provision the sandbox synchronously. The Modal SDK's blocking API warns
-    # when driven from inside a running event loop, so the provider lifecycle is
-    # kept out of asyncio; only the WebSocket client runs under asyncio.run().
-    # (The first run builds the image and cold-starts the sandbox, which can
-    # take a minute with no output - the prints below show progress.)
-    provider = ModalProvider(app_name="openenv-echo")
-    print("Starting Modal sandbox (building image on first run)...", flush=True)
-    base_url = provider.start_container(image)
-    print(f"Sandbox up at {base_url} - waiting for server...", flush=True)
-    provider.wait_for_ready(base_url, timeout_s=180)
-    print("Server ready.", flush=True)
-    try:
+    with ModalProvider(app_name="openenv-echo") as provider:
+        logger.info("Starting Modal sandbox (building image on first run)...")
+        base_url = provider.start_container(image)
+        logger.info("Sandbox up - waiting for server...")
+        provider.wait_for_ready(base_url, timeout_s=180)
+        logger.info("Server ready.")
         asyncio.run(_interact(base_url))
-    finally:
-        print("Stopping sandbox...", flush=True)
-        provider.stop_container()
+        logger.info("Stopping sandbox...")
 
     return 0
 

--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -143,6 +143,8 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         connect_timeout_s: float = 10.0,
         message_timeout_s: float = 60.0,
         max_message_size_mb: float = 100.0,
+        websocket_ping_interval_s: Optional[float] = 20.0,
+        websocket_ping_timeout_s: Optional[float] = 20.0,
         provider: Optional["ContainerProvider | RuntimeProvider"] = None,
         mode: Optional[str] = None,
     ):
@@ -160,6 +162,10 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
             max_message_size_mb (`float`, *optional*, defaults to `100.0`):
                 Maximum WebSocket message size in megabytes. Default 100MB to handle large
                 observations (screenshots, DOM, etc.).
+            websocket_ping_interval_s (`float` or `None`, *optional*, defaults to `20.0`):
+                WebSocket keepalive ping interval. Pass `None` to disable.
+            websocket_ping_timeout_s (`float` or `None`, *optional*, defaults to `20.0`):
+                WebSocket keepalive pong timeout. Pass `None` to disable.
             provider (`ContainerProvider` or `RuntimeProvider`, *optional*):
                 Container/runtime provider for lifecycle management.
             mode (`str`, *optional*):
@@ -180,6 +186,8 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         self._max_message_size = int(
             max_message_size_mb * 1024 * 1024
         )  # Convert MB to bytes
+        self._websocket_ping_interval_s = websocket_ping_interval_s
+        self._websocket_ping_timeout_s = websocket_ping_timeout_s
         self._provider = provider
         self._ws: Optional[ClientConnection] = None
 
@@ -215,6 +223,8 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
                 self._ws_url,
                 open_timeout=self._connect_timeout,
                 max_size=self._max_message_size,
+                ping_interval=self._websocket_ping_interval_s,
+                ping_timeout=self._websocket_ping_timeout_s,
                 **connect_kwargs,
             )
         except Exception as e:

--- a/src/openenv/core/mcp_client.py
+++ b/src/openenv/core/mcp_client.py
@@ -100,6 +100,8 @@ class MCPClientBase(EnvClient[Any, Observation, State]):
         base_url: str,
         connect_timeout_s: float = 10.0,
         message_timeout_s: float = 60.0,
+        websocket_ping_interval_s: Optional[float] = 20.0,
+        websocket_ping_timeout_s: Optional[float] = 20.0,
         provider: Optional[Any] = None,
         mode: Optional[str] = None,
     ):
@@ -113,6 +115,10 @@ class MCPClientBase(EnvClient[Any, Observation, State]):
                 Timeout for establishing WebSocket connection.
             message_timeout_s (`float`, *optional*, defaults to `60.0`):
                 Timeout for receiving responses to messages.
+            websocket_ping_interval_s (`float` or `None`, *optional*, defaults to `20.0`):
+                WebSocket keepalive ping interval. Pass `None` to disable.
+            websocket_ping_timeout_s (`float` or `None`, *optional*, defaults to `20.0`):
+                WebSocket keepalive pong timeout. Pass `None` to disable.
             provider (*optional*):
                 Container/runtime provider for lifecycle management.
             mode (`str`, *optional*):
@@ -134,6 +140,8 @@ class MCPClientBase(EnvClient[Any, Observation, State]):
             base_url=base_url,
             connect_timeout_s=connect_timeout_s,
             message_timeout_s=message_timeout_s,
+            websocket_ping_interval_s=websocket_ping_interval_s,
+            websocket_ping_timeout_s=websocket_ping_timeout_s,
             provider=provider,
             mode=mode,
         )

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -667,6 +667,26 @@ class TestGenericEnvClientConnection:
         assert os.environ["NO_PROXY"] == "example.com"
 
     @pytest.mark.asyncio
+    async def test_websocket_ping_options_forward_to_connect(self):
+        observed = {}
+
+        async def fake_ws_connect(*args, **kwargs):
+            observed["ping_interval"] = kwargs.get("ping_interval", "MISSING")
+            observed["ping_timeout"] = kwargs.get("ping_timeout", "MISSING")
+            return MagicMock()
+
+        client = GenericEnvClient(
+            base_url="ws://remote.example.com:8000",
+            websocket_ping_interval_s=None,
+            websocket_ping_timeout_s=None,
+        )
+
+        with patch("openenv.core.env_client.ws_connect", side_effect=fake_ws_connect):
+            await client.connect()
+
+        assert observed == {"ping_interval": None, "ping_timeout": None}
+
+    @pytest.mark.asyncio
     async def test_concurrent_localhost_connects_do_not_leak_no_proxy(
         self, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- add stock EnvClient WebSocket ping interval/timeout passthrough
- forward the same options through MCPClientBase
- clean up the Modal echo example to use logging, avoid tunnel URL output, and omit example-level ping settings

## Context

Follow-up to #821, which was merged before these review fixes could be pushed to its branch.

## Tests

- uv run --extra core pytest tests/test_core/test_generic_client.py::TestGenericEnvClientConnection tests/test_core/test_modal_provider.py
- uv run ruff check src/openenv/core/env_client.py src/openenv/core/mcp_client.py src/openenv/core/containers/runtime/modal_provider.py tests/test_core/test_generic_client.py tests/test_core/test_modal_provider.py examples/modal_echo_env.py
- uv run ruff format --check src/openenv/core/env_client.py src/openenv/core/mcp_client.py src/openenv/core/containers/runtime/modal_provider.py tests/test_core/test_generic_client.py tests/test_core/test_modal_provider.py examples/modal_echo_env.py
- uv run usort check src/openenv/core/env_client.py src/openenv/core/mcp_client.py src/openenv/core/containers/runtime/modal_provider.py tests/test_core/test_generic_client.py tests/test_core/test_modal_provider.py examples/modal_echo_env.py
- uv run python -m py_compile examples/modal_echo_env.py src/openenv/core/env_client.py src/openenv/core/mcp_client.py src/openenv/core/containers/runtime/modal_provider.py tests/test_core/test_generic_client.py tests/test_core/test_modal_provider.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible client API extension with defaults unchanged; example and test-only surface area aside from connect kwargs.
> 
> **Overview**
> Adds configurable **WebSocket keepalive** on environment clients: `EnvClient` now accepts `websocket_ping_interval_s` and `websocket_ping_timeout_s` (default **20s** each, or **`None`** to disable) and passes them through to `websockets` as `ping_interval` / `ping_timeout` on connect. **`MCPClientBase`** exposes the same constructor args and forwards them to the base client.
> 
> The **Modal echo example** switches to **`logging`** instead of prints, manages the sandbox with **`with ModalProvider(...)`** so teardown is automatic, and trims progress messages (no tunnel URL in logs).
> 
> A unit test asserts that custom ping settings (including `None`) reach **`ws_connect`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c8da044b4b9eb0a7fb027b7d2bc088fe62b094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->