### PR TITLE
BSD 3-Clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,28 @@
 BSD 3-Clause License
 
-(c) Meta Platforms, Inc. and affiliates.
+Copyright (c) 2026, OpenEnv contributors
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice,this list
-of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this
-list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may
-be used to endorse or promote products derived from this software without specific
-prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
-SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2026, OpenEnv contributors
+Copyright (c) 2026, Hugging Face, Inc.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/docs/source/environments/carla.md
+++ b/docs/source/environments/carla.md
@@ -361,4 +361,4 @@ Scenarios and navigation agents adapted from [sinatras/carla-env](https://github
 
 ## License
 
-BSD-3-Clause License (see [LICENSE](https://github.com/huggingface/OpenEnv/blob/main/LICENSE))
+BSD 3-Clause License (see [LICENSE](https://github.com/huggingface/OpenEnv/blob/main/LICENSE))

--- a/docs/source/environments/carla.md
+++ b/docs/source/environments/carla.md
@@ -361,4 +361,4 @@ Scenarios and navigation agents adapted from [sinatras/carla-env](https://github
 
 ## License
 
-BSD 3-Clause License (see [LICENSE](https://github.com/huggingface/OpenEnv/blob/main/LICENSE))
+BSD-3-Clause License (see [LICENSE](https://github.com/huggingface/OpenEnv/blob/main/LICENSE))

--- a/docs/source/environments/julia.md
+++ b/docs/source/environments/julia.md
@@ -218,4 +218,4 @@ uvicorn julia_env.server.app:app --host 0.0.0.0 --port 8000
 
 ## License
 
-This source code is licensed under the BSD-style license found in the LICENSE file in the root directory of this source tree.
+This source code is licensed under the BSD 3-Clause License found in the LICENSE file in the root directory of this source tree.

--- a/docs/source/environments/julia.md
+++ b/docs/source/environments/julia.md
@@ -218,4 +218,4 @@ uvicorn julia_env.server.app:app --host 0.0.0.0 --port 8000
 
 ## License
 
-This source code is licensed under the BSD 3-Clause License found in the LICENSE file in the root directory of this source tree.
+This source code is licensed under the BSD-style license found in the LICENSE file in the root directory of this source tree.

--- a/docs/source/environments/kernrl.md
+++ b/docs/source/environments/kernrl.md
@@ -137,4 +137,4 @@ For production deployments, consider additional isolation measures.
 
 ## License
 
-BSD-3-Clause (following OpenEnv licensing)
+BSD 3-Clause License (following OpenEnv licensing)

--- a/docs/source/environments/kernrl.md
+++ b/docs/source/environments/kernrl.md
@@ -137,4 +137,4 @@ For production deployments, consider additional isolation measures.
 
 ## License
 
-BSD 3-Clause License (following OpenEnv licensing)
+BSD-3-Clause (following OpenEnv licensing)

--- a/docs/source/environments/openapp.md
+++ b/docs/source/environments/openapp.md
@@ -1,5 +1,11 @@
 <!-- openenv-source: openapp_env -->
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!--
+Copyright (c) Meta Platforms, Inc. and affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+-->
 
 <div align="center">
 

--- a/docs/source/environments/openapp.md
+++ b/docs/source/environments/openapp.md
@@ -1,11 +1,5 @@
 <!-- openenv-source: openapp_env -->
-<!--
-Copyright (c) Meta Platforms, Inc. and affiliates.
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
--->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 <div align="center">
 

--- a/docs/source/environments/sumo.md
+++ b/docs/source/environments/sumo.md
@@ -339,4 +339,4 @@ If you use SUMO-RL in your research, please cite:
 
 ## License
 
-This integration is licensed under the BSD-style license. SUMO-RL and SUMO have their own licenses.
+This integration is licensed under the BSD 3-Clause License. SUMO-RL and SUMO have their own licenses.

--- a/docs/source/environments/sumo.md
+++ b/docs/source/environments/sumo.md
@@ -339,4 +339,4 @@ If you use SUMO-RL in your research, please cite:
 
 ## License
 
-This integration is licensed under the BSD 3-Clause License. SUMO-RL and SUMO have their own licenses.
+This integration is licensed under the BSD-style license. SUMO-RL and SUMO have their own licenses.

--- a/docs/source/environments/unity.md
+++ b/docs/source/environments/unity.md
@@ -1,5 +1,10 @@
 <!-- openenv-source: unity_env -->
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!--
+Copyright (c) Meta Platforms, Inc. and affiliates.
+All rights reserved.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+-->
 
 
 # Unity ML-Agents Environment

--- a/docs/source/environments/unity.md
+++ b/docs/source/environments/unity.md
@@ -1,10 +1,5 @@
 <!-- openenv-source: unity_env -->
-<!--
-Copyright (c) Meta Platforms, Inc. and affiliates.
-All rights reserved.
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
--->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
 
 
 # Unity ML-Agents Environment

--- a/docs/source/getting_started/environment-builder.md
+++ b/docs/source/getting_started/environment-builder.md
@@ -230,11 +230,7 @@ Keep building from the `openenv-base` image so shared tooling stays available:
 <summary>Dockerfile</summary>
 
 ```dockerfile
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Multi-stage build using openenv-base
 # This Dockerfile is flexible and works for both:

--- a/docs/source/tutorials/openenv-tutorial.md
+++ b/docs/source/tutorials/openenv-tutorial.md
@@ -1249,7 +1249,7 @@ OpenEnv includes 3 complete examples:
 
 Technical direction, RFCs, and release planning are coordinated in public through the OpenEnv repository.
 
-**License**: BSD 3-Clause (very permissive!)
+**License**: BSD 3-Clause License
 
 **Contributions**: Always welcome! Check out the issues tab.
 

--- a/examples/OpenEnv_Tutorial.ipynb
+++ b/examples/OpenEnv_Tutorial.ipynb
@@ -1912,7 +1912,7 @@
      "- 🤗 Hugging Face\n",
     "- 🚀 And many more!\n",
     "\n",
-    "**License**: BSD 3-Clause (very permissive!)\n",
+    "**License**: BSD 3-Clause License\n",
     "\n",
     "**Contributions**: Always welcome! Check out the issues tab.\n",
     "\n",

--- a/examples/echo_mcp_demo.py
+++ b/examples/echo_mcp_demo.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Echo MCP Demo - Demonstrating MCP tool usage via the canonical SIM mode pattern.

--- a/examples/local_coding_env.py
+++ b/examples/local_coding_env.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 #!/usr/bin/env python3
 """

--- a/examples/openapp_example.py
+++ b/examples/openapp_example.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Example usage of the OpenApp Environment.

--- a/examples/openapp_recording_demo.py
+++ b/examples/openapp_recording_demo.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Demo script optimized for recording videos of OpenApp environment interactions.

--- a/examples/opencode_env_simple.py
+++ b/examples/opencode_env_simple.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """End-to-end opencode_env example: write binary_search.py and verify it.
 

--- a/examples/openspiel_all_games.py
+++ b/examples/openspiel_all_games.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Example script demonstrating all 6 OpenSpiel games integrated with OpenEnv.

--- a/examples/openspiel_simple.py
+++ b/examples/openspiel_simple.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Simple example of using OpenSpiel environment with OpenEnv.

--- a/examples/sophistry_bench_sprint_grpo.py
+++ b/examples/sophistry_bench_sprint_grpo.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # /// script
 # requires-python = ">=3.10"

--- a/examples/textarena_simple.py
+++ b/examples/textarena_simple.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Quickstart example for the generic TextArena environment."""
 from __future__ import annotations

--- a/examples/unity_simple.py
+++ b/examples/unity_simple.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Unity ML-Agents Environment Example Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,6 +7,8 @@ name = "openenv"
 version = "0.3.2.dev0"
 description = "A unified framework for reinforcement learning environments"
 readme = "README.md"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     # Core shared dependencies - minimal set required for all environments

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """EnvTorch: Standardized agentic execution environments."""

--- a/src/openenv/auto/__init__.py
+++ b/src/openenv/auto/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 OpenEnv Auto Module

--- a/src/openenv/auto/_discovery.py
+++ b/src/openenv/auto/_discovery.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Environment Auto-Discovery System

--- a/src/openenv/auto/auto_action.py
+++ b/src/openenv/auto/auto_action.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 AutoAction - Automatic Action Class Selection

--- a/src/openenv/auto/auto_env.py
+++ b/src/openenv/auto/auto_env.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 AutoEnv - Automatic Environment Selection

--- a/src/openenv/cli/__init__.py
+++ b/src/openenv/cli/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """OpenEnv CLI package."""
 

--- a/src/openenv/cli/__main__.py
+++ b/src/openenv/cli/__main__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 OpenEnv CLI entry point.

--- a/src/openenv/cli/_cli_utils.py
+++ b/src/openenv/cli/_cli_utils.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """CLI utilities for OpenEnv command-line interface."""
 

--- a/src/openenv/cli/_validation.py
+++ b/src/openenv/cli/_validation.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Validation utilities for multi-mode deployment readiness.

--- a/src/openenv/cli/commands/__init__.py
+++ b/src/openenv/cli/commands/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """OpenEnv CLI commands."""
 

--- a/src/openenv/cli/commands/build.py
+++ b/src/openenv/cli/commands/build.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Build Docker images for OpenEnv environments."""
 

--- a/src/openenv/cli/commands/collect.py
+++ b/src/openenv/cli/commands/collect.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Run a rollout collection job against a deployed OpenEnv environment.
 

--- a/src/openenv/cli/commands/fork.py
+++ b/src/openenv/cli/commands/fork.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Fork (duplicate) a Hugging Face Space using the Hub API."""
 

--- a/src/openenv/cli/commands/push.py
+++ b/src/openenv/cli/commands/push.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Push an OpenEnv environment to Hugging Face Spaces."""
 

--- a/src/openenv/cli/commands/serve.py
+++ b/src/openenv/cli/commands/serve.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Serve OpenEnv environments locally (TO BE IMPLEMENTED)."""
 

--- a/src/openenv/cli/commands/skills.py
+++ b/src/openenv/cli/commands/skills.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Commands to manage OpenEnv CLI skills for AI assistants."""
 

--- a/src/openenv/cli/commands/validate.py
+++ b/src/openenv/cli/commands/validate.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 OpenEnv validate command.

--- a/src/openenv/cli/templates/__init__.py
+++ b/src/openenv/cli/templates/__init__.py
@@ -1,7 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """OpenEnv CLI templates package."""

--- a/src/openenv/cli/templates/openenv_env/__init__.py
+++ b/src/openenv/cli/templates/openenv_env/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """__ENV_TITLE_NAME__ Environment."""
 

--- a/src/openenv/cli/templates/openenv_env/client.py
+++ b/src/openenv/cli/templates/openenv_env/client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """__ENV_TITLE_NAME__ Environment Client."""
 

--- a/src/openenv/cli/templates/openenv_env/models.py
+++ b/src/openenv/cli/templates/openenv_env/models.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Data models for the __ENV_TITLE_NAME__ Environment.

--- a/src/openenv/cli/templates/openenv_env/pyproject.toml
+++ b/src/openenv/cli/templates/openenv_env/pyproject.toml
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 [build-system]
 requires = ["setuptools>=45", "wheel"]

--- a/src/openenv/cli/templates/openenv_env/server/Dockerfile
+++ b/src/openenv/cli/templates/openenv_env/server/Dockerfile
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 # Multi-stage build using openenv-base
 # This Dockerfile is flexible and works for both:

--- a/src/openenv/cli/templates/openenv_env/server/__ENV_NAME___environment.py
+++ b/src/openenv/cli/templates/openenv_env/server/__ENV_NAME___environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 __ENV_TITLE_NAME__ Environment Implementation.

--- a/src/openenv/cli/templates/openenv_env/server/__init__.py
+++ b/src/openenv/cli/templates/openenv_env/server/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """__ENV_TITLE_NAME__ environment server components."""
 

--- a/src/openenv/cli/templates/openenv_env/server/app.py
+++ b/src/openenv/cli/templates/openenv_env/server/app.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 FastAPI application for the __ENV_TITLE_NAME__ Environment.

--- a/src/openenv/core/README.md
+++ b/src/openenv/core/README.md
@@ -228,7 +228,7 @@ Base interface for environment implementations:
 
 ## License
 
-This project is licensed under the BSD-3-Clause License - see the LICENSE file for details.
+This project is licensed under the BSD 3-Clause License - see the LICENSE file for details.
 
 ## Contributing
 

--- a/src/openenv/core/__init__.py
+++ b/src/openenv/core/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Core components for agentic environments."""
 

--- a/src/openenv/core/containers/__init__.py
+++ b/src/openenv/core/containers/__init__.py
@@ -1,7 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Container management for environment servers."""

--- a/src/openenv/core/containers/images/Dockerfile
+++ b/src/openenv/core/containers/images/Dockerfile
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 #
 # OpenEnv Base Image

--- a/src/openenv/core/containers/runtime/__init__.py
+++ b/src/openenv/core/containers/runtime/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Container runtime providers."""
 

--- a/src/openenv/core/containers/runtime/aca_provider.py
+++ b/src/openenv/core/containers/runtime/aca_provider.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Azure Container Apps Sandbox provider for OpenEnv environments.
 

--- a/src/openenv/core/containers/runtime/daytona_provider.py
+++ b/src/openenv/core/containers/runtime/daytona_provider.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Daytona container provider for running OpenEnv environments in Daytona cloud sandboxes.

--- a/src/openenv/core/containers/runtime/modal_provider.py
+++ b/src/openenv/core/containers/runtime/modal_provider.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Modal container provider for running OpenEnv environments in Modal sandboxes.

--- a/src/openenv/core/containers/runtime/providers.py
+++ b/src/openenv/core/containers/runtime/providers.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Container provider abstractions for running environment servers.

--- a/src/openenv/core/env_client.py
+++ b/src/openenv/core/env_client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Environment client for persistent sessions.

--- a/src/openenv/core/env_server/__init__.py
+++ b/src/openenv/core/env_server/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Core environment interfaces and types."""
 

--- a/src/openenv/core/env_server/base_transforms.py
+++ b/src/openenv/core/env_server/base_transforms.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Base transform implementations for composing environment-specific transforms."""
 

--- a/src/openenv/core/env_server/exceptions.py
+++ b/src/openenv/core/env_server/exceptions.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Custom exceptions for environment server operations."""
 

--- a/src/openenv/core/env_server/gradio_theme.py
+++ b/src/openenv/core/env_server/gradio_theme.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unified terminal-style theme for OpenEnv Gradio UI (light/dark)."""
 

--- a/src/openenv/core/env_server/gradio_ui.py
+++ b/src/openenv/core/env_server/gradio_ui.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Gradio-based web UI for OpenEnv environments.

--- a/src/openenv/core/env_server/http_server.py
+++ b/src/openenv/core/env_server/http_server.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 HTTP server wrapper for Environment instances.

--- a/src/openenv/core/env_server/interfaces.py
+++ b/src/openenv/core/env_server/interfaces.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 import inspect
 from abc import ABC, abstractmethod

--- a/src/openenv/core/env_server/mcp_environment.py
+++ b/src/openenv/core/env_server/mcp_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 MCP Environment base class for OpenEnv.

--- a/src/openenv/core/env_server/mcp_types.py
+++ b/src/openenv/core/env_server/mcp_types.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 MCP (Model Context Protocol) type definitions for OpenEnv.

--- a/src/openenv/core/env_server/route_config.py
+++ b/src/openenv/core/env_server/route_config.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Route configuration utilities for declarative FastAPI route registration.

--- a/src/openenv/core/env_server/serialization.py
+++ b/src/openenv/core/env_server/serialization.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Shared serialization and deserialization utilities for OpenEnv HTTP servers.

--- a/src/openenv/core/env_server/types.py
+++ b/src/openenv/core/env_server/types.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from enum import Enum
 from typing import Annotated, Any, Dict, Literal, Optional, Union

--- a/src/openenv/core/env_server/web_interface.py
+++ b/src/openenv/core/env_server/web_interface.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Web interface for OpenEnv environments.

--- a/src/openenv/core/evals/__init__.py
+++ b/src/openenv/core/evals/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Evaluation harness support for OpenEnv."""
 

--- a/src/openenv/core/evals/base.py
+++ b/src/openenv/core/evals/base.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Base class for evaluation harnesses."""
 

--- a/src/openenv/core/evals/inspect_harness.py
+++ b/src/openenv/core/evals/inspect_harness.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Inspect AI harness integration for OpenEnv.
 

--- a/src/openenv/core/evals/types.py
+++ b/src/openenv/core/evals/types.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Pydantic models for eval configuration and results."""
 

--- a/src/openenv/core/generic_client.py
+++ b/src/openenv/core/generic_client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Generic environment client that works with raw dictionaries.

--- a/src/openenv/core/harness/__init__.py
+++ b/src/openenv/core/harness/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Experimental harness helpers for training and evaluation.
 

--- a/src/openenv/core/harness/collect.py
+++ b/src/openenv/core/harness/collect.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Rollout collection helpers for synthetic dataset generation.
 

--- a/src/openenv/core/llm_client.py
+++ b/src/openenv/core/llm_client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """LLM client abstraction for calling LLM endpoints.
 

--- a/src/openenv/core/mcp_client.py
+++ b/src/openenv/core/mcp_client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 MCP Client classes for tool-calling environments.

--- a/src/openenv/core/rubrics/__init__.py
+++ b/src/openenv/core/rubrics/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Rubrics for reward computation.
 

--- a/src/openenv/core/rubrics/base.py
+++ b/src/openenv/core/rubrics/base.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Base Rubric class for reward computation.
 

--- a/src/openenv/core/rubrics/containers.py
+++ b/src/openenv/core/rubrics/containers.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Container rubrics for composing reward computations.
 

--- a/src/openenv/core/rubrics/llm_judge.py
+++ b/src/openenv/core/rubrics/llm_judge.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """LLM-as-a-judge rubric for reward computation.
 

--- a/src/openenv/core/rubrics/trajectory.py
+++ b/src/openenv/core/rubrics/trajectory.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Trajectory-based rubrics for delayed reward computation.
 

--- a/src/openenv/core/sync_client.py
+++ b/src/openenv/core/sync_client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Synchronous wrapper for async EnvClient.

--- a/src/openenv/core/tools/__init__.py
+++ b/src/openenv/core/tools/__init__.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Core tools for code execution and other utilities."""
 

--- a/src/openenv/core/tools/local_python_executor.py
+++ b/src/openenv/core/tools/local_python_executor.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Local Python Executor (enhanced).
 

--- a/src/openenv/core/utils.py
+++ b/src/openenv/core/utils.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Utility functions for OpenEnv core."""
 

--- a/tests/core/test_evals/__init__.py
+++ b/tests/core/test_evals/__init__.py
@@ -1,7 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for evaluation types and harnesses."""

--- a/tests/core/test_evals/test_eval_harness.py
+++ b/tests/core/test_evals/test_eval_harness.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for EvalHarness ABC."""
 

--- a/tests/core/test_evals/test_eval_types.py
+++ b/tests/core/test_evals/test_eval_types.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for EvalConfig and EvalResult Pydantic models."""
 

--- a/tests/core/test_evals/test_inspect_harness.py
+++ b/tests/core/test_evals/test_inspect_harness.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for InspectAIHarness with mocked inspect_ai dependencies."""
 

--- a/tests/core/test_harness_collect.py
+++ b/tests/core/test_harness_collect.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for rollout collection, serialization, and resume."""
 

--- a/tests/core/test_harness_runtime.py
+++ b/tests/core/test_harness_runtime.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the harness/session runtime layer."""
 

--- a/tests/core/test_llm_client.py
+++ b/tests/core/test_llm_client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for LLMClient abstraction, OpenAIClient, AnthropicClient, and helpers."""
 

--- a/tests/core/test_mcp/__init__.py
+++ b/tests/core/test_mcp/__init__.py
@@ -1,7 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for MCP (Model Context Protocol) support."""

--- a/tests/core/test_mcp/test_mcp_client.py
+++ b/tests/core/test_mcp/test_mcp_client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for MCPToolClient.

--- a/tests/core/test_mcp/test_mcp_environment.py
+++ b/tests/core/test_mcp/test_mcp_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for MCPEnvironment base class."""
 

--- a/tests/core/test_mcp/test_mcp_integration.py
+++ b/tests/core/test_mcp/test_mcp_integration.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Integration tests for MCP functionality.

--- a/tests/core/test_mcp/test_mcp_types.py
+++ b/tests/core/test_mcp/test_mcp_types.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for MCP type definitions and deserialization routing."""
 

--- a/tests/core/test_mcp/test_mode_aware_tools.py
+++ b/tests/core/test_mcp/test_mode_aware_tools.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for mode-aware tool registration (Task #5 of Issue #359).

--- a/tests/core/test_mode_selection.py
+++ b/tests/core/test_mode_selection.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for mode selection in OpenEnv clients and environments.

--- a/tests/core/test_production_mode_mcp.py
+++ b/tests/core/test_production_mode_mcp.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for production mode MCP functionality.

--- a/tests/core/test_production_mode_routes.py
+++ b/tests/core/test_production_mode_routes.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for production mode routes in OpenEnv.

--- a/tests/core/test_route_config.py
+++ b/tests/core/test_route_config.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for declarative route registration helpers."""
 

--- a/tests/core/test_rubrics/__init__.py
+++ b/tests/core/test_rubrics/__init__.py
@@ -1,5 +1,1 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/core/test_rubrics/test_async_base_rubric.py
+++ b/tests/core/test_rubrics/test_async_base_rubric.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for async Rubric functionality.
 

--- a/tests/core/test_rubrics/test_async_containers.py
+++ b/tests/core/test_rubrics/test_async_containers.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for async container rubrics: Sequential, Gate, WeightedSum.
 

--- a/tests/core/test_rubrics/test_async_environment_integration.py
+++ b/tests/core/test_rubrics/test_async_environment_integration.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for async rubric integration with async Environment.
 

--- a/tests/core/test_rubrics/test_base_rubric.py
+++ b/tests/core/test_rubrics/test_base_rubric.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the base Rubric class."""
 

--- a/tests/core/test_rubrics/test_containers.py
+++ b/tests/core/test_rubrics/test_containers.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for container rubrics: Sequential, Gate, WeightedSum, RubricList, RubricDict."""
 

--- a/tests/core/test_rubrics/test_environment_integration.py
+++ b/tests/core/test_rubrics/test_environment_integration.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for rubric integration with Environment base class."""
 

--- a/tests/core/test_rubrics/test_llm_judge.py
+++ b/tests/core/test_rubrics/test_llm_judge.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for LLMJudge rubric."""
 

--- a/tests/core/test_rubrics/test_pre_hook_bugs.py
+++ b/tests/core/test_rubrics/test_pre_hook_bugs.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for pre-hook and container execution bugs.
 

--- a/tests/core/test_rubrics/test_trajectory_rubric.py
+++ b/tests/core/test_rubrics/test_trajectory_rubric.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for TrajectoryRubric and ExponentialDiscountingTrajectoryRubric."""
 

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from openenv.core.env_server.serialization import serialize_observation
 from openenv.core.env_server.types import Observation, ResetResponse, StepResponse

--- a/tests/core/test_simulation_mode_preserves_api.py
+++ b/tests/core/test_simulation_mode_preserves_api.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for simulation mode API preservation (Task #1).

--- a/tests/core/test_types_and_enums.py
+++ b/tests/core/test_types_and_enums.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for enums and Pydantic models in OpenEnv env_server.

--- a/tests/core/test_web_interface.py
+++ b/tests/core/test_web_interface.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the OpenEnv Gradio web interface helpers."""
 

--- a/tests/core/test_web_interface_layout.py
+++ b/tests/core/test_web_interface_layout.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for custom Gradio layout options."""
 

--- a/tests/envs/test_auto_env.py
+++ b/tests/envs/test_auto_env.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Unit tests for AutoEnv and AutoAction

--- a/tests/envs/test_browsergym_harness.py
+++ b/tests/envs/test_browsergym_harness.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for BrowserGym's harness-oriented session adapter."""
 

--- a/tests/envs/test_carla_environment.py
+++ b/tests/envs/test_carla_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for CARLA environment.

--- a/tests/envs/test_chess_environment.py
+++ b/tests/envs/test_chess_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for Chess environment."""
 

--- a/tests/envs/test_chess_rubric_migration.py
+++ b/tests/envs/test_chess_rubric_migration.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for chess environment rubric migration.
 

--- a/tests/envs/test_coding_env_integration.py
+++ b/tests/envs/test_coding_env_integration.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Integration tests for CodingEnv with Docker.
 

--- a/tests/envs/test_coding_tools_environment.py
+++ b/tests/envs/test_coding_tools_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 

--- a/tests/envs/test_connect4_env.py
+++ b/tests/envs/test_connect4_env.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Test Connect4 environment client and server integration.
 

--- a/tests/envs/test_discovery.py
+++ b/tests/envs/test_discovery.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Unit tests for Package-Based Environment Discovery

--- a/tests/envs/test_grid_world.py
+++ b/tests/envs/test_grid_world.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/envs/test_julia_env.py
+++ b/tests/envs/test_julia_env.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Test the JuliaCodeActEnv and JuliaExecutor functionality."""
 

--- a/tests/envs/test_jupyter_environment.py
+++ b/tests/envs/test_jupyter_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 

--- a/tests/envs/test_opencode_env.py
+++ b/tests/envs/test_opencode_env.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Smoke tests for ``opencode_env``.
 

--- a/tests/envs/test_openspiel_collect.py
+++ b/tests/envs/test_openspiel_collect.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """End-to-end smoke test for the rollout collect pipeline on OpenSpiel TTT.
 

--- a/tests/envs/test_openspiel_harness.py
+++ b/tests/envs/test_openspiel_harness.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the OpenSpiel harness session adapter."""
 

--- a/tests/envs/test_python_codeact_reset.py
+++ b/tests/envs/test_python_codeact_reset.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Test that PythonCodeActEnv.reset() properly resets executor state."""
 

--- a/tests/envs/test_python_codeact_rewards.py
+++ b/tests/envs/test_python_codeact_rewards.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Test that PythonCodeActEnv properly computes rewards via transform pipeline."""
 

--- a/tests/envs/test_reasoning_gym_environment.py
+++ b/tests/envs/test_reasoning_gym_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the Reasoning Gym Environment."""
 

--- a/tests/envs/test_repl_env.py
+++ b/tests/envs/test_repl_env.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the REPL Environment."""
 

--- a/tests/envs/test_repl_env_reset_cache.py
+++ b/tests/envs/test_repl_env_reset_cache.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit tests for REPL reset-time LLM cache invalidation."""
 

--- a/tests/envs/test_sophistry_bench_sprint_environment.py
+++ b/tests/envs/test_sophistry_bench_sprint_environment.py
@@ -1,4 +1,5 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
 """Tests for the sophistry-bench sprint OpenEnv environment."""
 
 import asyncio

--- a/tests/envs/test_terminus_environment.py
+++ b/tests/envs/test_terminus_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
 

--- a/tests/envs/test_unity_environment.py
+++ b/tests/envs/test_unity_environment.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Unit tests for Unity ML-Agents environment server.

--- a/tests/envs/test_websockets.py
+++ b/tests/envs/test_websockets.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Integration tests for OpenEnv environments.

--- a/tests/test_cli/test_build.py
+++ b/tests/test_cli/test_build.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for openenv build helpers."""
 

--- a/tests/test_cli/test_collect.py
+++ b/tests/test_cli/test_collect.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the ``openenv collect`` CLI command."""
 

--- a/tests/test_cli/test_fork.py
+++ b/tests/test_cli/test_fork.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the openenv fork command."""
 

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the openenv init command."""
 

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the openenv __main__ module."""
 

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the openenv push command."""
 

--- a/tests/test_cli/test_skills.py
+++ b/tests/test_cli/test_skills.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the openenv skills command."""
 

--- a/tests/test_cli/test_validate.py
+++ b/tests/test_cli/test_validate.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the openenv validate command and runtime validation utilities."""
 

--- a/tests/test_core/__init__.py
+++ b/tests/test_core/__init__.py
@@ -1,7 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for openenv.core module."""

--- a/tests/test_core/aca_integration_server.py
+++ b/tests/test_core/aca_integration_server.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Minimal OpenEnv-protocol server used by the opt-in ACA integration test.
 

--- a/tests/test_core/test_daytona_provider.py
+++ b/tests/test_core/test_daytona_provider.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit tests for DaytonaProvider. All tests mock the daytona SDK."""
 

--- a/tests/test_core/test_docker_base_image.py
+++ b/tests/test_core/test_docker_base_image.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Tests for the openenv-base Docker image.
 

--- a/tests/test_core/test_generic_client.py
+++ b/tests/test_core/test_generic_client.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Unit tests for GenericEnvClient and GenericAction

--- a/tests/test_core/test_modal_provider.py
+++ b/tests/test_core/test_modal_provider.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit tests for ModalProvider.
 

--- a/tests/test_core/test_uv_provider.py
+++ b/tests/test_core/test_uv_provider.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """Unit tests for UVProvider readiness handling.
 

--- a/tests/test_line_endings.py
+++ b/tests/test_line_endings.py
@@ -1,8 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
+# SPDX-License-Identifier: BSD-3-Clause
 
 """
 Tests for consistent line endings across the repository.

--- a/tutorial/01-environments.md
+++ b/tutorial/01-environments.md
@@ -1136,7 +1136,7 @@ OpenEnv includes 3 complete examples:
 
 Technical direction, RFCs, and release planning are coordinated in public through the OpenEnv repository.
 
-**License**: BSD 3-Clause (very permissive!)
+**License**: BSD 3-Clause License
 
 **Contributions**: Always welcome! Check out the issues tab.
 

--- a/tutorial/examples/OpenEnv_Tutorial.ipynb
+++ b/tutorial/examples/OpenEnv_Tutorial.ipynb
@@ -1908,10 +1908,10 @@
      "- 🟢 Nvidia\n",
      "- 💼 Mercor\n",
      "- 🚀 Fleet AI\n",
-     "- 🤗 Hugging Face\n"
+     "- 🤗 Hugging Face\n",
     "- 🚀 And many more!\n",
     "\n",
-    "**License**: BSD 3-Clause (very permissive!)\n",
+    "**License**: BSD 3-Clause License\n",
     "\n",
     "**Contributions**: Always welcome! Check out the issues tab.\n",
     "\n",


### PR DESCRIPTION
This PR switches OpenEnv to a complete BSD 3-Clause license and removes Meta-specific license headers outside envs/.