### PR TITLE
fix(tbench2_env): canonical test.sh scoring, real timeouts, task-image workdir

### DIFF
--- a/envs/tbench2_env/server/tbench2_env_environment.py
+++ b/envs/tbench2_env/server/tbench2_env_environment.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+import shlex
+import threading
 import sys
 import urllib.request
 import zipfile
@@ -82,6 +85,38 @@ def _read_instruction(task_dir: Path) -> str:
     return ""
 
 
+def _task_image_workdir(task_dir: Path) -> str:
+    """WORKDIR pinned by the task's own image (environment/Dockerfile).
+
+    Empty string when the task ships no Dockerfile or no WORKDIR; multi-stage
+    Dockerfiles resolve to the last WORKDIR (the final stage's).
+    """
+    dockerfile = task_dir / "environment" / "Dockerfile"
+    workdir = ""
+    if dockerfile.is_file():
+        for line in dockerfile.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"^\s*WORKDIR\s+(\S+)", line, re.IGNORECASE)
+            if m:
+                workdir = m.group(1)
+    return workdir
+
+
+def _workdir_is_server_tree(workdir: str) -> bool:
+    """True when *workdir* contains this server's own code.
+
+    A Dockerfile-parsed WORKDIR is only meaningful when the server runs
+    inside the task image (per-task sandboxes, where the server layer lives
+    elsewhere, e.g. /opt/envserver). The standard env-server image also
+    installs to /app — the most common task WORKDIR — so the path merely
+    existing is not enough: if the server's own code sits under it, it is
+    the server tree, not the task tree.
+    """
+    try:
+        return Path(__file__).resolve().is_relative_to(Path(workdir).resolve())
+    except OSError:
+        return True  # unresolvable path: fail toward the task-dir fallback
+
+
 def _read_timeout(task_dir: Path, fallback: float) -> float:
     task_toml = task_dir / "task.toml"
     if not task_toml.exists():
@@ -103,7 +138,7 @@ class Tbench2Environment(Environment[Tbench2Action, Tbench2Observation, Tbench2S
         self,
         tasks_dir: str | None = None,
         output_dir: str | None = None,
-        command_timeout_s: float = 20.0,
+        command_timeout_s: float | None = None,
         safe_mode: bool = False,
         default_task_id: str | None = None,
     ) -> None:
@@ -112,6 +147,11 @@ class Tbench2Environment(Environment[Tbench2Action, Tbench2Observation, Tbench2S
         self.output_dir = Path(
             output_dir or os.getenv("TB2_OUTPUT_DIR", "/tmp/tbench2_env_runs")
         )
+        # Overridable via TB2_COMMAND_TIMEOUT_S: create_app instantiates the
+        # environment with no arguments, and real TB2 agent commands / the
+        # canonical tests/test.sh routinely exceed the old 20s default.
+        if command_timeout_s is None:
+            command_timeout_s = float(os.getenv("TB2_COMMAND_TIMEOUT_S", "20.0"))
         self.command_timeout_s = command_timeout_s
         self.safe_mode = safe_mode
         self.default_task_id = default_task_id or os.getenv(
@@ -122,6 +162,7 @@ class Tbench2Environment(Environment[Tbench2Action, Tbench2Observation, Tbench2S
         self._task_dir: Path | None = None
         self._terminal_toolkit = None
         self._instruction = ""
+        self._workdir = ""
 
     def reset(
         self,
@@ -150,13 +191,30 @@ class Tbench2Environment(Environment[Tbench2Action, Tbench2Observation, Tbench2S
         )
         session_logs_dir.mkdir(parents=True, exist_ok=True)
 
+        # Commands run in the task image's real WORKDIR — where agents and
+        # the canonical harness expect to operate, and not always /app
+        # (fix-git: /app/personal-site, prove-plus-comm: /workspace).
+        # TB2_TASK_WORKDIR overrides; otherwise the task's own Dockerfile is
+        # parsed, trusted only when the path isn't the server's own install
+        # tree (see _workdir_is_server_tree); plain local mode falls back to
+        # the task source dir.
+        workdir = os.getenv("TB2_TASK_WORKDIR", "").strip()
+        if not workdir:
+            workdir = _task_image_workdir(task_dir)
+            if workdir and _workdir_is_server_tree(workdir):
+                workdir = ""
+        if not (workdir and Path(workdir).is_dir()):
+            workdir = str(task_dir)
+        self._workdir = workdir
+        # No install_dependencies: evaluation runs the task's canonical
+        # tests/test.sh, which pins its own pytest toolchain via uvx (see
+        # _evaluate_canonical), so the toolkit venv does not need pytest.
         self._terminal_toolkit = TerminalToolkit(
             timeout=self.command_timeout_s,
-            working_directory=str(task_dir),
+            working_directory=workdir,
             use_docker_backend=False,
             session_logs_dir=session_logs_dir,
             safe_mode=self.safe_mode,
-            install_dependencies=["pytest"],
         )
 
         self._state = Tbench2State(
@@ -209,10 +267,14 @@ class Tbench2Environment(Environment[Tbench2Action, Tbench2Observation, Tbench2S
 
         try:
             if action.action_type == "exec":
+                # Pass the timeout explicitly: camel's shell_exec has its own
+                # per-call default (20s) and ignores the constructor timeout,
+                # which silently truncates any longer-running agent command.
                 output = self._terminal_toolkit.shell_exec(
                     command=action.command,
                     block=action.block,
                     id=session_id,
+                    timeout=self.command_timeout_s,
                 )
             elif action.action_type == "write":
                 self._ensure_session_id(action.session_id, action.action_type)
@@ -312,13 +374,32 @@ class Tbench2Environment(Environment[Tbench2Action, Tbench2Observation, Tbench2S
         if self._terminal_toolkit is None:
             raise RuntimeError("Terminal toolkit not initialized.")
 
-        _read_timeout(self._task_dir, fallback=900.0)  # Validate timeout config
+        # The task's own verifier budget (task.toml [verifier].timeout_sec) —
+        # heavy tests legitimately run minutes (circuit-fibsqrt declares 3600s).
+        verifier_timeout_s = _read_timeout(self._task_dir, fallback=900.0)
         tests_dir = self._task_dir / "tests"
-        cmd = f"cd {self._task_dir} && python -m pytest -q {tests_dir} -rA; echo __TB2_EXIT_CODE__:$?"
+        if (tests_dir / "test.sh").is_file():
+            return self._evaluate_canonical(tests_dir, verifier_timeout_s)
+
+        # Fallback for tasks without the canonical harness (none of the 89
+        # official TB2 tasks — they all ship test.sh — but custom task dirs
+        # may only have bare pytest tests). Prefer uvx so pytest comes with
+        # its own toolchain like the canonical harness does; fall back to a
+        # preinstalled pytest for environments without uv.
+        # Verify from the same directory the agent worked in.
+        fallback_cwd = self._workdir or str(self._task_dir)
+        cmd = (
+            f"cd {shlex.quote(fallback_cwd)} && "
+            "if command -v uvx >/dev/null 2>&1; "
+            f"then uvx --with pytest==8.4.1 pytest -q {shlex.quote(str(tests_dir))} -rA; "
+            f"else python -m pytest -q {shlex.quote(str(tests_dir))} -rA; fi; "
+            "echo __TB2_EXIT_CODE__:$?"
+        )
         output = self._terminal_toolkit.shell_exec(
             id="tb2-tests",
             command=cmd,
             block=True,
+            timeout=verifier_timeout_s,
         )
 
         exit_code = 1
@@ -333,6 +414,62 @@ class Tbench2Environment(Environment[Tbench2Action, Tbench2Observation, Tbench2S
 
         reward = 1.0 if exit_code == 0 else 0.0
         info = {"tests_passed": exit_code == 0, "exit_code": exit_code}
+        return output, reward, info
+
+    # The canonical harness uses the official fixed paths (/tests,
+    # /logs/verifier/reward.txt), which are per-container, not per-session.
+    # Serialize evaluations so concurrent sessions on one server cannot
+    # overwrite each other's staged tests or read another session's reward.
+    _CANONICAL_EVAL_LOCK = threading.Lock()
+
+    def _evaluate_canonical(
+        self, tests_dir: Path, timeout_s: float
+    ) -> tuple[str, float, dict[str, Any]]:
+        """Score via the task's OFFICIAL harness, exactly as the TB2 verifier does.
+
+        tests/test.sh pins its own pytest toolchain (uvx: Python 3.13 +
+        pytest 8.4.1 + ctrf), runs tests/test_outputs.py from /tests against
+        the task workdir, and writes the binary result to
+        /logs/verifier/reward.txt. Bare ``pytest tests/`` (the fallback above)
+        skips that toolchain pinning and mis-scores any task whose tests need
+        it, so the canonical harness is preferred whenever the task ships it.
+        """
+        # Same working dir the agent operated in (resolved during reset).
+        workdir = self._workdir or str(self._task_dir)
+        marker = "__TB2_REWARD__:"
+        cmd = (
+            # /tests is recreated from scratch — a prior task's files on the
+            # same server must not leak into pytest collection — and the
+            # reward file removed so a stale one can never be read back if
+            # test.sh fails to run.
+            "rm -rf /tests && mkdir -p /tests /logs/verifier && "
+            "rm -f /logs/verifier/reward.txt && "
+            f"cp -a {shlex.quote(str(tests_dir))}/. /tests/ && "
+            f"cd {shlex.quote(workdir)} && bash /tests/test.sh > /tmp/tb2_testsh.log 2>&1; "
+            # Surface the harness log tail so callers keep the pytest
+            # diagnostics; the reward marker line stays last for parsing.
+            "tail -c 20000 /tmp/tb2_testsh.log 2>/dev/null; "
+            f"echo {marker}$(cat /logs/verifier/reward.txt 2>/dev/null)"
+        )
+        with self._CANONICAL_EVAL_LOCK:
+            output = self._terminal_toolkit.shell_exec(
+                id="tb2-tests",
+                command=cmd,
+                block=True,
+                timeout=timeout_s,
+            )
+
+        reward = 0.0
+        for line in output.splitlines()[::-1]:
+            if marker in line:
+                raw = line.split(marker, 1)[1].strip()
+                try:
+                    reward = float(raw) if raw else 0.0
+                except ValueError:
+                    reward = 0.0
+                break
+
+        info = {"tests_passed": reward == 1.0, "harness": "tests/test.sh"}
         return output, reward, info
 
 

--- a/tests/envs/test_tbench2_env.py
+++ b/tests/envs/test_tbench2_env.py
@@ -50,6 +50,53 @@ def test_tbench2_reset_uses_default_task_id(monkeypatch, tmp_path: Path):
     assert "terminal task" in observation.instruction
 
 
+def _make_env(monkeypatch, tmp_path: Path, task_id: str) -> Tbench2Environment:
+    monkeypatch.setattr(
+        tbench2_env_environment,
+        "_require_terminal_toolkit",
+        lambda: _FakeTerminalToolkit,
+    )
+    return Tbench2Environment(
+        tasks_dir=str(tmp_path),
+        output_dir=str(tmp_path / "runs"),
+        default_task_id=task_id,
+    )
+
+
+def test_tbench2_workdir_from_task_dockerfile(monkeypatch, tmp_path: Path):
+    """A parsed WORKDIR that exists and isn't the server tree becomes the cwd."""
+    task_dir = tmp_path / "demo-task"
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "instruction.md").write_text("do it\n")
+    image_workdir = tmp_path / "image-workdir"
+    image_workdir.mkdir()
+    (task_dir / "environment" / "Dockerfile").write_text(
+        f"FROM python:3.13\nWORKDIR {image_workdir}\n"
+    )
+
+    env = _make_env(monkeypatch, tmp_path, "demo-task")
+    env.reset()
+
+    assert env._workdir == str(image_workdir)
+
+
+def test_tbench2_workdir_rejects_server_tree(monkeypatch, tmp_path: Path):
+    """A parsed WORKDIR that is the server's own install tree (e.g. /app on
+    the standard server image) falls back to the task source dir."""
+    server_tree = Path(tbench2_env_environment.__file__).resolve().parent
+    task_dir = tmp_path / "demo-task"
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "instruction.md").write_text("do it\n")
+    (task_dir / "environment" / "Dockerfile").write_text(
+        f"FROM python:3.13\nWORKDIR {server_tree}\n"
+    )
+
+    env = _make_env(monkeypatch, tmp_path, "demo-task")
+    env.reset()
+
+    assert env._workdir == str(task_dir)
+
+
 @pytest.mark.skipif(camel is None, reason="camel-ai not installed")
 @pytest.mark.skipif(
     os.environ.get("TB2_ENABLE_TESTS", "0") != "1",


### PR DESCRIPTION
## Summary
Makes local-mode `Tbench2Environment` faithful to real Terminal-Bench-2 semantics: `evaluate` scores with each task's **official `tests/test.sh`** (pinned uvx toolchain, `/logs/verifier/reward.txt`), command execution honors **real time budgets**, and commands run in the **task image's own WORKDIR**. Follow-up to #503, which fixed evaluate always returning 0 — this makes the returned reward match the official TB2 verifier.

Details:
- **Canonical scoring**: bare `pytest tests/` (current behavior) skips the toolchain the official harness pins (uvx: Python 3.13, pytest 8.4.1, ctrf) and mis-scores tasks that depend on it. `_evaluate_task` now runs `tests/test.sh` when the task ships it; the bare-pytest fallback remains for custom task dirs, upgraded to prefer `uvx --with pytest==8.4.1` so it carries its own toolchain too.
- **Real timeouts**: camel's `shell_exec` has a per-call default of 20s and ignores the constructor timeout, silently truncating agent commands and evaluations (e.g. `circuit-fibsqrt` declares a 3600s verifier budget and was cut mid-test, scoring a false 0). Agent execs now pass `command_timeout_s` (overridable via `TB2_COMMAND_TIMEOUT_S`); evaluate passes the task's own `[verifier].timeout_sec`.
- **Task workdir**: task images pin their own WORKDIR and both agents and oracle solutions assume commands run there — it is not always `/app` (`fix-git`: `/app/personal-site`, `prove-plus-comm`: `/workspace`). The shell cwd now resolves from the task's `environment/Dockerfile` (`TB2_TASK_WORKDIR` overrides), falling back to the task source dir for plain local mode.
- **Drop `install_dependencies=['pytest']`**: evaluation now carries its own pytest via uvx; when the server runs with `CAMEL_RUNTIME=true`, camel's `.initial_env` venv then also stops shadowing the task image's native python on PATH.

## Type of Change
- [x] Bug fix

## Alignment Checklist
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles (notably: rewards are computed inside the environment, per RFC 002)
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated (Gym API signatures unchanged; server-internal changes only)
- [x] I have run `bash .claude/hooks/lint.sh` — the touched file is clean (pre-existing failures in other envs are untouched)

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)

## Test Plan
Validated on real per-task TB2 containers (official task images), scoring official solutions under the official oracle convention:
- **Full 89-task golden sweep**: 82/89 score 1.0 with 0 infra errors; the 7 remaining failures trace to upstream solution drift in terminal-bench-2 itself (apt version pins gone from Debian, missing `setuptools` for pystan, etc. — happy to share the per-task evidence).
- Each fix maps to tasks that flip from a false 0.0 to 1.0: `circuit-fibsqrt`/`compile-compcert` (timeouts), `fix-git`/`prove-plus-comm` (workdir), plus correct scoring across the suite via test.sh.
- 11-task concurrent regression on the final revision: 11/11 pass.

Note: the canonical eval uses the official global paths (`/tests`, `/logs/verifier/reward.txt`), which assumes one concurrent session per container — consistent with TB2's one-task-per-container model (and with one-env-one-trajectory); flagging for reviewers running multi-session servers against a single container.

## Claude Code Review
/alignment-review run on this change: Tier 1 (format) fixed; flags addressed during review — fallback now carries its own pytest toolchain; workdir resolution centralized server-side so all deployment modes agree. No principle or RFC conflicts identified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward computation and shell cwd/timeouts for all local TB2 sessions; canonical eval uses shared `/tests` paths and requires the lock when multiple sessions share one container.
> 
> **Overview**
> Aligns **local-mode** `Tbench2Environment` with official Terminal-Bench 2 verifier behavior so rewards and execution context match what agents and the harness expect.
> 
> **Evaluation** now prefers each task’s **`tests/test.sh`** when present: tests are staged under `/tests`, the harness runs from the resolved task workdir, and reward is read from `/logs/verifier/reward.txt` instead of inferring pass/fail from bare `pytest`. A **thread lock** serializes canonical evals so concurrent sessions on one server do not clash on `/tests` or the reward file. Tasks without `test.sh` keep a pytest fallback, now preferring **`uvx --with pytest==8.4.1`** and using the agent workdir; verifier runs use **`[verifier].timeout_sec`** from `task.toml`.
> 
> **Shell execution** passes **`timeout=self.command_timeout_s`** into `shell_exec` (camel’s per-call 20s default was truncating long commands). **`command_timeout_s`** defaults via **`TB2_COMMAND_TIMEOUT_S`** when the env is constructed with no args.
> 
> **Working directory** is resolved on `reset` from **`TB2_TASK_WORKDIR`**, else the task **`environment/Dockerfile`** `WORKDIR` (ignored when it overlaps the server install tree), else the task source dir—replacing always using the task folder as cwd. **`install_dependencies=['pytest']`** is removed from `TerminalToolkit` because scoring brings its own toolchain.
> 
> Tests add coverage for Dockerfile workdir selection and server-tree rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b0b8e902da5c2a5eef3bd15ea983bc88af3275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->