### PR TITLE
chore(deps): aggregate core dependabot updates

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@7e6bd45ee271b96e75484eeafea1b3e6139cd0c7  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@6108e850ae1cf2f71bb0815a600bcd50c39abfa7  # main
     with:
       commit_sha: ${{ github.sha }}
       package: openenv

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@7e6bd45ee271b96e75484eeafea1b3e6139cd0c7  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@6108e850ae1cf2f71bb0815a600bcd50c39abfa7  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@7e6bd45ee271b96e75484eeafea1b3e6139cd0c7  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@6108e850ae1cf2f71bb0815a600bcd50c39abfa7  # main
     with:
       package_name: openenv
     secrets:


### PR DESCRIPTION
Aggregates the current non-env Dependabot updates into one maintainer-facing PR.

Included source PRs:
- #960 doc-builder upload_pr_documentation workflow pin
- #961 doc-builder build_main_documentation workflow pin
- #962 doc-builder build_pr_documentation workflow pin

No `src/` files or runtime dependency files are changed; this is limited to GitHub documentation workflow pins.

Validation:
- `git diff --check hf/main...HEAD`
