### PR TITLE
[codex] refactor runtime server parsers

### DIFF
--- a/src/openenv/core/containers/runtime/_server_config.py
+++ b/src/openenv/core/containers/runtime/_server_config.py
@@ -47,6 +47,7 @@ def parse_dockerfile_cmd(dockerfile_content: str) -> str | None:
             if isinstance(parts, list) and all(isinstance(p, str) for p in parts):
                 return " ".join(parts)
         except (json.JSONDecodeError, TypeError):
+            # Invalid exec-form JSON falls back to the raw CMD below.
             pass
 
     return last_cmd if last_cmd else None

--- a/src/openenv/core/containers/runtime/_server_config.py
+++ b/src/openenv/core/containers/runtime/_server_config.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared helpers for reading environment server configuration."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import yaml
+
+
+def parse_openenv_app_field(yaml_content: str) -> str | None:
+    """Extract the top-level ``app`` value from raw ``openenv.yaml`` content."""
+    try:
+        data = yaml.safe_load(yaml_content) or {}
+    except Exception:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    value = data.get("app")
+    if isinstance(value, str):
+        value = value.strip()
+        return value if value else None
+    return None
+
+
+def parse_dockerfile_cmd(dockerfile_content: str) -> str | None:
+    """Extract the server command from the last Dockerfile ``CMD``."""
+    last_cmd: str | None = None
+    for line in dockerfile_content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        match = re.match(r"CMD\s+(.+)", stripped, flags=re.IGNORECASE)
+        if match:
+            last_cmd = match.group(1).strip()
+
+    if last_cmd is None:
+        return None
+
+    if last_cmd.startswith("["):
+        try:
+            parts = json.loads(last_cmd)
+            if isinstance(parts, list) and all(isinstance(p, str) for p in parts):
+                return " ".join(parts)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return last_cmd if last_cmd else None

--- a/src/openenv/core/containers/runtime/daytona_provider.py
+++ b/src/openenv/core/containers/runtime/daytona_provider.py
@@ -8,14 +8,12 @@ Requires the ``daytona`` SDK: ``pip install daytona>=0.10``
 
 from __future__ import annotations
 
-import json
 import os
 import shlex
 import time
 from typing import Any, Callable, Dict, Optional
 
-import yaml
-
+from ._server_config import parse_dockerfile_cmd, parse_openenv_app_field
 from .providers import ContainerProvider
 
 
@@ -149,19 +147,7 @@ class DaytonaProvider(ContainerProvider):
 
         Uses PyYAML to handle comments, quotes, and nested keys correctly.
         """
-        try:
-            data = yaml.safe_load(yaml_content) or {}
-        except Exception:
-            return None
-
-        if not isinstance(data, dict):
-            return None
-
-        value = data.get("app")
-        if isinstance(value, str):
-            value = value.strip()
-            return value if value else None
-        return None
+        return parse_openenv_app_field(yaml_content)
 
     @staticmethod
     def _parse_dockerfile_cmd(dockerfile_content: str) -> Optional[str]:
@@ -176,32 +162,7 @@ class DaytonaProvider(ContainerProvider):
         Returns:
             The command as a single string, or ``None`` if no ``CMD`` found.
         """
-        import re
-
-        last_cmd: Optional[str] = None
-        for line in dockerfile_content.splitlines():
-            stripped = line.strip()
-            # Skip comments
-            if stripped.startswith("#"):
-                continue
-            match = re.match(r"CMD\s+(.+)", stripped, flags=re.IGNORECASE)
-            if match:
-                last_cmd = match.group(1).strip()
-
-        if last_cmd is None:
-            return None
-
-        # Exec form: CMD ["executable", "param1", ...]
-        if last_cmd.startswith("["):
-            try:
-                parts = json.loads(last_cmd)
-                if isinstance(parts, list) and all(isinstance(p, str) for p in parts):
-                    return " ".join(parts)
-            except (json.JSONDecodeError, TypeError):
-                pass
-
-        # Shell form: CMD executable param1 ...
-        return last_cmd if last_cmd else None
+        return parse_dockerfile_cmd(dockerfile_content)
 
     @staticmethod
     def strip_buildkit_syntax(dockerfile_content: str) -> str:

--- a/src/openenv/core/containers/runtime/modal_provider.py
+++ b/src/openenv/core/containers/runtime/modal_provider.py
@@ -17,14 +17,12 @@ see https://modal.com/docs/guide/sandbox-v2 .
 
 from __future__ import annotations
 
-import json
 import logging
 import shlex
 import time
 from typing import Any, Dict, Optional
 
-import yaml
-
+from ._server_config import parse_dockerfile_cmd, parse_openenv_app_field
 from .providers import ContainerProvider
 
 logger = logging.getLogger(__name__)
@@ -318,19 +316,7 @@ class ModalProvider(ContainerProvider):
 
         Uses PyYAML to handle comments, quotes, and nested keys correctly.
         """
-        try:
-            data = yaml.safe_load(yaml_content) or {}
-        except Exception:
-            return None
-
-        if not isinstance(data, dict):
-            return None
-
-        value = data.get("app")
-        if isinstance(value, str):
-            value = value.strip()
-            return value if value else None
-        return None
+        return parse_openenv_app_field(yaml_content)
 
     @staticmethod
     def _parse_dockerfile_cmd(dockerfile_content: str) -> str | None:
@@ -345,31 +331,7 @@ class ModalProvider(ContainerProvider):
         Returns:
             The command as a single string, or ``None`` if no ``CMD`` found.
         """
-        import re
-
-        last_cmd: str | None = None
-        for line in dockerfile_content.splitlines():
-            stripped = line.strip()
-            if stripped.startswith("#"):
-                continue
-            match = re.match(r"CMD\s+(.+)", stripped, flags=re.IGNORECASE)
-            if match:
-                last_cmd = match.group(1).strip()
-
-        if last_cmd is None:
-            return None
-
-        # Exec form: CMD ["executable", "param1", ...]
-        if last_cmd.startswith("["):
-            try:
-                parts = json.loads(last_cmd)
-                if isinstance(parts, list) and all(isinstance(p, str) for p in parts):
-                    return " ".join(parts)
-            except (json.JSONDecodeError, TypeError):
-                pass
-
-        # Shell form: CMD executable param1 ...
-        return last_cmd if last_cmd else None
+        return parse_dockerfile_cmd(dockerfile_content)
 
     @classmethod
     def image_from_dockerfile(


### PR DESCRIPTION
Summary:
- share OpenEnv YAML app parsing and Dockerfile CMD parsing between Modal and Daytona providers

Test plan:
- PYTHONPATH=src:envs uv run python -m pytest tests/test_core/test_modal_provider.py tests/test_core/test_daytona_provider.py -q
- PYTHONPATH=src:envs uv run python -m pytest tests/test_core -q
- uv run usort check src/openenv/core/containers/runtime/_server_config.py src/openenv/core/containers/runtime/modal_provider.py src/openenv/core/containers/runtime/daytona_provider.py
- uv run ruff format src/openenv/core/containers/runtime/_server_config.py src/openenv/core/containers/runtime/modal_provider.py src/openenv/core/containers/runtime/daytona_provider.py --check
- uv run ruff check src/openenv/core/containers/runtime/_server_config.py src/openenv/core/containers/runtime/modal_provider.py src/openenv/core/containers/runtime/daytona_provider.py
- git diff --check
