### PR TITLE
Unpin huggingface_hub in HF sandbox examples

### DIFF
--- a/examples/browsergym_trl_hf_sandbox.py
+++ b/examples/browsergym_trl_hf_sandbox.py
@@ -18,7 +18,7 @@
 #     "trl[vllm,peft]",
 #     "trackio",
 #     "kernels",
-#     "huggingface_hub @ git+https://github.com/huggingface/huggingface_hub.git@5b643062ac4efa4d940d7d614a4dfc8ccaf910b5",
+#     "huggingface_hub>=1.22.0",
 #     "transformers>=5.0.0",
 # ]
 # ///

--- a/examples/hf_sandbox_coding_env.py
+++ b/examples/hf_sandbox_coding_env.py
@@ -9,7 +9,7 @@
 
 # /// script
 # dependencies = [
-#     "huggingface_hub @ git+https://github.com/huggingface/huggingface_hub.git@5b643062ac4efa4d940d7d614a4dfc8ccaf910b5",
+#     "huggingface_hub>=1.22.0",
 # ]
 # ///
 


### PR DESCRIPTION
## Summary
Replaces the `huggingface_hub` git-commit pin in the two HF sandbox examples with a packaged version floor (`>=1.22.0`), now that the released `huggingface_hub` exports the sandbox proxy API. This is the follow-up promised in PR #841.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [x] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)

## Test Plan
Context: in PR #841, the two standalone HF sandbox examples pinned `huggingface_hub` to git commit `5b643062ac4efa4d940d7d614a4dfc8ccaf910b5` because no PyPI release exported `SandboxPool` yet. The last review comment noted: *"Once Hub releases that API, we can replace the git pin with the packaged version floor."*

That release is now out. Verified against the packaged `huggingface_hub` 1.22.0 wheel from PyPI:
- `huggingface_hub/__init__.py` exports `Sandbox`, `SandboxPool`, `SandboxProcess`, `SandboxCommandResult`.
- The API surface the provider uses is present: `SandboxPool.create`, `Sandbox.proxy_url_for`, `Sandbox.proxy_headers`.
- The `SandboxPool(image=..., flavor=..., name=...)` constructor kwargs in `hf_sandbox_provider.py` match the released `SandboxPool.__init__` signature, so there is no drift between the pinned commit and 1.22.0.

Scope is limited to the two example header dependency blocks; no source or core dependency changes. The core floor in `pyproject.toml` stays at `huggingface_hub>=0.20.0` on purpose, since `HFSandboxProvider` already guards the import with a clear `RuntimeError` for older versions and we don't want to force the new version on users who don't use the sandbox provider.

## Claude Code Review
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only dependency metadata; no runtime or core package constraint changes.
> 
> **Overview**
> Swaps the **git-commit pin** on `huggingface_hub` in the two standalone HF sandbox example scripts (`browsergym_trl_hf_sandbox.py`, `hf_sandbox_coding_env.py`) for a **PyPI floor** of `huggingface_hub>=1.22.0`, now that the released package exports the sandbox proxy API (`SandboxPool`, etc.) those examples need.
> 
> **No** changes to library source or root `pyproject.toml` dependency floors—only the `/// script` dependency blocks in those examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3094333f1ef0d8899a8f11f6c08a78f559b894ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->