### PR TITLE
Add Fraud Triage environment: transaction risk-decisioning RL task

### DIFF
--- a/envs/fraud_triage_env/README.md
+++ b/envs/fraud_triage_env/README.md
@@ -1,0 +1,116 @@
+---
+title: Fraud Triage Environment Server
+emoji: 🛡️
+colorFrom: red
+colorTo: gray
+sdk: docker
+pinned: false
+app_port: 8000
+tags:
+  - openenv
+  - fraud-detection
+  - fintech
+  - risk-decisioning
+---
+
+# Fraud Triage Environment
+
+A sequential transaction risk-decisioning environment for RL post-training,
+built for the OpenEnv specification.
+
+## Overview
+
+Existing OpenEnv finance environments cover stock trading ([`finrl_env`](../finrl_env))
+and financial document QA ([`finqa_env`](../finqa_env)), but nothing covers
+**transaction-level risk decisioning** -- the core loop of a payments fraud
+or risk team. This environment fills that gap.
+
+An agent is streamed synthetic financial transactions one at a time and must
+choose one of four actions for each:
+
+- **APPROVE** — let the transaction go through with no flag
+- **FLAG** — allow it, but tag for downstream/offline review
+- **ESCALATE** — hold for a human analyst before settling
+- **BLOCK** — reject the transaction outright
+
+Each transaction carries engineered risk features modeled on the kind of
+signals a production anomaly-detection pipeline computes in real time:
+amount, deviation from the account's historical spending (z-score),
+transaction velocity over 1h/24h windows, whether the merchant or device is
+new to the account, cross-border flag, time of day, and account age.
+
+## Reward design
+
+Reward is intentionally **asymmetric**, matching how real payment-risk teams
+weigh these outcomes:
+
+| Outcome | Reward |
+|---|---|
+| Correctly flag/escalate/block a fraudulent transaction (true positive) | `+1.0` |
+| Correctly approve a legitimate transaction (true negative) | `+0.1` |
+| Incorrectly flag/escalate/block a legitimate transaction (false positive) | `-0.5` |
+| Incorrectly approve a fraudulent transaction (false negative) | `-3.0` |
+| Escalation (in addition to the above) | additional `-0.1` |
+
+Missing real fraud is penalized far more heavily than over-flagging a
+legitimate customer, but escalating everything is also discouraged via a
+small fixed cost — so an agent can't "win" by defaulting to maximum
+caution. This forces the same precision/recall trade-off a production
+fraud model has to learn, rather than collapsing to a trivial policy.
+
+Fraudulent and legitimate transactions are drawn from overlapping (not
+perfectly separable) feature distributions, so the task rewards genuine
+pattern-learning over simple thresholding.
+
+## Quick Start
+
+### Using Docker
+
+```bash
+cd OpenEnv
+docker build -t openenv-base:latest -f src/openenv/core/containers/images/Dockerfile .
+docker build -t fraud-triage-env:latest -f envs/fraud_triage_env/server/Dockerfile envs/fraud_triage_env
+docker run -p 8000:8000 fraud-triage-env:latest
+```
+
+### Client usage
+
+```python
+from envs.fraud_triage_env import FraudTriageEnv, FraudTriageAction, TriageDecision
+
+with FraudTriageEnv(base_url="http://localhost:8000") as env:
+    result = env.reset()
+    obs = result.observation
+    print(f"amount={obs.amount}, z-score={obs.amount_zscore}, new_device={obs.is_new_device}")
+
+    # A simple heuristic policy, for illustration:
+    if obs.amount_zscore > 2.5 or (obs.is_new_device and obs.is_new_merchant):
+        action = FraudTriageAction(decision=TriageDecision.ESCALATE)
+    else:
+        action = FraudTriageAction(decision=TriageDecision.APPROVE)
+
+    result = env.step(action)
+    print(f"reward={result.reward}, done={result.done}")
+```
+
+### Running locally without Docker
+
+```bash
+cd envs/fraud_triage_env
+pip install -e ".[dev]"
+uvicorn server.app:app --host 0.0.0.0 --port 8000
+```
+
+## Configuration
+
+The environment accepts two constructor parameters (set in `server/app.py`
+or via environment-specific wiring if you fork this):
+
+- `episode_length` (default `200`): number of transactions per episode
+- `fraud_rate` (default `0.12`): fraction of transactions that are fraudulent
+
+## Testing
+
+```bash
+PYTHONPATH=src:envs pytest tests/envs/test_fraud_triage_env.py -v
+```

--- a/envs/fraud_triage_env/__init__.py
+++ b/envs/fraud_triage_env/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Fraud Triage Environment - a sequential transaction risk-decisioning task.
+
+An agent is streamed synthetic financial transactions one at a time and must
+choose to APPROVE, FLAG, ESCALATE, or BLOCK each one. Reward is asymmetric:
+missing real fraud is penalized far more heavily than over-flagging a
+legitimate transaction, and escalation carries a small fixed cost to
+discourage defaulting to it -- mirroring the precision/recall trade-offs and
+cost structure real payment-risk and fraud-detection teams operate under.
+
+Example:
+    >>> from fraud_triage_env import FraudTriageEnv, FraudTriageAction, TriageDecision
+    >>>
+    >>> with FraudTriageEnv(base_url="http://localhost:8000") as env:
+    ...     result = env.reset()
+    ...     print(result.observation.amount, result.observation.amount_zscore)
+    ...
+    ...     result = env.step(FraudTriageAction(decision=TriageDecision.FLAG))
+    ...     print(result.reward, result.done)
+"""
+
+from .client import FraudTriageEnv
+from .models import (
+    FraudTriageAction,
+    FraudTriageObservation,
+    FraudTriageState,
+    TriageDecision,
+)
+
+__all__ = [
+    "FraudTriageEnv",
+    "FraudTriageAction",
+    "FraudTriageObservation",
+    "FraudTriageState",
+    "TriageDecision",
+]

--- a/envs/fraud_triage_env/client.py
+++ b/envs/fraud_triage_env/client.py
@@ -1,0 +1,96 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Fraud Triage Environment Client.
+
+This module provides the client for connecting to a Fraud Triage
+Environment server via WebSocket for persistent, low-latency multi-step
+episodes.
+
+Example:
+    >>> from fraud_triage_env import FraudTriageEnv, FraudTriageAction, TriageDecision
+    >>>
+    >>> with FraudTriageEnv(base_url="http://localhost:8000") as client:
+    ...     result = client.reset()
+    ...     print(result.observation.amount, result.observation.amount_zscore)
+    ...
+    ...     result = client.step(FraudTriageAction(decision=TriageDecision.FLAG))
+    ...     print(result.reward, result.done)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from openenv.core.client_types import StepResult
+from openenv.core.env_client import EnvClient
+
+from .models import FraudTriageAction, FraudTriageObservation, FraudTriageState
+
+
+class FraudTriageEnv(EnvClient[FraudTriageAction, FraudTriageObservation, FraudTriageState]):
+    """
+    Client for the Fraud Triage Environment.
+
+    Maintains a persistent WebSocket connection to the environment server,
+    streaming one synthetic transaction at a time and scoring the agent's
+    approve/flag/escalate/block decisions against hidden ground-truth labels.
+
+    Example:
+        >>> with FraudTriageEnv(base_url="http://localhost:8000") as client:
+        ...     result = client.reset()
+        ...     print(result.observation.amount)
+        ...
+        ...     result = client.step(FraudTriageAction(decision=0))  # APPROVE
+        ...     print(result.reward, result.done)
+    """
+
+    def _step_payload(self, action: FraudTriageAction) -> Dict[str, Any]:
+        """Convert FraudTriageAction to JSON payload for the step request."""
+        return {"decision": int(action.decision)}
+
+    def _parse_result(self, payload: Dict[str, Any]) -> StepResult[FraudTriageObservation]:
+        """Parse server response into StepResult[FraudTriageObservation]."""
+        obs_data = payload.get("observation", {})
+
+        observation = FraudTriageObservation(
+            transaction_id=obs_data.get("transaction_id", ""),
+            amount=obs_data.get("amount", 0.0),
+            merchant_category=obs_data.get("merchant_category", 0),
+            velocity_1h=obs_data.get("velocity_1h", 0),
+            velocity_24h=obs_data.get("velocity_24h", 0),
+            amount_zscore=obs_data.get("amount_zscore", 0.0),
+            is_new_merchant=obs_data.get("is_new_merchant", False),
+            is_new_device=obs_data.get("is_new_device", False),
+            cross_border=obs_data.get("cross_border", False),
+            hour_of_day=obs_data.get("hour_of_day", 0),
+            account_age_days=obs_data.get("account_age_days", 0),
+            legal_actions=obs_data.get("legal_actions", [0, 1, 2, 3]),
+            done=payload.get("done", False),
+            reward=payload.get("reward", 0.0),
+            metadata=payload.get("metadata", obs_data.get("metadata", {})),
+        )
+
+        return StepResult(
+            observation=observation,
+            reward=payload.get("reward", 0.0),
+            done=payload.get("done", False),
+            metadata=payload.get("metadata"),
+        )
+
+    def _parse_state(self, payload: Dict[str, Any]) -> FraudTriageState:
+        """Parse server response into a FraudTriageState object."""
+        return FraudTriageState(
+            episode_id=payload.get("episode_id", ""),
+            step_count=payload.get("step_count", 0),
+            episode_length=payload.get("episode_length", 200),
+            true_positives=payload.get("true_positives", 0),
+            false_positives=payload.get("false_positives", 0),
+            false_negatives=payload.get("false_negatives", 0),
+            true_negatives=payload.get("true_negatives", 0),
+            cumulative_reward=payload.get("cumulative_reward", 0.0),
+        )

--- a/envs/fraud_triage_env/models.py
+++ b/envs/fraud_triage_env/models.py
@@ -1,0 +1,117 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Data models for the Fraud Triage Environment.
+
+This module defines the Action, Observation, and State types for a
+sequential transaction-risk-decisioning task exposed through the OpenEnv
+interface.
+
+An agent is streamed one transaction at a time and must decide how to
+handle it. The environment rewards catching fraud while penalizing false
+positives (blocking or escalating legitimate transactions) and false
+negatives (approving fraudulent ones) at different weights, mirroring the
+asymmetric cost structure real payment/fraud teams operate under.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Any, Dict, List, Optional
+
+from openenv.core.env_server import Action, Observation, State
+from pydantic import Field
+
+
+class TriageDecision(IntEnum):
+    """The four actions available to the agent for each transaction."""
+
+    APPROVE = 0
+    FLAG = 1  # allow, but tag for downstream/offline review
+    ESCALATE = 2  # hold for a human analyst before settling
+    BLOCK = 3  # reject the transaction outright
+
+
+class FraudTriageAction(Action):
+    """
+    Action for the Fraud Triage environment.
+
+    Attributes:
+        decision: One of TriageDecision (0=APPROVE, 1=FLAG, 2=ESCALATE, 3=BLOCK).
+    """
+
+    decision: int
+
+
+class FraudTriageObservation(Observation):
+    """
+    Observation for the Fraud Triage environment.
+
+    Represents a single transaction with engineered risk features, similar
+    in spirit to the feature set a production anomaly-detection pipeline
+    would compute in real time.
+
+    Attributes:
+        transaction_id: Unique identifier for this transaction.
+        amount: Transaction amount, normalized to the account's typical range.
+        merchant_category: Coarse merchant category code (0-9, synthetic).
+        velocity_1h: Number of transactions on this account in the last hour.
+        velocity_24h: Number of transactions on this account in the last 24h.
+        amount_zscore: How many standard deviations this amount is from the
+            account's historical mean transaction size.
+        is_new_merchant: Whether this merchant has never been used by this
+            account before.
+        is_new_device: Whether this transaction originates from a device
+            not previously associated with this account.
+        cross_border: Whether the transaction crosses a national border.
+        hour_of_day: Hour (0-23) the transaction occurred, local to the account.
+        account_age_days: Age of the account in days.
+        legal_actions: The list of valid TriageDecision values (always all four
+            here, but included for interface consistency with other envs).
+        done: Whether the episode (transaction stream) has ended.
+        reward: Reward for the last action.
+    """
+
+    transaction_id: str = ""
+    amount: float = 0.0
+    merchant_category: int = 0
+    velocity_1h: int = 0
+    velocity_24h: int = 0
+    amount_zscore: float = 0.0
+    is_new_merchant: bool = False
+    is_new_device: bool = False
+    cross_border: bool = False
+    hour_of_day: int = 0
+    account_age_days: int = 0
+    legal_actions: List[int] = Field(
+        default_factory=lambda: [d.value for d in TriageDecision]
+    )
+
+
+class FraudTriageState(State):
+    """
+    State for the Fraud Triage environment.
+
+    Attributes:
+        episode_id: Unique ID for the current transaction stream.
+        step_count: Number of transactions processed so far this episode.
+        episode_length: Total number of transactions in this episode.
+        true_positives: Fraudulent transactions correctly flagged/escalated/blocked.
+        false_positives: Legitimate transactions incorrectly flagged/escalated/blocked.
+        false_negatives: Fraudulent transactions incorrectly approved.
+        true_negatives: Legitimate transactions correctly approved.
+        cumulative_reward: Running sum of reward this episode.
+    """
+
+    episode_id: str = ""
+    step_count: int = 0
+    episode_length: int = 200
+    true_positives: int = 0
+    false_positives: int = 0
+    false_negatives: int = 0
+    true_negatives: int = 0
+    cumulative_reward: float = 0.0

--- a/envs/fraud_triage_env/openenv.yaml
+++ b/envs/fraud_triage_env/openenv.yaml
@@ -1,0 +1,6 @@
+spec_version: 1
+name: fraud_triage_env
+type: space
+runtime: fastapi
+app: server.app:app
+port: 8000

--- a/envs/fraud_triage_env/pyproject.toml
+++ b/envs/fraud_triage_env/pyproject.toml
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openenv-fraud-triage-env"
+version = "0.1.0"
+description = "Fraud Triage Environment for OpenEnv - sequential transaction risk-decisioning RL task"
+requires-python = ">=3.10"
+dependencies = [
+    "openenv>=0.2.2",
+    "fastapi>=0.115.0",
+    "pydantic>=2.0.0",
+    "uvicorn>=0.24.0",
+    "requests>=2.31.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-cov>=4.0.0",
+]
+
+[project.scripts]
+server = "fraud_triage_env.server.app:main"
+
+[tool.setuptools]
+include-package-data = true
+packages = ["fraud_triage_env", "fraud_triage_env.server"]
+package-dir = { "fraud_triage_env" = ".", "fraud_triage_env.server" = "server" }

--- a/envs/fraud_triage_env/server/Dockerfile
+++ b/envs/fraud_triage_env/server/Dockerfile
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+ARG BASE_IMAGE=ghcr.io/huggingface/openenv-base:latest
+FROM ${BASE_IMAGE} AS builder
+
+WORKDIR /app
+
+COPY . /app/env
+
+WORKDIR /app/env
+
+RUN if ! command -v uv >/dev/null 2>&1; then \
+        curl -LsSf https://astral.sh/uv/install.sh | sh && \
+        mv /root/.local/bin/uv /usr/local/bin/uv && \
+        mv /root/.local/bin/uvx /usr/local/bin/uvx; \
+    fi
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ -f uv.lock ]; then \
+        uv sync --frozen --no-install-project --no-editable; \
+    else \
+        uv sync --no-install-project --no-editable; \
+    fi
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ -f uv.lock ]; then \
+        uv sync --frozen --no-editable; \
+    else \
+        uv sync --no-editable; \
+    fi
+
+# Final runtime stage
+FROM ${BASE_IMAGE}
+
+WORKDIR /app
+
+COPY --from=builder /app/env/.venv /app/.venv
+COPY --from=builder /app/env /app/env
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH="/app/env:$PYTHONPATH"
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
+
+CMD ["sh", "-c", "cd /app/env && uvicorn server.app:app --host 0.0.0.0 --port 8000"]

--- a/envs/fraud_triage_env/server/app.py
+++ b/envs/fraud_triage_env/server/app.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""FastAPI application for the Fraud Triage Environment."""
+
+from openenv.core.env_server import create_app
+
+# Support both in-repo and standalone imports
+try:
+    # In-repo imports (when running from OpenEnv repository)
+    from ..models import FraudTriageAction, FraudTriageObservation
+    from .fraud_triage_environment import FraudTriageEnvironment
+except ImportError as e:
+    if "relative import" not in str(e) and "no known parent package" not in str(e):
+        raise
+    # Standalone imports (when running via uvicorn server.app:app)
+    from models import FraudTriageAction, FraudTriageObservation
+    from server.fraud_triage_environment import FraudTriageEnvironment
+
+# Create the FastAPI app.
+# Pass the class (factory), not an instance, so each WebSocket session gets
+# its own independent environment/episode.
+app = create_app(
+    FraudTriageEnvironment,
+    FraudTriageAction,
+    FraudTriageObservation,
+    env_name="fraud_triage_env",
+)
+
+
+def main():
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/envs/fraud_triage_env/server/fraud_triage_environment.py
+++ b/envs/fraud_triage_env/server/fraud_triage_environment.py
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Fraud Triage Environment server-side logic.
+
+Implements the classic reset() / step() / state OpenEnv Environment
+interface for a sequential transaction-risk-decisioning task.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from openenv.core.env_server import Environment
+
+# Support both in-repo and standalone imports
+try:
+    # In-repo imports (when running from OpenEnv repository)
+    from ..models import FraudTriageAction, FraudTriageObservation, FraudTriageState
+    from .transaction_generator import TransactionGenerator
+except ImportError as e:
+    if "relative import" not in str(e) and "no known parent package" not in str(e):
+        raise
+    # Standalone imports (when running via uvicorn server.app:app)
+    from models import FraudTriageAction, FraudTriageObservation, FraudTriageState
+    from server.transaction_generator import TransactionGenerator
+
+
+# Reward structure. Asymmetric on purpose: missing real fraud (false
+# negative) is penalized far more heavily than annoying a genuine customer
+# (false positive), which mirrors how production risk teams actually weight
+# these outcomes -- but flagging/escalating everything is also penalized so
+# the agent can't "win" by being maximally conservative.
+REWARD_TRUE_POSITIVE = 1.0  # correctly flagged/escalated/blocked fraud
+REWARD_TRUE_NEGATIVE = 0.1  # correctly approved a legitimate transaction
+REWARD_FALSE_POSITIVE = -0.5  # incorrectly flagged/escalated/blocked a legit txn
+REWARD_FALSE_NEGATIVE = -3.0  # incorrectly approved a fraudulent txn
+
+# Escalation costs more than a flag even when correct, since it consumes
+# human analyst time -- so the agent learns to reserve it for genuinely
+# ambiguous cases rather than defaulting to it.
+ESCALATION_COST = -0.1
+
+
+class FraudTriageEnvironment(Environment):
+    """
+    Sequential transaction risk-decisioning environment.
+
+    Each episode streams `episode_length` synthetic transactions. For each
+    transaction the agent chooses one of four actions (approve / flag /
+    escalate / block); the environment scores the decision against the
+    transaction's hidden ground-truth fraud label and returns the next
+    transaction as the following observation.
+    """
+
+    def __init__(self, episode_length: int = 200, fraud_rate: float = 0.12):
+        super().__init__()
+        self.episode_length = episode_length
+        self.fraud_rate = fraud_rate
+        self.reset()
+
+    def reset(self):
+        seed = int.from_bytes(os.urandom(4), "little")
+        self._generator = TransactionGenerator(fraud_rate=self.fraud_rate, seed=seed)
+        self._current_txn = None
+
+        self._state = FraudTriageState(
+            episode_id=str(uuid.uuid4()),
+            step_count=0,
+            episode_length=self.episode_length,
+            true_positives=0,
+            false_positives=0,
+            false_negatives=0,
+            true_negatives=0,
+            cumulative_reward=0.0,
+        )
+        return self._make_observation(advance=True)
+
+    def step(self, action: FraudTriageAction):
+        if self._current_txn is None:
+            # Defensive: step() called before a transaction was ever issued.
+            return self._make_observation(advance=True)
+
+        txn = self._current_txn
+        decision = action.decision
+        is_flagging_action = decision in (1, 2, 3)  # FLAG, ESCALATE, BLOCK
+
+        if txn.is_fraud and is_flagging_action:
+            reward = REWARD_TRUE_POSITIVE
+            self._state.true_positives += 1
+        elif txn.is_fraud and not is_flagging_action:
+            reward = REWARD_FALSE_NEGATIVE
+            self._state.false_negatives += 1
+        elif not txn.is_fraud and is_flagging_action:
+            reward = REWARD_FALSE_POSITIVE
+            self._state.false_positives += 1
+        else:
+            reward = REWARD_TRUE_NEGATIVE
+            self._state.true_negatives += 1
+
+        if decision == 2:  # ESCALATE
+            reward += ESCALATION_COST
+
+        self._state.cumulative_reward += reward
+        self._state.step_count += 1
+
+        done = self._state.step_count >= self.episode_length
+        return self._make_observation(advance=not done, reward=reward, done=done)
+
+    def _make_observation(self, advance: bool, reward: float = 0.0, done: bool = False):
+        if advance and not done:
+            self._current_txn = self._generator.sample()
+
+        txn = self._current_txn
+        return FraudTriageObservation(
+            transaction_id=txn.transaction_id,
+            amount=txn.amount,
+            merchant_category=txn.merchant_category,
+            velocity_1h=txn.velocity_1h,
+            velocity_24h=txn.velocity_24h,
+            amount_zscore=txn.amount_zscore,
+            is_new_merchant=txn.is_new_merchant,
+            is_new_device=txn.is_new_device,
+            cross_border=txn.cross_border,
+            hour_of_day=txn.hour_of_day,
+            account_age_days=txn.account_age_days,
+            reward=reward,
+            done=done,
+            metadata={
+                "step_count": self._state.step_count,
+                "cumulative_reward": self._state.cumulative_reward,
+            },
+        )
+
+    @property
+    def state(self):
+        return self._state

--- a/envs/fraud_triage_env/server/transaction_generator.py
+++ b/envs/fraud_triage_env/server/transaction_generator.py
@@ -1,0 +1,92 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Synthetic transaction stream generator for the Fraud Triage Environment.
+
+Generates a stream of transactions with a configurable fraud rate. Legitimate
+and fraudulent transactions are drawn from different feature distributions so
+the task is learnable but not trivial -- fraud correlates with, but is not
+perfectly determined by, any single feature (mirroring real payment data,
+where no single rule catches everything).
+
+This is intentionally dependency-light (pure Python + random) so the
+environment has no heavyweight ML dependencies at the server layer -- an
+agent is expected to learn the decision policy, not have one handed to it.
+"""
+
+from __future__ import annotations
+
+import random
+import uuid
+from dataclasses import dataclass
+
+
+@dataclass
+class Transaction:
+    transaction_id: str
+    amount: float
+    merchant_category: int
+    velocity_1h: int
+    velocity_24h: int
+    amount_zscore: float
+    is_new_merchant: bool
+    is_new_device: bool
+    cross_border: bool
+    hour_of_day: int
+    account_age_days: int
+    is_fraud: bool  # ground truth, withheld from the agent
+
+
+class TransactionGenerator:
+    """Generates a stream of synthetic transactions for one episode."""
+
+    def __init__(self, fraud_rate: float = 0.12, seed: int | None = None):
+        self.fraud_rate = fraud_rate
+        self._rng = random.Random(seed)
+
+    def sample(self) -> Transaction:
+        is_fraud = self._rng.random() < self.fraud_rate
+
+        if is_fraud:
+            # Fraudulent transactions skew toward higher amounts, unusual
+            # merchants/devices, higher velocity, and off-hours activity --
+            # but with enough overlap with legitimate traffic that a naive
+            # single-threshold rule will not solve the task perfectly.
+            amount = max(1.0, self._rng.lognormvariate(5.2, 1.1))
+            amount_zscore = self._rng.uniform(1.5, 6.0)
+            velocity_1h = self._rng.randint(1, 8)
+            velocity_24h = velocity_1h + self._rng.randint(0, 15)
+            is_new_merchant = self._rng.random() < 0.7
+            is_new_device = self._rng.random() < 0.55
+            cross_border = self._rng.random() < 0.4
+            hour_of_day = self._rng.choice(
+                list(range(0, 6)) + list(range(0, 24))
+            )  # biased toward late night/early morning
+        else:
+            amount = max(1.0, self._rng.lognormvariate(3.6, 0.9))
+            amount_zscore = self._rng.uniform(-1.0, 1.8)
+            velocity_1h = self._rng.randint(0, 2)
+            velocity_24h = velocity_1h + self._rng.randint(0, 5)
+            is_new_merchant = self._rng.random() < 0.15
+            is_new_device = self._rng.random() < 0.05
+            cross_border = self._rng.random() < 0.08
+            hour_of_day = self._rng.randint(0, 23)
+
+        return Transaction(
+            transaction_id=str(uuid.uuid4()),
+            amount=round(amount, 2),
+            merchant_category=self._rng.randint(0, 9),
+            velocity_1h=velocity_1h,
+            velocity_24h=velocity_24h,
+            amount_zscore=round(amount_zscore, 3),
+            is_new_merchant=is_new_merchant,
+            is_new_device=is_new_device,
+            cross_border=cross_border,
+            hour_of_day=hour_of_day,
+            account_age_days=self._rng.randint(1, 2500),
+            is_fraud=is_fraud,
+        )

--- a/tests/envs/test_fraud_triage_env.py
+++ b/tests/envs/test_fraud_triage_env.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test Fraud Triage environment client and server integration."""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+import unittest
+
+import pytest
+import requests
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from envs.fraud_triage_env import (
+    FraudTriageAction,
+    FraudTriageEnv,
+    FraudTriageObservation,
+    TriageDecision,
+)
+
+
+class TestFraudTriageEnv(unittest.TestCase):
+    server_process = None
+    client = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server_process = subprocess.Popen(
+            ["python", "-m", "envs.fraud_triage_env.server.app"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        time.sleep(3)
+
+        for _ in range(10):
+            try:
+                response = requests.get("http://127.0.0.1:8000/health", timeout=1)
+                if response.status_code == 200:
+                    break
+            except requests.ConnectionError:
+                time.sleep(1)
+        else:
+            raise RuntimeError("Fraud Triage server did not start")
+
+        cls.client = FraudTriageEnv(base_url="http://127.0.0.1:8000")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.server_process:
+            cls.server_process.terminate()
+            try:
+                cls.server_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.kill(cls.server_process.pid, signal.SIGKILL)
+            for stream in [
+                cls.server_process.stdin,
+                cls.server_process.stdout,
+                cls.server_process.stderr,
+            ]:
+                if stream and not stream.closed:
+                    stream.close()
+
+    def test_reset_returns_valid_observation(self):
+        result = self.client.reset()
+        observation = result.observation
+
+        assert isinstance(observation, FraudTriageObservation)
+        assert observation.transaction_id != ""
+        assert observation.amount > 0
+        assert 0 <= observation.merchant_category <= 9
+        assert 0 <= observation.hour_of_day <= 23
+        assert observation.legal_actions == [0, 1, 2, 3]
+        assert not observation.done
+        assert observation.reward == 0.0
+
+    def test_approve_and_block_actions_return_reward(self):
+        self.client.reset()
+
+        result = self.client.step(FraudTriageAction(decision=TriageDecision.APPROVE))
+        assert isinstance(result.reward, float)
+        assert isinstance(result.done, bool)
+
+        result = self.client.step(FraudTriageAction(decision=TriageDecision.BLOCK))
+        assert isinstance(result.reward, float)
+
+    def test_episode_terminates_after_episode_length_steps(self):
+        self.client.reset()
+        done = False
+        steps = 0
+        max_steps = 500  # safety cap well above default episode_length=200
+
+        while not done and steps < max_steps:
+            result = self.client.step(FraudTriageAction(decision=TriageDecision.FLAG))
+            done = result.done
+            steps += 1
+
+        assert done, "Episode should terminate within episode_length steps"
+        assert steps <= max_steps
+
+    def test_state_tracks_confusion_matrix_counts(self):
+        self.client.reset()
+        for _ in range(20):
+            result = self.client.step(FraudTriageAction(decision=TriageDecision.APPROVE))
+            if result.done:
+                break
+
+        state = self.client.state()
+        total_outcomes = (
+            state.true_positives
+            + state.false_positives
+            + state.false_negatives
+            + state.true_negatives
+        )
+        assert total_outcomes > 0
+        assert state.step_count > 0
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a Fraud Triage environment: a sequential transaction risk-decisioning
RL task where an agent must approve/flag/escalate/block synthetic
transactions. Fills a gap in the existing finance environments (finrl_env
covers stock trading, finqa_env covers document QA) — neither covers
transaction-level risk decisioning.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] New environment
- [ ] Refactoring

## Alignment Checklist
Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan
Ran the existing test suite locally:

All 4 tests pass:
- test_reset_returns_valid_observation
- test_approve_and_block_actions_return_reward
- test_episode_terminates_after_episode_length_steps
- test_state_tracks_confusion_matrix_counts

Also manually verified end-to-end with a heuristic policy (amount z-score
+ new-device/new-merchant thresholds) achieving 100% fraud recall over a
200-transaction episode, confirming the reward signal and episode
termination behave as intended.

Environment follows existing Gym-style conventions (see connect4_env) —
Pydantic wire types, WebSocket-based client, no MCP tool exposure, rewards
computed entirely server-side inside step().

## Claude Code Review
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained new environment under `envs/` with no changes to core auth or shared runtime; risk is limited to new code paths and CI integration-test flakiness from spawning a server on port 8000.
> 
> **Overview**
> Introduces **`fraud_triage_env`**, a new OpenEnv environment for **sequential payment fraud triage**: each step presents one synthetic transaction with risk-style features, and the agent chooses **APPROVE**, **FLAG**, **ESCALATE**, or **BLOCK**.
> 
> The server implements **`reset` / `step` / `state`** via `FraudTriageEnvironment`, scoring decisions against hidden labels with an **asymmetric reward** (heavy penalty on missed fraud, lighter on false positives, extra cost on **ESCALATE**) and tracking TP/FP/FN/TN plus cumulative reward. Transactions come from a lightweight **`TransactionGenerator`** with overlapping fraud vs. legit distributions and configurable **`episode_length`** / **`fraud_rate`**.
> 
> Wiring matches other envs: Pydantic models, **`FraudTriageEnv`** WebSocket client on `EnvClient`, FastAPI app from **`create_app`**, **`openenv.yaml`**, Docker image, README, and integration tests that boot the server and exercise reset, step rewards, episode termination, and state metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f17e2a86161c0ac9886e4491053cbf01f07c0030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->