### PR TITLE
[codex] refactor collect legal action parsing

### DIFF
--- a/src/openenv/cli/commands/collect.py
+++ b/src/openenv/cli/commands/collect.py
@@ -86,33 +86,34 @@ def _resolve_api_key(provider: str) -> str:
     )
 
 
+def _extract_legal_actions(messages: list[dict[str, Any]]) -> list[int]:
+    for message in reversed(messages):
+        content = message.get("content") or ""
+        if not isinstance(content, str):
+            continue
+        try:
+            payload = json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            payload = None
+        if isinstance(payload, dict) and "legal_actions" in payload:
+            legal = payload["legal_actions"]
+            if isinstance(legal, list):
+                return [int(a) for a in legal]
+        match = re.search(r"Legal actions:\s*\[([^\]]*)\]", content)
+        if match:
+            raw = match.group(1).strip()
+            if not raw:
+                return []
+            return [int(x) for x in raw.split(",")]
+    return []
+
+
 def _build_scripted_model_step():
     """Default teacher: pick the first legal action from the latest observation.
 
     Matches the scripted teacher in ``examples/ttt_collect_demo.py``. Lets
     users smoke-test the CLI without any API key configured.
     """
-
-    def _extract_legal_actions(messages: list[dict[str, Any]]) -> list[int]:
-        for message in reversed(messages):
-            content = message.get("content") or ""
-            if not isinstance(content, str):
-                continue
-            try:
-                payload = json.loads(content)
-            except (json.JSONDecodeError, ValueError):
-                payload = None
-            if isinstance(payload, dict) and "legal_actions" in payload:
-                legal = payload["legal_actions"]
-                if isinstance(legal, list):
-                    return [int(a) for a in legal]
-            match = re.search(r"Legal actions:\s*\[([^\]]*)\]", content)
-            if match:
-                raw = match.group(1).strip()
-                if not raw:
-                    return []
-                return [int(x) for x in raw.split(",")]
-        return []
 
     def model_step(messages, tools, sampling):
         del sampling

--- a/tests/test_cli/test_collect.py
+++ b/tests/test_cli/test_collect.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from openenv.cli.__main__ import app
+from openenv.cli.commands.collect import _extract_legal_actions
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -219,6 +220,27 @@ def test_openai_provider_errors_without_model(tmp_path: Path, mock_pipeline):
 
     assert result.exit_code != 0
     assert "model" in result.output.lower()
+
+
+def test_extract_legal_actions_from_json_observation():
+    actions = _extract_legal_actions(
+        [
+            {"content": "ignored"},
+            {"content": '{"legal_actions": [2, 4, 6]}'},
+        ]
+    )
+
+    assert actions == [2, 4, 6]
+
+
+def test_extract_legal_actions_from_text_observation():
+    actions = _extract_legal_actions(
+        [
+            {"content": "Legal actions: [1, 3, 5]"},
+        ]
+    )
+
+    assert actions == [1, 3, 5]
 
 
 def test_keep_losses_disables_filter(tmp_path: Path, mock_pipeline):


### PR DESCRIPTION
Refactors the `openenv collect` scripted teacher legal-action parsing into a small helper and adds focused coverage for the existing JSON/text observation formats.

Validation:
- `uv run usort check src/openenv/cli/commands/collect.py tests/test_cli/test_collect.py`
- `uv run ruff format src/openenv/cli/commands/collect.py tests/test_cli/test_collect.py --check`
- `uv run ruff check src/openenv/cli/commands/collect.py tests/test_cli/test_collect.py`
- `PYTHONPATH=src:envs uv run python -m pytest tests/test_cli/test_collect.py tests/test_cli -q`
- `PYTHONPATH=src:envs uv run pytest tests/ --ignore=tests/envs/test_browsergym_environment.py --ignore=tests/envs/test_dipg_environment.py --ignore=tests/envs/test_websearch_environment.py --ignore=tests/envs/test_python_codeact_reset.py --ignore=tests/envs/test_python_codeact_rewards.py --ignore=tests/envs/test_textarena_environment.py -m "not integration and not network and not docker" -q`