### PR TITLE
CLI: scaffold publish requirements

### DIFF
--- a/.claude/skills/generate-openenv-env/SKILL.md
+++ b/.claude/skills/generate-openenv-env/SKILL.md
@@ -120,6 +120,8 @@ Use these standards:
 - For MCP/tool-call UIs that send stringified JSON arguments, add action validators/parsers in `server/app.py`.
 - Export public client/models symbols in `__init__.py`.
 - Keep `openenv.yaml` aligned with current scaffold format (`spec_version: 1`, `name`, `type`, `runtime`, `app`, `port`).
+- Add a Harbor schema 1.1 `task.toml` and configure truthful resource,
+  networking, timeout, verifier, and artifact requirements for the environment.
 - Avoid training/evaluation code paths in this skill.
 
 ### 8. Validate before handoff
@@ -134,6 +136,7 @@ PYTHONPATH=src:envs uv run python -c "from envs.<name>_env.server.<name>_environ
 cd envs/<name>_env
 openenv build
 openenv validate --verbose
+openenv validate --profile publish --remote
 PYTHONPATH=src:envs uv run pytest envs/<name>_env -q
 ```
 

--- a/.claude/skills/generate-openenv-env/assets/openenv_env_template/task.toml
+++ b/.claude/skills/generate-openenv-env/assets/openenv_env_template/task.toml
@@ -1,0 +1,13 @@
+schema_version = "1.1"
+
+[task]
+name = "openenv/__ENV_NAME__"
+description = "__ENV_TITLE_NAME__ OpenEnv environment"
+
+[environment]
+cpus = 1
+memory_mb = 2048
+storage_mb = 10240
+gpus = 0
+# Set this to false when the environment does not need outbound internet.
+allow_internet = true

--- a/.claude/skills/generate-openenv-env/references/env-generation-checklist.md
+++ b/.claude/skills/generate-openenv-env/references/env-generation-checklist.md
@@ -79,11 +79,14 @@ Ask only what changes architecture or contracts.
 Mark complete only when all are true:
 
 - `envs/<name>_env/openenv.yaml` exists, uses `spec_version: 1`, and points to `server.app:app`.
+- `envs/<name>_env/task.toml` uses Harbor schema 1.1 and truthfully declares
+  publish-time resource and network requirements.
 - `models.py` defines typed action/observation/state.
 - `server/<name>_environment.py` implements `reset`, `step`, and `state`.
 - `server/app.py` calls `create_app` with action/observation classes.
 - `client.py` matches the selected archetype and correctly serializes/parses data.
 - `__init__.py` exports the public API.
 - `README.md` includes quickstart and configuration.
-- `openenv build` and `openenv validate --verbose` pass, or failures are documented.
+- `openenv build` and `openenv validate --profile publish --remote` pass, or
+  failures are documented.
 - Runtime smoke check is executed (`/health`; optionally `openenv validate --url`).

--- a/envs/echo_env/task.toml
+++ b/envs/echo_env/task.toml
@@ -1,0 +1,12 @@
+schema_version = "1.1"
+
+[task]
+name = "openenv/echo-env"
+description = "Canonical OpenEnv echo environment used for validation and examples."
+
+[environment]
+cpus = 1
+memory_mb = 2048
+storage_mb = 10240
+gpus = 0
+allow_internet = false

--- a/src/openenv/cli/templates/openenv_env/task.toml
+++ b/src/openenv/cli/templates/openenv_env/task.toml
@@ -1,0 +1,13 @@
+schema_version = "1.1"
+
+[task]
+name = "openenv/__ENV_NAME__"
+description = "__ENV_TITLE_NAME__ OpenEnv environment"
+
+[environment]
+cpus = 1
+memory_mb = 2048
+storage_mb = 10240
+gpus = 0
+# Set this to false when the environment does not need outbound internet.
+allow_internet = true

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -39,6 +39,7 @@ def test_init_creates_directory_structure(tmp_path: Path) -> None:
     assert (env_dir / "client.py").exists()
     assert (env_dir / "README.md").exists()
     assert (env_dir / "openenv.yaml").exists()
+    assert (env_dir / "task.toml").exists()
     assert (env_dir / "server").exists()
     assert (env_dir / "server" / "__init__.py").exists()
     assert (env_dir / "server" / "app.py").exists()
@@ -114,6 +115,22 @@ def test_init_generates_openenv_yaml(tmp_path: Path) -> None:
     assert "app: server.app:app" in yaml_content
     assert "port: 8000" in yaml_content
     assert "__ENV_NAME__" not in yaml_content
+
+
+def test_init_generates_publish_requirements(tmp_path: Path) -> None:
+    env_name = "test_env"
+    result = runner.invoke(
+        app,
+        ["init", env_name, "--output-dir", str(tmp_path)],
+        input="\n",
+    )
+
+    assert result.exit_code == 0
+    task_content = (tmp_path / env_name / "task.toml").read_text()
+    assert 'schema_version = "1.1"' in task_content
+    assert 'name = "openenv/test_env"' in task_content
+    assert "[environment]" in task_content
+    assert "__ENV_NAME__" not in task_content
 
 
 def test_init_readme_has_hf_frontmatter(tmp_path: Path) -> None:


### PR DESCRIPTION
## What & Why

Strict publish validation needs declared resource and network requirements, but legacy scaffolds omitted them. This PR adds a Harbor schema 1.1 `task.toml` to new environments and gives `echo_env` a truthful canonical envelope.

## Risk & Review Guidance

- **Risk level**: MEDIUM — changes generated project configuration and introduces a migration requirement
- **Task class**: migration
- **Review focus**: `src/openenv/cli/templates/openenv_env/task.toml:1` for generated defaults; `envs/echo_env/task.toml:1` for canonical values; generator checklist updates for truthful configuration
- **Blast radius**: Bad defaults can request the wrong hardware/network posture or encourage authors to copy inaccurate requirements.

## Decisions & Alternatives

- **Schema 1.1 is auxiliary input** — keeps the core planner spec-neutral.
- **Scaffold conservative explicit fields** — authors must review CPU, memory, storage, GPU, and internet values.
- **Do not bulk-invent configs for legacy environments** — unknown requirements remain visible blockers.

## Verification

- PASS: `PYTHONPATH=src:envs .venv/bin/python -m pytest tests/ -q -m 'not integration'` — 1,559 passed, 114 skipped, 31 external integration tests deselected on the complete stack.
- PASS: Fork whole-stack CI — 7/7 checks passed, including Python 3.11/3.12, lint, docs, lock validation, and package smoke tests.
- NOT verified: Resource values for legacy environments were intentionally not inferred.

## Scope & Non-Goals

- This PR does not migrate every existing environment; owners need to declare truthful values.

## Breaking Changes / Migration Notes

New `openenv init` output includes `task.toml`. Older environments must add a truthful requirements envelope before the strict publish gate can pass.

## Stack

PR 15 of 17; depends on #955.

<details>
<summary>Full 17-PR stack</summary>

1. [#942 RFC 008: Spec-neutral local and remote validation architecture](https://github.com/huggingface/OpenEnv/pull/942)
2. [#943 Validation foundation: spec-neutral contracts and adapters](https://github.com/huggingface/OpenEnv/pull/943)
3. [#944 Validation policy: spec-aware check registry and planner](https://github.com/huggingface/OpenEnv/pull/944)
4. [#945 Validation executor: hardened shared reports and eligibility](https://github.com/huggingface/OpenEnv/pull/945)
5. [#946 Local validation API: execution-model-aware profiles](https://github.com/huggingface/OpenEnv/pull/946)
6. [#947 CLI: validation profiles and shared reports](https://github.com/huggingface/OpenEnv/pull/947)
7. [#948 HF runtime: dedicated sandbox execution mode](https://github.com/huggingface/OpenEnv/pull/948)
8. [#949 HF certification: enforce trusted dedicated isolation](https://github.com/huggingface/OpenEnv/pull/949)
9. [#950 [RFC 008] Define remote author validation and publish gating](https://github.com/huggingface/OpenEnv/pull/950)
10. [#951 Validation: unify CLI reports and add a strict publish profile](https://github.com/huggingface/OpenEnv/pull/951)
11. [#952 Validation: add structured author diagnostics and remediation](https://github.com/huggingface/OpenEnv/pull/952)
12. [#953 Validation: run author validation in dedicated HF Sandboxes](https://github.com/huggingface/OpenEnv/pull/953)
13. [#954 Validation: isolate submitted code in author Sandboxes](https://github.com/huggingface/OpenEnv/pull/954)
14. [#955 Validation: bind author reports to policy and source](https://github.com/huggingface/OpenEnv/pull/955)
15. [#956 CLI: scaffold publish requirements](https://github.com/huggingface/OpenEnv/pull/956) ← current
16. [#957 CLI: gate pushes on staged remote validation](https://github.com/huggingface/OpenEnv/pull/957)
17. [#958 Docs: explain local, remote, and publish validation](https://github.com/huggingface/OpenEnv/pull/958)

</details>

All upstream PRs remain draft while RFC 008 is under review.