### PR TITLE
Validation: isolate submitted code in author Sandboxes

### DIFF
--- a/src/openenv/validation/local.py
+++ b/src/openenv/validation/local.py
@@ -96,6 +96,24 @@ def _runtime_environment(
     return process_env
 
 
+def _subject_process_kwargs() -> dict[str, Any]:
+    """Return POSIX identity controls supplied by a trusted isolated runner."""
+    raw_uid = os.environ.get("OPENENV_VALIDATION_SUBJECT_UID")
+    raw_gid = os.environ.get("OPENENV_VALIDATION_SUBJECT_GID")
+    if raw_uid is None and raw_gid is None:
+        return {}
+    if os.name != "posix" or raw_uid is None or raw_gid is None:
+        raise RuntimeError("The isolated subject identity is incomplete or unsupported")
+    try:
+        uid = int(raw_uid)
+        gid = int(raw_gid)
+    except ValueError as exc:
+        raise RuntimeError("The isolated subject identity is malformed") from exc
+    if uid <= 0 or gid <= 0:
+        raise RuntimeError("The isolated subject identity must be unprivileged")
+    return {"user": uid, "group": gid, "extra_groups": ()}
+
+
 def _ensure_port_available(port: int) -> None:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
         probe.settimeout(0.25)
@@ -283,6 +301,13 @@ def _launch_environment(env_path: Path, timeout_s: float) -> Iterator[str]:
     base_url = f"http://127.0.0.1:{port}"
     _ensure_port_available(port)
     with TemporaryDirectory(prefix="openenv-validation-") as temporary_home:
+        subject_process_kwargs = _subject_process_kwargs()
+        if subject_process_kwargs:
+            os.chown(
+                temporary_home,
+                subject_process_kwargs["user"],
+                subject_process_kwargs["group"],
+            )
         process_env = _runtime_environment(
             env_path, temporary_home=Path(temporary_home)
         )
@@ -293,6 +318,7 @@ def _launch_environment(env_path: Path, timeout_s: float) -> Iterator[str]:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,
+            **subject_process_kwargs,
         )
         try:
             deadline = time.monotonic() + timeout_s

--- a/src/openenv/validation/remote.py
+++ b/src/openenv/validation/remote.py
@@ -44,7 +44,7 @@ DEFAULT_SANDBOX_IMAGE = "python:3.12"
 DEFAULT_SANDBOX_FLAVOR = "cpu-basic"
 _REMOTE_REVISION_ARCHIVE = "/tmp/openenv-revision.tar.gz"
 _REMOTE_VALIDATOR_ARCHIVE = "/tmp/openenv-validator.tar.gz"
-_REMOTE_REPORT = "/workspace/validation-report.json"
+_REMOTE_REPORT = "/workspace/trusted/validation-report.json"
 _REVISION_PATTERN = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 _EXCLUDED_PARTS = frozenset(
     {
@@ -195,13 +195,29 @@ profile="$4"
 runtime_timeout="$5"
 environment_root=/workspace/environment
 validator_root=/workspace/validator
-mkdir -p "$environment_root" "$validator_root" || exit 70
+trusted_root=/workspace/trusted
+subject_root=/workspace/subject
+subject_site="$subject_root/site-packages"
+subject_home="$subject_root/home"
+subject_uid=10001
+subject_gid=10001
+mkdir -p "$environment_root" "$validator_root" "$trusted_root" || exit 70
+chmod 700 "$trusted_root" || exit 70
 tar -xzf "$revision_archive" -C "$environment_root" || exit 70
 tar -xzf "$validator_archive" -C "$validator_root" || exit 70
 python -m pip install --disable-pip-version-check --no-input "$validator_root" || exit 70
-python -m pip install --disable-pip-version-check --no-input "$environment_root" || exit 71
+chown -R 0:0 "$environment_root" "$validator_root" "$trusted_root" || exit 70
+chmod -R a+rX,go-w "$environment_root" "$validator_root" || exit 70
+mkdir -p "$subject_site" "$subject_home" || exit 70
+chown -R "$subject_uid:$subject_gid" "$subject_root" || exit 70
+setpriv --reuid="$subject_uid" --regid="$subject_gid" --clear-groups \
+  env HOME="$subject_home" python -m pip install --disable-pip-version-check \
+  --no-input --target "$subject_site" "$environment_root" || exit 71
 set +e
-PYTHONPATH="$validator_root/src" python -m openenv.cli.__main__ validate \
+OPENENV_VALIDATION_SUBJECT_UID="$subject_uid" \
+OPENENV_VALIDATION_SUBJECT_GID="$subject_gid" \
+PYTHONPATH="$validator_root/src:$subject_site" \
+python -m openenv.cli.__main__ validate \
   "$environment_root" --profile "$profile" --json --output "$report_path" \
   --timeout "$runtime_timeout"
 validation_status=$?
@@ -575,5 +591,7 @@ def run_remote_validation(
             ) from exc
         finally:
             if sandbox is not None:
+                with suppress(Exception):
+                    sandbox.kill()
                 with suppress(Exception):
                     sandbox.close()

--- a/tests/test_validation/test_local.py
+++ b/tests/test_validation/test_local.py
@@ -13,6 +13,7 @@ import pytest
 from openenv.validation.local import (
     _runtime_environment,
     _server_command,
+    _subject_process_kwargs,
     run_local_validation,
 )
 from openenv.validation.models import (
@@ -255,3 +256,19 @@ def test_server_command_honors_manifest_port(tmp_path: Path) -> None:
 def test_static_profile_rejects_url_in_public_api() -> None:
     with pytest.raises(ValueError, match="local source"):
         run_local_validation("https://example.com", profile=ValidationProfile.STATIC)
+
+
+def test_remote_subject_process_drops_to_declared_unprivileged_identity() -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "OPENENV_VALIDATION_SUBJECT_UID": "10001",
+            "OPENENV_VALIDATION_SUBJECT_GID": "10002",
+        },
+        clear=False,
+    ):
+        assert _subject_process_kwargs() == {
+            "user": 10001,
+            "group": 10002,
+            "extra_groups": (),
+        }

--- a/tests/test_validation/test_remote.py
+++ b/tests/test_validation/test_remote.py
@@ -187,6 +187,8 @@ def test_remote_validation_uses_dedicated_sandbox_and_returns_report(
     command_text = " ".join(command) if isinstance(command, list) else command
     assert "publish" in command_text
     assert "validation" in command_text
+    assert "setpriv" in command_text
+    assert "/workspace/trusted/validation-report.json" in command_text
     for remote_path in uploads:
         assert remote_path in command_text
     sandbox.files.download.assert_called_once()
@@ -201,6 +203,7 @@ def test_remote_validation_uses_dedicated_sandbox_and_returns_report(
     assert report.certified is False
     assert report.certification_eligible is False
     assert report.results[0].criterion_id == "source.validation_spec"
+    sandbox.kill.assert_called_once_with()
     sandbox.close.assert_called_once_with()
 
 
@@ -233,6 +236,7 @@ def test_remote_validation_command_failure_is_clean_and_closes_sandbox(
     assert "failed" in message
     assert "hf_1234567890abcdef" not in message
     sandbox.files.download.assert_not_called()
+    sandbox.kill.assert_called_once_with()
     sandbox.close.assert_called_once_with()
 
 
@@ -264,4 +268,5 @@ def test_remote_validation_malformed_report_is_clean_and_closes_sandbox(
     assert "report" in message
     assert "invalid" in message or "malformed" in message
     assert "not-json" not in message
+    sandbox.kill.assert_called_once_with()
     sandbox.close.assert_called_once_with()


### PR DESCRIPTION
## What & Why

The first remote runner allowed submitted build/runtime processes too much proximity to the trusted report path. This hardening layer separates subject execution by UID, keeps trusted inputs read-only, and makes teardown explicit.

## Risk & Review Guidance

- **Risk level**: HIGH — fixes an isolation boundary around untrusted code
- **Task class**: security
- **Review focus**: `src/openenv/validation/remote.py:242` for UID/report-path setup; `src/openenv/validation/local.py` for subject UID/GID propagation; remote/local isolation tests
- **Blast radius**: Without this boundary, submitted code could forge or mutate the author report or survive beyond validation.

## Decisions & Alternatives

- **Root-owned report writer, unprivileged subject UID** — rejected same-UID convenience.
- **Read-only source and validator trees** — subject code gets only the access required to install/run.
- **Kill then close in `finally`** — teardown is mandatory on success and failure.

## Verification

- PASS: `PYTHONPATH=src:envs .venv/bin/python -m pytest tests/ -q -m 'not integration'` — 1,559 passed, 114 skipped, 31 external integration tests deselected on the complete stack.
- PASS: Fork whole-stack CI — 7/7 checks passed, including Python 3.11/3.12, lint, docs, lock validation, and package smoke tests.
- NOT verified: Kernel-level containment is delegated to the dedicated HF Sandbox platform and was not live-tested here.

## Scope & Non-Goals

- Task-provided verifier isolation remains advisory in the author runner until a separate verifier Sandbox exists.

## Stack

PR 13 of 17; depends on #953.

<details>
<summary>Full 17-PR stack</summary>

1. [#942 RFC 008: Spec-neutral local and remote validation architecture](https://github.com/huggingface/OpenEnv/pull/942)
2. [#943 Validation foundation: spec-neutral contracts and adapters](https://github.com/huggingface/OpenEnv/pull/943)
3. [#944 Validation policy: spec-aware check registry and planner](https://github.com/huggingface/OpenEnv/pull/944)
4. [#945 Validation executor: hardened shared reports and eligibility](https://github.com/huggingface/OpenEnv/pull/945)
5. [#946 Local validation API: execution-model-aware profiles](https://github.com/huggingface/OpenEnv/pull/946)
6. [#947 CLI: validation profiles and shared reports](https://github.com/huggingface/OpenEnv/pull/947)
7. [#948 HF runtime: dedicated sandbox execution mode](https://github.com/huggingface/OpenEnv/pull/948)
8. [#949 HF certification: enforce trusted dedicated isolation](https://github.com/huggingface/OpenEnv/pull/949)
9. [#950 [RFC 008] Define remote author validation and publish gating](https://github.com/huggingface/OpenEnv/pull/950)
10. [#951 Validation: unify CLI reports and add a strict publish profile](https://github.com/huggingface/OpenEnv/pull/951)
11. [#952 Validation: add structured author diagnostics and remediation](https://github.com/huggingface/OpenEnv/pull/952)
12. [#953 Validation: run author validation in dedicated HF Sandboxes](https://github.com/huggingface/OpenEnv/pull/953)
13. [#954 Validation: isolate submitted code in author Sandboxes](https://github.com/huggingface/OpenEnv/pull/954) ← current
14. [#955 Validation: bind author reports to policy and source](https://github.com/huggingface/OpenEnv/pull/955)
15. [#956 CLI: scaffold publish requirements](https://github.com/huggingface/OpenEnv/pull/956)
16. [#957 CLI: gate pushes on staged remote validation](https://github.com/huggingface/OpenEnv/pull/957)
17. [#958 Docs: explain local, remote, and publish validation](https://github.com/huggingface/OpenEnv/pull/958)

</details>

All upstream PRs remain draft while RFC 008 is under review.