### PR TITLE
chore: point openspiel base image to ghcr.io/huggingface namespace

### DIFF
--- a/docs/source/environments/openspiel.md
+++ b/docs/source/environments/openspiel.md
@@ -63,7 +63,7 @@ From the **environment directory** (`envs/openspiel_env/`):
 docker build -t openspiel-env:latest -f server/Dockerfile .
 ```
 
-This uses the pre-built `ghcr.io/meta-pytorch/openenv-openspiel-base` image which already contains compiled OpenSpiel.
+This uses the pre-built `ghcr.io/huggingface/openenv-openspiel-base` image which already contains compiled OpenSpiel.
 
 ### Building Your Own Base Image (Optional)
 

--- a/envs/openspiel_env/README.md
+++ b/envs/openspiel_env/README.md
@@ -75,7 +75,7 @@ From the **environment directory** (`envs/openspiel_env/`):
 docker build -t openspiel-env:latest -f server/Dockerfile .
 ```
 
-This uses the pre-built `ghcr.io/meta-pytorch/openenv-openspiel-base` image which already contains compiled OpenSpiel.
+This uses the pre-built `ghcr.io/huggingface/openenv-openspiel-base` image which already contains compiled OpenSpiel.
 
 ### Building Your Own Base Image (Optional)
 

--- a/envs/openspiel_env/server/Dockerfile
+++ b/envs/openspiel_env/server/Dockerfile
@@ -23,7 +23,7 @@
 # =============================================================================
 
 # Default: use pre-built image from GHCR (skips C++ compilation)
-ARG OPENSPIEL_BASE_IMAGE=ghcr.io/meta-pytorch/openenv-openspiel-base:sha-e622c7e
+ARG OPENSPIEL_BASE_IMAGE=ghcr.io/huggingface/openenv-openspiel-base:latest
 FROM ${OPENSPIEL_BASE_IMAGE}
 
 WORKDIR /app

--- a/envs/openspiel_env/server/prepare_hf.sh
+++ b/envs/openspiel_env/server/prepare_hf.sh
@@ -21,7 +21,7 @@ sed_inplace() {
 }
 
 # Replace ARG with hardcoded FROM using the special OpenSpiel base
-sed_inplace 's|ARG OPENSPIEL_BASE_IMAGE=.*|FROM ghcr.io/meta-pytorch/openenv-openspiel-base:sha-e622c7e|g' "$DOCKERFILE_PATH"
+sed_inplace 's|ARG OPENSPIEL_BASE_IMAGE=.*|FROM ghcr.io/huggingface/openenv-openspiel-base:latest|g' "$DOCKERFILE_PATH"
 sed_inplace '/^FROM \${OPENSPIEL_BASE_IMAGE}/d' "$DOCKERFILE_PATH"
 
 echo "OpenSpiel: Modified Dockerfile to use GHCR OpenSpiel base image"


### PR DESCRIPTION
## Summary
Point the OpenSpiel environment at the canonical `ghcr.io/huggingface/openenv-openspiel-base` base image instead of the legacy `ghcr.io/meta-pytorch` namespace. The base image is now built and published to the `huggingface` namespace by `openspiel_base_build.yml`, so the env Dockerfile default and the docs should reference it there. The Dockerfile now tracks `:latest` rather than a pinned (and stale) `sha-` tag.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] New environment
- [x] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
- `python scripts/sync_env_docs.py --check` passes (the `openspiel.md` stub was regenerated from the README with `--fix`).
- `ghcr.io/huggingface/openenv-openspiel-base` is public and pullable (verified anonymously).
- Building the env consumes the new base image:
```bash
docker build -t openspiel-env:latest -f envs/openspiel_env/server/Dockerfile envs/openspiel_env
This requires the base image build (openspiel_base_build.yml) to have published :latest to the huggingface namespace from main first.
```

## Claude Code Review

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and Docker defaults only; no application logic changes. Using `:latest` instead of a pinned digest is a minor reproducibility tradeoff for builds.
> 
> **Overview**
> Switches the OpenSpiel env’s default pre-built Docker base from **`ghcr.io/meta-pytorch/openenv-openspiel-base:sha-e622c7e`** to **`ghcr.io/huggingface/openenv-openspiel-base:latest`**, matching where `openspiel_base_build.yml` now publishes the image.
> 
> The same registry path is updated in **`server/Dockerfile`**, **`server/prepare_hf.sh`** (HF Space Dockerfile rewrite), and the build docs in **`envs/openspiel_env/README.md`** / **`docs/source/environments/openspiel.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4da704e3e93efb93766a281ac0f116fc1e1edc7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->