### PR TITLE
Fix DIPG RL notebook JSON

### DIFF
--- a/examples/dipg/dipg-rl.ipynb
+++ b/examples/dipg/dipg-rl.ipynb
@@ -47,7 +47,7 @@
     "import os, importlib.util\n",
     "!pip install --upgrade -qqq uv\n",
     "if importlib.util.find_spec(\"torch\") is None or \"COLAB_\" in \"\".join(os.environ.keys()):\n",
-    "    try: import numpy; get_numpy = f\"numpy=={numpy.__version__}\\"\n",
+    "    try: import numpy; get_numpy = f\"numpy=={numpy.__version__}\"\n",
     "    except: get_numpy = \"numpy\"\n",
     "    !uv pip install -qqq \\\n",
     "        \"torch>=2.8.0\" \"triton>=3.4.0\" {get_numpy} torchvision bitsandbytes \"transformers==4.56.2\" trackio \\\n",
@@ -2004,3 +2004,4 @@
    }
   }
  }
+}


### PR DESCRIPTION
Fixes malformed JSON in the DIPG RL notebook so notebook tooling can parse it again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example notebook-only edits with no library or runtime behavior changes.
> 
> **Overview**
> Repairs **`examples/dipg/dipg-rl.ipynb`** so Jupyter/nbconvert can load it again.
> 
> The setup cell’s **`get_numpy`** f-string is corrected (stray escape before the closing quote), which restores valid Python in that install block. The notebook file’s **trailing JSON** is fixed by properly closing the embedded widget state and root object, with a newline at EOF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4a3839a45baefa31f0356ee9119c8c531b8327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->