### PR TITLE
Provider-owned startup

### DIFF
--- a/docs/source/guides/runtime-providers.md
+++ b/docs/source/guides/runtime-providers.md
@@ -32,8 +32,24 @@ provider's full API.
 
 ## Lifecycle
 
-Container providers share the same flow. `from_docker_image` uses
-`LocalDockerProvider` by default; pass `provider=` to run the server elsewhere:
+Container providers that store their source image on the provider can be owned
+by the client. In this form, the client starts the provider on first connect,
+waits for readiness, and stops the provider when the client closes:
+
+```python
+image = DaytonaProvider.image_from_dockerfile("envs/echo_env/server/Dockerfile")
+provider = DaytonaProvider(image=image)
+
+async with MyEnv(provider=provider) as env:
+    result = await env.reset()
+    ...
+```
+
+`ModalProvider`, `DaytonaProvider`, and `ACASandboxProvider` support this
+provider-owned flow. Providers that require an explicit image at
+`start_container()` time, such as `LocalDockerProvider` and
+`DockerSwarmProvider`, should still be started manually and passed in with the
+returned `base_url`:
 
 ```python
 base_url = provider.start_container(image)
@@ -48,6 +64,23 @@ finally:
 
 `UVProvider` is not a container provider: it runs the server as a local process
 and exposes `.start()` / `.wait_for_ready()` / `.stop()` instead.
+
+## Reusing one server for multiple sessions
+
+After a client has connected, call `new_session()` to open another independent
+environment session against the same running server:
+
+```python
+async with MyEnv(provider=provider) as env:
+    first = await env.reset()
+    child = await env.new_session()
+    second = await child.reset()
+```
+
+Child sessions are owned by the parent client: closing the parent also closes
+any children it created. You can still close a child earlier when you no longer
+need it. Server capacity limits still apply, so `new_session()` can fail while
+opening the child WebSocket when the server has reached `MAX_CONCURRENT_ENVS`.
 
 ## Running many environments in parallel
 
@@ -88,6 +121,7 @@ falls back to `DefaultAzureCredential`).
 from openenv.core.containers.runtime.aca_provider import ACASandboxProvider
 
 provider = ACASandboxProvider(
+    image="disk:my-env",
     subscription_id="<subscription-id>",
     resource_group="<resource-group>",
     sandbox_group="<sandbox-group>",
@@ -108,7 +142,7 @@ variable.
 from openenv.core.containers.runtime.daytona_provider import DaytonaProvider
 
 image = DaytonaProvider.image_from_dockerfile("envs/echo_env/server/Dockerfile")
-provider = DaytonaProvider()
+provider = DaytonaProvider(image=image)
 ```
 
 Full examples: [`examples/daytona_tbench2_simple.py`](https://github.com/huggingface/OpenEnv/blob/main/examples/daytona_tbench2_simple.py)
@@ -151,7 +185,7 @@ Runs the server in a Modal sandbox over an encrypted tunnel. Install with
 from openenv.core.containers.runtime.modal_provider import ModalProvider
 
 image = ModalProvider.image_from_dockerfile("envs/echo_env/server/Dockerfile")
-provider = ModalProvider(app_name="openenv")
+provider = ModalProvider(app_name="openenv", image=image)
 ```
 
 Full example: [`examples/modal_echo_env.py`](https://github.com/huggingface/OpenEnv/blob/main/examples/modal_echo_env.py).

--- a/src/openenv/core/containers/runtime/aca_provider.py
+++ b/src/openenv/core/containers/runtime/aca_provider.py
@@ -287,8 +287,12 @@ class ACASandboxProvider(ContainerProvider):
     orphaning the running sandbox.
 
     ```python
-    with ACASandboxProvider(anonymous_port=True, ...) as provider:
-        base_url = provider.start_container("disk:my-env", cmd=...)
+    with ACASandboxProvider(
+        image="disk:my-env",
+        anonymous_port=True,
+        ...,
+    ) as provider:
+        base_url = provider.start_container(cmd=...)
         ...
     # sandbox deleted and SDK client closed on exit
     ```
@@ -311,6 +315,8 @@ class ACASandboxProvider(ContainerProvider):
         labels: Optional[Dict[str, str]] = None,
         egress_policy: Any = None,
         anonymous_port: Literal[True] | None = None,
+        image: Optional[str] = None,
+        env_vars: Optional[Dict[str, str]] = None,
         cmd: Optional[str] = None,
         working_directory: Optional[str] = None,
         surface_server_logs: bool = False,
@@ -339,6 +345,8 @@ class ACASandboxProvider(ContainerProvider):
         self.labels = dict(labels or {})
         self.egress_policy = egress_policy
         self.anonymous_port = anonymous_port
+        self._image = image
+        self._env_vars = dict(env_vars or {}) if env_vars is not None else None
         self.cmd = cmd
         self.working_directory = working_directory
         self.surface_server_logs = surface_server_logs
@@ -404,7 +412,7 @@ class ACASandboxProvider(ContainerProvider):
 
     def start_container(
         self,
-        image: str,
+        image: Optional[str] = None,
         port: Optional[int] = None,
         env_vars: Optional[Dict[str, str]] = None,
         **kwargs: Any,
@@ -413,9 +421,10 @@ class ACASandboxProvider(ContainerProvider):
 
         `image` is an ACA sandbox *source*, not a Docker/OCI registry image: a
         bare string or `disk:<name>` for a public disk image, or `disk-id:<id>`
-        for a private one. A value that looks like a container image (a registry
-        path or `name:tag`) is rejected with guidance. Only port 8000 is
-        supported. `**kwargs` accepts per-start overrides (`cmd`, `labels`,
+        for a private one. It may be omitted when supplied to the constructor.
+        A value that looks like a container image (a registry path or
+        `name:tag`) is rejected with guidance. Only port 8000 is supported.
+        `**kwargs` accepts per-start overrides (`cmd`, `labels`,
         `egress_policy`, `anonymous_port`); unknown options raise `ValueError`
         so typos cannot silently change sandbox behavior.
         """
@@ -433,7 +442,15 @@ class ACASandboxProvider(ContainerProvider):
                 f"(got {bind_port})."
             )
 
-        disk, disk_id = _source_from_image(image)
+        effective_image = image if image is not None else self._image
+        if effective_image is None:
+            raise ValueError(
+                "ACASandboxProvider requires an image. Pass it to the constructor "
+                "or start_container()."
+            )
+        effective_env_vars = self._env_vars if env_vars is None else env_vars
+
+        disk, disk_id = _source_from_image(effective_image)
         labels = dict(self.labels)
         labels.update(kwargs.pop("labels", {}) or {})
         cmd = kwargs.pop("cmd", None) or self.cmd
@@ -464,7 +481,9 @@ class ACASandboxProvider(ContainerProvider):
 
         # Record injected secret values so captured server output can be scrubbed
         # before it is ever surfaced in an error (security invariant S4).
-        self._redact_values = {value for value in (env_vars or {}).values() if value}
+        self._redact_values = {
+            value for value in (effective_env_vars or {}).values() if value
+        }
 
         # Two-stage cleanup. A create failure created nothing, so just drop the
         # recorded secrets and re-raise (notably it must NOT delete a sandbox
@@ -474,7 +493,7 @@ class ACASandboxProvider(ContainerProvider):
             self._sandbox = self._adapter.create_sandbox(
                 disk=disk,
                 disk_id=disk_id,
-                env_vars=dict(env_vars or {}) if env_vars else None,
+                env_vars=dict(effective_env_vars or {}) if effective_env_vars else None,
                 labels=labels or None,
                 egress_policy=egress_policy,
                 cpu=self.cpu,

--- a/src/openenv/core/containers/runtime/daytona_provider.py
+++ b/src/openenv/core/containers/runtime/daytona_provider.py
@@ -40,6 +40,8 @@ class DaytonaProvider(ContainerProvider):
     def __init__(
         self,
         *,
+        image: Optional[str] = None,
+        env_vars: Optional[Dict[str, str]] = None,
         api_key: Optional[str] = None,
         public: bool = False,
         resources: Optional[Any] = None,
@@ -51,6 +53,11 @@ class DaytonaProvider(ContainerProvider):
     ):
         """
         Args:
+            image: Docker image, snapshot reference, or ``"dockerfile:<path>"``
+                source to use when ``start_container()`` is called without an
+                image.
+            env_vars: Environment variables to use when ``start_container()`` is
+                called without explicit ``env_vars``.
             api_key: Daytona API key. Falls back to ``DAYTONA_API_KEY`` env var.
             public: If True, the sandbox preview is publicly accessible.
             resources: Optional ``daytona.Resources`` instance for CPU/memory.
@@ -71,6 +78,8 @@ class DaytonaProvider(ContainerProvider):
             config_kwargs["target"] = target
 
         self._daytona = Daytona(DaytonaConfig(**config_kwargs))
+        self._image = image
+        self._env_vars = env_vars
         self._public = public
         self._resources = resources
         self._auto_stop_interval = auto_stop_interval
@@ -349,7 +358,7 @@ class DaytonaProvider(ContainerProvider):
 
     def start_container(
         self,
-        image: str,
+        image: Optional[str] = None,
         port: Optional[int] = None,
         env_vars: Optional[Dict[str, str]] = None,
         **kwargs: Any,
@@ -370,7 +379,8 @@ class DaytonaProvider(ContainerProvider):
             image: Docker image name (e.g. ``"echo-env:latest"``),
                    ``"snapshot:<name>"`` to create from a pre-built snapshot,
                    or ``"dockerfile:<path>"`` returned by
-                   :meth:`image_from_dockerfile`.
+                   :meth:`image_from_dockerfile`. May be omitted when supplied
+                   to the constructor.
             port: Must be ``None`` or ``8000``. Daytona exposes port 8000
                   via its preview proxy; other ports raise ``ValueError``.
             env_vars: Environment variables forwarded to the sandbox.
@@ -386,6 +396,14 @@ class DaytonaProvider(ContainerProvider):
                 "The Daytona preview proxy routes to port 8000 inside the sandbox."
             )
 
+        effective_image = image if image is not None else self._image
+        if effective_image is None:
+            raise ValueError(
+                "DaytonaProvider requires an image. Pass it to the constructor "
+                "or start_container()."
+            )
+        effective_env_vars = self._env_vars if env_vars is None else env_vars
+
         # Resolve the server command (may be None; discovery happens after
         # sandbox creation when we can inspect the filesystem).
         cmd = kwargs.pop("cmd", None) or self._cmd
@@ -395,24 +413,24 @@ class DaytonaProvider(ContainerProvider):
 
         # Build creation params
         create_kwargs: Dict[str, Any] = {}
-        if env_vars:
-            create_kwargs["env_vars"] = env_vars
+        if effective_env_vars:
+            create_kwargs["env_vars"] = effective_env_vars
         if self._public:
             create_kwargs["public"] = True
         if self._auto_stop_interval != 15:
             create_kwargs["auto_stop_interval"] = self._auto_stop_interval
 
-        if image.startswith("snapshot:"):
+        if effective_image.startswith("snapshot:"):
             from daytona import CreateSandboxFromSnapshotParams
 
-            snapshot_name = image[len("snapshot:") :]
+            snapshot_name = effective_image[len("snapshot:") :]
             params = CreateSandboxFromSnapshotParams(
                 snapshot=snapshot_name, **create_kwargs
             )
-        elif image.startswith("dockerfile:"):
+        elif effective_image.startswith("dockerfile:"):
             from daytona import CreateSandboxFromImageParams, Image
 
-            dockerfile_path = image[len("dockerfile:") :]
+            dockerfile_path = effective_image[len("dockerfile:") :]
             meta = self._dockerfile_registry.get(dockerfile_path)
             if meta is None:
                 raise ValueError(
@@ -445,7 +463,7 @@ class DaytonaProvider(ContainerProvider):
         else:
             from daytona import CreateSandboxFromImageParams
 
-            img_kwargs = {"image": image, **create_kwargs}
+            img_kwargs = {"image": effective_image, **create_kwargs}
             if self._resources is not None:
                 img_kwargs["resources"] = self._resources
             params = CreateSandboxFromImageParams(**img_kwargs)

--- a/src/openenv/core/containers/runtime/modal_provider.py
+++ b/src/openenv/core/containers/runtime/modal_provider.py
@@ -182,6 +182,8 @@ class ModalProvider(ContainerProvider):
     def __init__(
         self,
         *,
+        image: str | None = None,
+        env_vars: dict[str, str] | None = None,
         app_name: str = "openenv",
         use_sandbox_v2: bool = False,
         timeout: int = 300,
@@ -193,6 +195,12 @@ class ModalProvider(ContainerProvider):
     ):
         """
         Args:
+            image (`str`, *optional*):
+                Registry image tag or ``"dockerfile:<path>"`` source to use
+                when ``start_container()`` is called without an image.
+            env_vars (`dict`, *optional*):
+                Environment variables to use when ``start_container()`` is
+                called without explicit ``env_vars``.
             app_name (`str`, *optional*, defaults to `"openenv"`):
                 Modal app name the sandbox is created under. Looked up (and
                 created if missing) via ``modal.App.lookup``.
@@ -223,6 +231,8 @@ class ModalProvider(ContainerProvider):
                 orchestrator/CI logs. When `True`, a best-effort redacted,
                 length-bounded excerpt is included in startup-crash errors.
         """
+        self._image = image
+        self._env_vars = env_vars
         self._app_name = app_name
         self._use_sandbox_v2 = use_sandbox_v2
         self._timeout = timeout
@@ -467,7 +477,7 @@ class ModalProvider(ContainerProvider):
 
     def start_container(
         self,
-        image: str,
+        image: str | None = None,
         port: int | None = None,
         env_vars: dict[str, str] | None = None,
         **kwargs: Any,
@@ -487,10 +497,11 @@ class ModalProvider(ContainerProvider):
            ``image_from_dockerfile``).
 
         Args:
-            image (`str`):
+            image (`str`, *optional*):
                 Registry image tag (e.g. ``"echo-env:latest"``) or
                 ``"dockerfile:<path>"`` returned by
-                :meth:`image_from_dockerfile`.
+                :meth:`image_from_dockerfile`. May be omitted when supplied to
+                the constructor.
             port (`int`, *optional*):
                 Must be ``None`` or ``8000``. Modal exposes port 8000 via an
                 encrypted tunnel; other ports raise ``ValueError``.
@@ -517,18 +528,26 @@ class ModalProvider(ContainerProvider):
                 f"{_DEFAULT_MODAL_PORT} inside the sandbox."
             )
 
+        effective_image = image if image is not None else self._image
+        if effective_image is None:
+            raise ValueError(
+                "ModalProvider requires an image. Pass it to the constructor "
+                "or start_container()."
+            )
+        effective_env_vars = self._env_vars if env_vars is None else env_vars
+
         # Resolve the server command (may be None; discovery happens after
         # sandbox creation when we can inspect the filesystem).
         cmd = kwargs.pop("cmd", None) or self._cmd
 
         # CMD parsed from Dockerfile (populated for "dockerfile:" images).
         parsed_cmd: str | None = None
-        if image.startswith("dockerfile:"):
-            meta = self._dockerfile_registry.get(image[len("dockerfile:") :])
+        if effective_image.startswith("dockerfile:"):
+            meta = self._dockerfile_registry.get(effective_image[len("dockerfile:") :])
             if meta is not None:
                 parsed_cmd = meta.get("server_cmd")
 
-        modal_image = self._build_image(image)
+        modal_image = self._build_image(effective_image)
 
         extra: Dict[str, Any] = dict(kwargs)
         if self._cpu is not None:
@@ -538,7 +557,9 @@ class ModalProvider(ContainerProvider):
 
         # Record injected secret values so captured server output can be
         # scrubbed before it is ever surfaced in an error.
-        self._redact_values = {value for value in (env_vars or {}).values() if value}
+        self._redact_values = {
+            value for value in (effective_env_vars or {}).values() if value
+        }
 
         # A create failure created nothing, so just drop the recorded secrets
         # and re-raise (the double-start guard above guarantees there is no
@@ -548,7 +569,7 @@ class ModalProvider(ContainerProvider):
                 image=modal_image,
                 encrypted_ports=[_DEFAULT_MODAL_PORT],
                 timeout=self._timeout,
-                env=env_vars,
+                env=effective_env_vars,
                 extra=extra,
             )
         except Exception:

--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -140,7 +140,7 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
 
     def __init__(
         self,
-        base_url: str,
+        base_url: Optional[str] = None,
         connect_timeout_s: float = 10.0,
         message_timeout_s: float = 60.0,
         max_message_size_mb: float = 100.0,
@@ -153,9 +153,10 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         Initialize environment client.
 
         Args:
-            base_url (`str`):
+            base_url (`str`, *optional*):
                 Base URL of the environment server (http:// or ws://). Will be converted to
-                ws:// if http:// is provided.
+                ws:// if http:// is provided. May be omitted when the provider
+                has enough constructor state to start itself.
             connect_timeout_s (`float`, *optional*, defaults to `10.0`):
                 Timeout for establishing WebSocket connection.
             message_timeout_s (`float`, *optional*, defaults to `60.0`):
@@ -175,13 +176,13 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
                 `OPENENV_CLIENT_MODE` environment variable. Constructor parameter takes
                 precedence over environment variable. Case-insensitive.
         """
+        if base_url is None and provider is None:
+            raise ValueError("EnvClient requires either base_url or provider.")
+
         # Store mode (use object.__setattr__ to bypass immutability)
         object.__setattr__(self, "_mode", _normalize_mode(mode))
 
-        # Convert HTTP URL to WebSocket URL
-        ws_url = convert_to_ws_url(base_url)
-
-        self._ws_url = f"{ws_url}/ws"
+        self._ws_url: Optional[str] = None
         self._connect_timeout = connect_timeout_s
         self._message_timeout = message_timeout_s
         self._max_message_size = int(
@@ -190,8 +191,30 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         self._websocket_ping_interval_s = websocket_ping_interval_s
         self._websocket_ping_timeout_s = websocket_ping_timeout_s
         self._provider = provider
+        self._start_provider_on_connect = base_url is None
         self._ws: Optional[ClientConnection] = None
         self._ws_loop: Optional[asyncio.AbstractEventLoop] = None
+        if base_url is not None:
+            self._set_base_url(base_url)
+
+    def _set_base_url(self, base_url: str) -> None:
+        ws_url = convert_to_ws_url(base_url)
+        self._ws_url = f"{ws_url}/ws"
+
+    def _start_provider_if_needed(self) -> None:
+        if self._ws_url is not None:
+            return
+        if self._provider is None:
+            raise RuntimeError("EnvClient has no base URL or provider.")
+        if hasattr(self._provider, "start_container"):
+            base_url = self._provider.start_container()
+            self._provider.wait_for_ready(base_url)
+        elif hasattr(self._provider, "start"):
+            base_url = self._provider.start()
+            self._provider.wait_for_ready()
+        else:
+            raise TypeError("provider must define start_container() or start().")
+        self._set_base_url(base_url)
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Prevent modification of _mode after initialization."""
@@ -224,6 +247,14 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
             self._ws = None
             self._ws_loop = None
 
+        try:
+            self._start_provider_if_needed()
+        except Exception:
+            await self.close()
+            raise
+
+        assert self._ws_url is not None
+
         # Disable the proxy for localhost connections via the per-connection
         # `proxy` argument rather than mutating the process-global NO_PROXY
         # env var: concurrent connect() calls (e.g. asyncio.gather over many
@@ -243,6 +274,7 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
             )
             self._ws_loop = asyncio.get_running_loop()
         except Exception as e:
+            await self.close()
             raise ConnectionError(f"Failed to connect to {self._ws_url}: {e}") from e
 
         return self
@@ -529,6 +561,8 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
                 self._provider.stop_container()
             elif hasattr(self._provider, "stop"):
                 self._provider.stop()
+        if self._start_provider_on_connect:
+            self._ws_url = None
 
     async def __aenter__(self) -> "EnvClient":
         """Enter async context manager, ensuring connection is established."""

--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -43,6 +43,7 @@ import json
 import os
 import time
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from typing import Any, Dict, Generic, Optional, Type, TYPE_CHECKING, TypeVar
 from urllib.parse import urlsplit
 
@@ -96,6 +97,25 @@ def _is_localhost_ws_url(ws_url: str) -> bool:
         return ipaddress.ip_address(hostname).is_loopback
     except ValueError:
         return False
+
+
+def _required_start_container_parameters(provider: Any) -> list[str]:
+    """Return required arguments for a bound provider.start_container()."""
+    try:
+        signature = inspect.signature(provider.start_container)
+    except (TypeError, ValueError):
+        return []
+    return [
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    ]
 
 
 class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
@@ -211,6 +231,15 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         if self._provider is None:
             raise RuntimeError("EnvClient has no base URL or provider.")
         if hasattr(self._provider, "start_container"):
+            required_parameters = _required_start_container_parameters(self._provider)
+            if required_parameters:
+                required = ", ".join(required_parameters)
+                raise ValueError(
+                    f"{type(self._provider).__name__} does not support "
+                    "provider-owned startup because start_container() requires "
+                    f"{required}. Start the provider manually and pass base_url, "
+                    "or configure a provider with a constructor-owned image/source."
+                )
             base_url = self._provider.start_container()
             self._provider.wait_for_ready(base_url)
         elif hasattr(self._provider, "start"):
@@ -220,36 +249,46 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
             raise TypeError("provider must define start_container() or start().")
         self._set_base_url(base_url)
 
-    def _create_session_client(
-        self, *, track: bool = True
-    ) -> "EnvClient[Any, Any, Any]":
+    def _create_session_client(self) -> "EnvClient[Any, Any, Any]":
         self._start_provider_if_needed()
         if self._base_url is None:
             raise RuntimeError("EnvClient has no base URL.")
 
         signature = inspect.signature(type(self))
-        constructor_kwargs = {
+        accepts_kwargs = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        )
+        candidate_kwargs = {
             "base_url": self._base_url,
             "connect_timeout_s": self._connect_timeout,
             "message_timeout_s": self._message_timeout,
-        }
-        optional_kwargs = {
             "max_message_size_mb": self._max_message_size / (1024 * 1024),
             "websocket_ping_interval_s": self._websocket_ping_interval_s,
             "websocket_ping_timeout_s": self._websocket_ping_timeout_s,
             "mode": self._mode,
         }
-        for name, value in optional_kwargs.items():
-            if name in signature.parameters:
+        constructor_kwargs = {}
+        for name, value in candidate_kwargs.items():
+            if accepts_kwargs or name in signature.parameters:
                 constructor_kwargs[name] = value
 
         client = type(self)(**constructor_kwargs)
-        if track:
-            self._child_clients.append(client)
         return client
 
     async def new_session(self) -> "EnvClient[Any, Any, Any]":
-        client = self._create_session_client(track=False)
+        """
+        Create and connect a new session against the same environment server.
+
+        Returns:
+            `EnvClient`: A connected child client of the same concrete type.
+
+        The child session is tracked by this parent and closed when the parent
+        is closed. Server-side capacity still applies: when the server is at
+        `MAX_CONCURRENT_ENVS`, opening the child WebSocket can fail and is
+        surfaced as a connection error.
+        """
+        client = self._create_session_client()
         await client.connect()
         self._child_clients.append(client)
         return client
@@ -591,21 +630,25 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         If this client was created via from_docker_image() or from_env(),
         this will also stop and remove the associated container/process.
         """
-        for child in self._child_clients:
-            await child.close()
+        for child in list(self._child_clients):
+            with suppress(Exception):
+                await child.close()
         self._child_clients.clear()
 
-        await self.disconnect()
-
-        if self._provider is not None:
-            # Handle both ContainerProvider and RuntimeProvider
-            if hasattr(self._provider, "stop_container"):
-                self._provider.stop_container()
-            elif hasattr(self._provider, "stop"):
-                self._provider.stop()
-        if self._start_provider_on_connect:
-            self._base_url = None
-            self._ws_url = None
+        try:
+            await self.disconnect()
+        finally:
+            try:
+                if self._provider is not None:
+                    # Handle both ContainerProvider and RuntimeProvider
+                    if hasattr(self._provider, "stop_container"):
+                        self._provider.stop_container()
+                    elif hasattr(self._provider, "stop"):
+                        self._provider.stop()
+            finally:
+                if self._start_provider_on_connect:
+                    self._base_url = None
+                    self._ws_url = None
 
     async def __aenter__(self) -> "EnvClient":
         """Enter async context manager, ensuring connection is established."""

--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -37,6 +37,7 @@ Examples:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import ipaddress
 import json
 import os
@@ -182,6 +183,7 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         # Store mode (use object.__setattr__ to bypass immutability)
         object.__setattr__(self, "_mode", _normalize_mode(mode))
 
+        self._base_url: Optional[str] = None
         self._ws_url: Optional[str] = None
         self._connect_timeout = connect_timeout_s
         self._message_timeout = message_timeout_s
@@ -192,12 +194,14 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         self._websocket_ping_timeout_s = websocket_ping_timeout_s
         self._provider = provider
         self._start_provider_on_connect = base_url is None
+        self._child_clients: list[EnvClient[Any, Any, Any]] = []
         self._ws: Optional[ClientConnection] = None
         self._ws_loop: Optional[asyncio.AbstractEventLoop] = None
         if base_url is not None:
             self._set_base_url(base_url)
 
     def _set_base_url(self, base_url: str) -> None:
+        self._base_url = base_url.rstrip("/")
         ws_url = convert_to_ws_url(base_url)
         self._ws_url = f"{ws_url}/ws"
 
@@ -215,6 +219,40 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         else:
             raise TypeError("provider must define start_container() or start().")
         self._set_base_url(base_url)
+
+    def _create_session_client(
+        self, *, track: bool = True
+    ) -> "EnvClient[Any, Any, Any]":
+        self._start_provider_if_needed()
+        if self._base_url is None:
+            raise RuntimeError("EnvClient has no base URL.")
+
+        signature = inspect.signature(type(self))
+        constructor_kwargs = {
+            "base_url": self._base_url,
+            "connect_timeout_s": self._connect_timeout,
+            "message_timeout_s": self._message_timeout,
+        }
+        optional_kwargs = {
+            "max_message_size_mb": self._max_message_size / (1024 * 1024),
+            "websocket_ping_interval_s": self._websocket_ping_interval_s,
+            "websocket_ping_timeout_s": self._websocket_ping_timeout_s,
+            "mode": self._mode,
+        }
+        for name, value in optional_kwargs.items():
+            if name in signature.parameters:
+                constructor_kwargs[name] = value
+
+        client = type(self)(**constructor_kwargs)
+        if track:
+            self._child_clients.append(client)
+        return client
+
+    async def new_session(self) -> "EnvClient[Any, Any, Any]":
+        client = self._create_session_client(track=False)
+        await client.connect()
+        self._child_clients.append(client)
+        return client
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Prevent modification of _mode after initialization."""
@@ -553,6 +591,10 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
         If this client was created via from_docker_image() or from_env(),
         this will also stop and remove the associated container/process.
         """
+        for child in self._child_clients:
+            await child.close()
+        self._child_clients.clear()
+
         await self.disconnect()
 
         if self._provider is not None:
@@ -562,6 +604,7 @@ class EnvClient(ABC, Generic[ActT, ObsT, StateT]):
             elif hasattr(self._provider, "stop"):
                 self._provider.stop()
         if self._start_provider_on_connect:
+            self._base_url = None
             self._ws_url = None
 
     async def __aenter__(self) -> "EnvClient":

--- a/src/openenv/core/sync_client.py
+++ b/src/openenv/core/sync_client.py
@@ -89,6 +89,7 @@ class SyncEnvClient(Generic[ActT, ObsT, StateT]):
         self._loop_ready = threading.Event()
         self._loop_init_lock = threading.Lock()
         self._async_wrapper_cache: Dict[str, Any] = {}
+        self._child_clients: list[SyncEnvClient[ActT, ObsT, StateT]] = []
 
     def _run_loop_forever(self) -> None:
         """Run a dedicated event loop for this sync client."""
@@ -211,9 +212,20 @@ class SyncEnvClient(Generic[ActT, ObsT, StateT]):
     def close(self) -> None:
         """Close the connection and clean up resources."""
         try:
+            for child in self._child_clients:
+                child.close()
+            self._child_clients.clear()
             self._run(self._async.close())
         finally:
             self._stop_loop()
+
+    def new_session(self) -> "SyncEnvClient[ActT, ObsT, StateT]":
+        """Create a new synchronous session against the same environment server."""
+        async_client = self._async._create_session_client(track=False)
+        client = SyncEnvClient(async_client)
+        client.connect()
+        self._child_clients.append(client)
+        return client
 
     def __enter__(self) -> "SyncEnvClient[ActT, ObsT, StateT]":
         """Enter context manager, establishing connection."""

--- a/src/openenv/core/sync_client.py
+++ b/src/openenv/core/sync_client.py
@@ -32,6 +32,7 @@ import asyncio
 import concurrent.futures
 import inspect
 import threading
+from contextlib import suppress
 from typing import Any, Dict, Generic, TYPE_CHECKING, TypeVar
 
 from .client_types import StateT, StepResult
@@ -212,16 +213,29 @@ class SyncEnvClient(Generic[ActT, ObsT, StateT]):
     def close(self) -> None:
         """Close the connection and clean up resources."""
         try:
-            for child in self._child_clients:
-                child.close()
+            for child in list(self._child_clients):
+                with suppress(Exception):
+                    child.close()
             self._child_clients.clear()
             self._run(self._async.close())
         finally:
             self._stop_loop()
 
     def new_session(self) -> "SyncEnvClient[ActT, ObsT, StateT]":
-        """Create a new synchronous session against the same environment server."""
-        async_client = self._async._create_session_client(track=False)
+        """
+        Create a new synchronous session against the same environment server.
+
+        Returns:
+            `SyncEnvClient`: A connected child wrapper around a child async
+            client of the same concrete type.
+
+        The child session is tracked by this parent and closed when the parent
+        is closed. Call this after the parent has connected, because the child
+        reuses the parent's current base URL. Server-side capacity still
+        applies: when the server is at `MAX_CONCURRENT_ENVS`, opening the child
+        WebSocket can fail and is surfaced as a connection error.
+        """
+        async_client = self._async._create_session_client()
         client = SyncEnvClient(async_client)
         client.connect()
         self._child_clients.append(client)

--- a/tests/test_core/test_aca_provider.py
+++ b/tests/test_core/test_aca_provider.py
@@ -156,6 +156,35 @@ def test_start_container_creates_disk_sandbox_and_exposes_port(adapter):
     )
 
 
+def test_constructor_image_used_when_start_omits_image(adapter):
+    provider = _provider(
+        adapter,
+        image="disk:constructor-env",
+        env_vars={"DEBUG": "1"},
+    )
+
+    provider.start_container()
+
+    created = adapter.created[0]
+    assert created["disk"] == "constructor-env"
+    assert created["env_vars"] == {"DEBUG": "1"}
+
+
+def test_start_image_overrides_constructor_image(adapter):
+    provider = _provider(adapter, image="disk:constructor-env")
+
+    provider.start_container("disk:explicit-env")
+
+    assert adapter.created[0]["disk"] == "explicit-env"
+
+
+def test_requires_image_from_constructor_or_start(adapter):
+    provider = _provider(adapter)
+
+    with pytest.raises(ValueError, match="requires an image"):
+        provider.start_container()
+
+
 def test_provider_imports_from_its_module():
     # Optional cloud providers are imported from their module, not re-exported
     # from the runtime package (matches DaytonaProvider).

--- a/tests/test_core/test_daytona_provider.py
+++ b/tests/test_core/test_daytona_provider.py
@@ -178,6 +178,31 @@ class TestStartContainer:
         url = provider.start_container("echo-env:latest")
         assert url == "https://8000-signed-tok.proxy.daytona.works"
 
+    def test_constructor_image_used_when_start_omits_image(self):
+        """A provider-owned image lets the outer client call start_container()."""
+        provider = DaytonaProvider(
+            api_key="test-key",
+            image="constructor-env:latest",
+            env_vars={"DEBUG": "1"},
+        )
+        url = provider.start_container()
+        assert url.startswith("https://")
+        params, _ = provider._daytona._created[0]
+        assert isinstance(params, _fake_daytona.CreateSandboxFromImageParams)
+        assert params.image == "constructor-env:latest"
+        assert params.env_vars == {"DEBUG": "1"}
+
+    def test_start_image_overrides_constructor_image(self):
+        """Explicit start_container image takes precedence."""
+        provider = DaytonaProvider(api_key="test-key", image="constructor-env:latest")
+        provider.start_container("explicit-env:latest")
+        params, _ = provider._daytona._created[0]
+        assert params.image == "explicit-env:latest"
+
+    def test_requires_image_from_constructor_or_start(self, provider):
+        with pytest.raises(ValueError, match="requires an image"):
+            provider.start_container()
+
 
 # ---------------------------------------------------------------------------
 # Tests: port validation

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -118,6 +118,25 @@ class TestGenericEnvClientInstantiation:
         assert client._ws_url is None
 
     @pytest.mark.asyncio
+    async def test_provider_owned_startup_requires_no_arg_start_container(self):
+        """Providers that require an image fail with actionable guidance."""
+
+        class _RequiresImageProvider:
+            def start_container(self, image):
+                raise AssertionError("start_container should not be called")
+
+            def wait_for_ready(self, base_url):
+                raise AssertionError("wait_for_ready should not be called")
+
+            def stop_container(self):
+                pass
+
+        client = GenericEnvClient(provider=_RequiresImageProvider())
+
+        with pytest.raises(ValueError, match=r"start_container\(\) requires image"):
+            await client.connect()
+
+    @pytest.mark.asyncio
     async def test_new_session_reuses_provider_server(self, mock_provider):
         """Child sessions connect to the same server without owning the provider."""
         websockets = []
@@ -143,6 +162,33 @@ class TestGenericEnvClientInstantiation:
             await client.close()
 
         mock_provider.stop_container.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_close_stops_provider_when_child_close_raises(self, mock_provider):
+        """Parent cleanup continues even when a child session close fails."""
+        client = GenericEnvClient(provider=mock_provider)
+        child = MagicMock()
+        child.close = AsyncMock(side_effect=RuntimeError("child close failed"))
+        client._child_clients.append(child)
+
+        await client.close()
+
+        child.close.assert_awaited_once_with()
+        assert client._child_clients == []
+        mock_provider.stop_container.assert_called_once_with()
+
+    def test_session_client_filters_constructor_kwargs(self):
+        """Child creation respects subclasses with narrower __init__ signatures."""
+
+        class MinimalGenericClient(GenericEnvClient):
+            def __init__(self, base_url):
+                super().__init__(base_url=base_url)
+
+        client = MinimalGenericClient(base_url="http://localhost:8000")
+        child = client._create_session_client()
+
+        assert isinstance(child, MinimalGenericClient)
+        assert child._base_url == "http://localhost:8000"
 
 
 class TestGenericEnvClientStepPayload:
@@ -631,6 +677,19 @@ class TestSyncEnvClientWrapper:
                 assert len(websockets) == 2
 
         mock_provider.start_container.assert_called_once_with()
+        mock_provider.stop_container.assert_called_once_with()
+
+    def test_sync_close_stops_provider_when_child_close_raises(self, mock_provider):
+        """Sync parent cleanup continues when child close fails."""
+        client = GenericEnvClient(provider=mock_provider).sync()
+        child = Mock()
+        child.close.side_effect = RuntimeError("child close failed")
+        client._child_clients.append(child)
+
+        client.close()
+
+        child.close.assert_called_once_with()
+        assert client._child_clients == []
         mock_provider.stop_container.assert_called_once_with()
 
 

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -117,6 +117,33 @@ class TestGenericEnvClientInstantiation:
         mock_provider.stop_container.assert_called_once_with()
         assert client._ws_url is None
 
+    @pytest.mark.asyncio
+    async def test_new_session_reuses_provider_server(self, mock_provider):
+        """Child sessions connect to the same server without owning the provider."""
+        websockets = []
+
+        async def fake_ws_connect(*args, **kwargs):
+            ws = AsyncMock()
+            websockets.append(ws)
+            return ws
+
+        with patch("openenv.core.env_client.ws_connect", side_effect=fake_ws_connect):
+            client = GenericEnvClient(provider=mock_provider)
+            await client.connect()
+            session = await client.new_session()
+
+            assert isinstance(session, GenericEnvClient)
+            assert session is not client
+            assert session._provider is None
+            assert session._base_url == "http://localhost:8000"
+            assert session._ws_url == "ws://localhost:8000/ws"
+            assert len(websockets) == 2
+            mock_provider.start_container.assert_called_once_with()
+
+            await client.close()
+
+        mock_provider.stop_container.assert_called_once_with()
+
 
 class TestGenericEnvClientStepPayload:
     """Test _step_payload method."""
@@ -583,6 +610,28 @@ class TestSyncEnvClientWrapper:
 
         assert result.observation == {"output": "hello"}
         assert result.reward == 1.0
+
+    def test_sync_client_new_session_reuses_provider_server(self, mock_provider):
+        """The sync wrapper exposes child sessions without another context manager."""
+        websockets = []
+
+        async def fake_ws_connect(*args, **kwargs):
+            ws = AsyncMock()
+            websockets.append(ws)
+            return ws
+
+        with patch("openenv.core.env_client.ws_connect", side_effect=fake_ws_connect):
+            with GenericEnvClient(provider=mock_provider).sync() as client:
+                session = client.new_session()
+
+                assert isinstance(session, SyncEnvClient)
+                assert isinstance(session.async_client, GenericEnvClient)
+                assert session.async_client._provider is None
+                assert session.async_client._base_url == "http://localhost:8000"
+                assert len(websockets) == 2
+
+        mock_provider.start_container.assert_called_once_with()
+        mock_provider.stop_container.assert_called_once_with()
 
 
 # ============================================================================

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -85,6 +85,38 @@ class TestGenericEnvClientInstantiation:
         assert client._connect_timeout == 30.0
         assert client._message_timeout == 120.0
 
+    def test_instantiation_with_provider_only(self, mock_provider):
+        """Test provider-owned startup without an initial base URL."""
+        client = GenericEnvClient(provider=mock_provider)
+        assert client._ws_url is None
+
+    def test_instantiation_requires_base_url_or_provider(self):
+        """Test that clients need either a URL or a provider."""
+        with pytest.raises(ValueError, match="requires either base_url or provider"):
+            GenericEnvClient()
+
+    @pytest.mark.asyncio
+    async def test_connect_starts_provider_when_base_url_omitted(self, mock_provider):
+        """The outer client can start a provider that owns its image/source."""
+        ws = MagicMock()
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+
+        with patch("openenv.core.env_client.ws_connect", AsyncMock(return_value=ws)):
+            client = GenericEnvClient(provider=mock_provider)
+            await client.connect()
+
+            mock_provider.start_container.assert_called_once_with()
+            mock_provider.wait_for_ready.assert_called_once_with(
+                "http://localhost:8000"
+            )
+            assert client._ws_url == "ws://localhost:8000/ws"
+
+            await client.close()
+
+        mock_provider.stop_container.assert_called_once_with()
+        assert client._ws_url is None
+
 
 class TestGenericEnvClientStepPayload:
     """Test _step_payload method."""

--- a/tests/test_core/test_modal_provider.py
+++ b/tests/test_core/test_modal_provider.py
@@ -157,6 +157,29 @@ class TestStartContainer:
         provider.start_container("echo-env:latest", env_vars={"FOO": "bar"})
         assert adapter.created[0]["env"] == {"FOO": "bar"}
 
+    def test_constructor_image_used_when_start_omits_image(self, adapter):
+        provider = ModalProvider(
+            _adapter=adapter,
+            image="constructor-env:latest",
+            env_vars={"FOO": "bar"},
+        )
+        provider.start_container()
+        image = adapter.created[0]["image"]
+        assert image.kind == "registry"
+        assert image.ref == "constructor-env:latest"
+        assert adapter.created[0]["env"] == {"FOO": "bar"}
+
+    def test_start_image_overrides_constructor_image(self, adapter):
+        provider = ModalProvider(_adapter=adapter, image="constructor-env:latest")
+        provider.start_container("explicit-env:latest")
+        image = adapter.created[0]["image"]
+        assert image.ref == "explicit-env:latest"
+
+    def test_requires_image_from_constructor_or_start(self, adapter):
+        provider = ModalProvider(_adapter=adapter)
+        with pytest.raises(ValueError, match="requires an image"):
+            provider.start_container()
+
     def test_server_started_in_background(self, provider, adapter):
         provider.start_container("echo-env:latest")
         assert any(


### PR DESCRIPTION
This PR lets EnvClient start providers that own their image/source, so that Daytona and Modal are consistent with HFSandbox and this improved DX:

```python
with BrowserGymEnv(
    message_timeout_s=120.0,
    max_message_size_mb=100.0,
    provider=provider,
).sync() as browsergym_env:
    env.reset()
```