### PR TITLE
[codex] refactor inspect eval kwargs

### DIFF
--- a/src/openenv/core/evals/inspect_harness.py
+++ b/src/openenv/core/evals/inspect_harness.py
@@ -11,6 +11,18 @@ from typing import Any, Dict, Optional
 
 from openenv.core.evals.base import EvalHarness
 
+_NON_EMPTY_EVAL_KWARGS = ("task_args", "model_args")
+_OPTIONAL_EVAL_KWARGS = (
+    "max_samples",
+    "max_connections",
+    "temperature",
+    "max_tokens",
+    "epochs",
+    "solver",
+    "scorer",
+    "model_base_url",
+)
+
 
 class InspectAIHarness(EvalHarness):
     """Evaluation harness wrapping Inspect AI's ``eval()`` function.
@@ -82,7 +94,6 @@ class InspectAIHarness(EvalHarness):
                 "Install it with: pip install 'inspect-ai>=0.3.0'"
             )
 
-        # Extract required model parameter
         model = eval_parameters.get("model")
         if model is None:
             raise ValueError(
@@ -90,48 +101,10 @@ class InspectAIHarness(EvalHarness):
                 "(e.g. 'openai/gpt-4o', 'hf/meta-llama/...')."
             )
 
-        # Task: explicit parameter or fall back to dataset
         task = eval_parameters.get("task", dataset)
-
-        # Build eval kwargs
-        eval_kwargs: Dict[str, Any] = {}
-
-        task_args = eval_parameters.get("task_args", {})
-        if task_args:
-            eval_kwargs["task_args"] = task_args
-
-        model_args = eval_parameters.get("model_args", {})
-        if model_args:
-            eval_kwargs["model_args"] = model_args
-
-        for key in (
-            "max_samples",
-            "max_connections",
-            "temperature",
-            "max_tokens",
-            "epochs",
-        ):
-            value = eval_parameters.get(key)
-            if value is not None:
-                eval_kwargs[key] = value
-
-        if eval_parameters.get("solver") is not None:
-            eval_kwargs["solver"] = eval_parameters["solver"]
-
-        if eval_parameters.get("scorer") is not None:
-            eval_kwargs["scorer"] = eval_parameters["scorer"]
-
-        if self.log_dir is not None:
-            eval_kwargs["log_dir"] = self.log_dir
-
-        model_base_url = eval_parameters.get("model_base_url")
-        if model_base_url is not None:
-            eval_kwargs["model_base_url"] = model_base_url
-
-        # Run evaluation
+        eval_kwargs = self._build_eval_kwargs(eval_parameters)
         logs = inspect_eval(task, model=model, **eval_kwargs)
 
-        # Extract results from the first log
         if not logs:
             raise RuntimeError(
                 "Inspect AI evaluation returned no logs. "
@@ -144,6 +117,25 @@ class InspectAIHarness(EvalHarness):
             )
 
         return self._extract_scores(log)
+
+    def _build_eval_kwargs(self, eval_parameters: Dict[str, Any]) -> Dict[str, Any]:
+        """Build keyword arguments passed through to ``inspect_ai.eval``."""
+
+        eval_kwargs: Dict[str, Any] = {}
+        for key in _NON_EMPTY_EVAL_KWARGS:
+            value = eval_parameters.get(key, {})
+            if value:
+                eval_kwargs[key] = value
+
+        for key in _OPTIONAL_EVAL_KWARGS:
+            value = eval_parameters.get(key)
+            if value is not None:
+                eval_kwargs[key] = value
+
+        if self.log_dir is not None:
+            eval_kwargs["log_dir"] = self.log_dir
+
+        return eval_kwargs
 
     def _extract_scores(self, log: Any) -> Dict[str, Any]:
         """Parse an EvalLog's results into a flat score dictionary.

--- a/tests/core/test_evals/test_inspect_harness.py
+++ b/tests/core/test_evals/test_inspect_harness.py
@@ -182,24 +182,30 @@ class TestInspectAIHarnessRun:
             {
                 "model": "openai/gpt-4o",
                 "max_samples": 100,
+                "max_connections": 4,
                 "temperature": 0.5,
                 "max_tokens": 256,
                 "epochs": 3,
+                "model_base_url": "https://example.test/v1",
             }
         )
         _, kwargs = mock_eval.call_args
         assert kwargs["max_samples"] == 100
+        assert kwargs["max_connections"] == 4
         assert kwargs["temperature"] == 0.5
         assert kwargs["max_tokens"] == 256
         assert kwargs["epochs"] == 3
+        assert kwargs["model_base_url"] == "https://example.test/v1"
 
     def test_none_optional_kwargs_omitted(self):
         _, mock_eval = self._run_harness({"model": "openai/gpt-4o"})
         _, kwargs = mock_eval.call_args
         assert "max_samples" not in kwargs
+        assert "max_connections" not in kwargs
         assert "temperature" not in kwargs
         assert "max_tokens" not in kwargs
         assert "epochs" not in kwargs
+        assert "model_base_url" not in kwargs
 
     def test_task_args_passed_through(self):
         _, mock_eval = self._run_harness(


### PR DESCRIPTION
Summary:
- Extract InspectAI eval keyword assembly into a private helper.
- Add coverage for existing max_connections and model_base_url pass-through.

Validation:
- PYTHONPATH=src:envs uv run python -m pytest tests/core/test_evals -q
- PYTHONPATH=src:envs uv run python -m pytest tests/ -q -m "not integration and not docker and not network"
- uv run ruff check src/openenv/core/evals tests/core/test_evals
- uv run ruff format --check src/openenv/core/evals tests/core/test_evals
- uv run usort check src/openenv/core/evals tests/core/test_evals