### PR TITLE
chore(deps): aggregate core dependabot updates

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@7e6bd45ee271b96e75484eeafea1b3e6139cd0c7  # main
     with:
       commit_sha: ${{ github.sha }}
       package: openenv

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@e60a538eea9817ab312196d0d233604b01697265  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@7e6bd45ee271b96e75484eeafea1b3e6139cd0c7  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@bcff59fca682130d2e7271ca8589911b7ac0b8bf  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@7e6bd45ee271b96e75484eeafea1b3e6139cd0c7  # main
     with:
       package_name: openenv
     secrets:


### PR DESCRIPTION
## Summary

Aggregates the open non-env Dependabot workflow updates into one maintainer-owned PR.

Included single PRs:
- #927: bump `huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml`
- #928: bump `huggingface/doc-builder/.github/workflows/build_pr_documentation.yml`
- #929: bump `huggingface/doc-builder/.github/workflows/build_main_documentation.yml`

Changed paths:
- `.github/workflows/upload_pr_documentation.yml`
- `.github/workflows/build_pr_documentation.yml`
- `.github/workflows/build_documentation.yml`

## Validation

- `git diff --check hf/main...HEAD`

No `src/` files or Python dependency files are changed, so the core unit/integration test path was not run locally for this workflow-only rollup.