### PR TITLE
ci: use ubuntu-latest for openspiel base build (8-core-ubuntu runner unknown)

### DIFF
--- a/.github/workflows/openspiel_base_build.yml
+++ b/.github/workflows/openspiel_base_build.yml
@@ -94,6 +94,8 @@ jobs:
           file: envs/openspiel_env/server/Dockerfile.openspiel-base
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-base:latest
           tags: ${{ steps.meta-openspiel-base.outputs.tags }}
           labels: ${{ steps.meta-openspiel-base.outputs.labels }}
           cache-from: type=gha,scope=openspiel-base

--- a/.github/workflows/openspiel_base_build.yml
+++ b/.github/workflows/openspiel_base_build.yml
@@ -58,7 +58,7 @@ jobs:
 
   # Job 2: Build OpenSpiel base image (depends on base)
   build-openspiel-base:
-    runs-on: 8-core-ubuntu
+    runs-on: ubuntu-latest
     needs: build-base  # Wait for base image to be built
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
The `build-openspiel-base` job in `openspiel_base_build.yml` requested `runs-on: 8-core-ubuntu`, a runner label that is not provisioned for this repo. Infra confirmed the runner is unknown, so the job sat in `queued` forever and never picked up a runner. This switches it to `ubuntu-latest`, the standard GitHub-hosted runner already used by the sibling `build-base` job.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
The workflow is `workflow_dispatch` only, so it does not run as a PR check. To verify without merging, dispatch it against this branch:

```bash
gh workflow run openspiel_base_build.yml --ref fix/openspiel-runner
gh run list --workflow=openspiel_base_build.yml --limit 3
```

The build-openspiel-base job should now pick up an ubuntu-latest runner (instead of hanging in queued) and complete the OpenSpiel base image build. Watch build time and memory while compiling OpenSpiel on the 4-core standard runner. If it runs out of resources, the follow-up is to request a valid larger/internal runner label from infra.


## Claude Code Review

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application runtime impact; OpenSpiel compile may be slower or OOM on standard runners.
> 
> **Overview**
> Fixes **`build-openspiel-base`** in `openspiel_base_build.yml` so it can actually run: **`runs-on`** changes from the unprovisioned **`8-core-ubuntu`** label to **`ubuntu-latest`**, matching **`build-base`**.
> 
> The OpenSpiel base Docker build now passes **`BASE_IMAGE`** pointing at the **`openenv-base:latest`** image just pushed in the first job, so **`Dockerfile.openspiel-base`** layers on the correct GHCR base instead of the local default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9bb94ff5e127b5de38d09e8e11bf41bb599346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->