### PR TITLE
Bump 0.4.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openenv"
-version = "0.4.1"
+version = "0.4.2.dev0"
 description = "A unified framework for reinforcement learning environments"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
This PR bumps OpenEnv to 0.4.2.dev0 after the 0.4.1 release.