### PR TITLE
Refactor init template path resolution

### DIFF
--- a/src/openenv/cli/commands/init.py
+++ b/src/openenv/cli/commands/init.py
@@ -298,16 +298,8 @@ def _copy_and_template_file(
         ) from e
 
 
-def _copy_template_directory(
-    template_pkg: str,
-    template_dir: str,
-    dest_dir: Path,
-    replacements: Dict[str, str],
-    env_name: str,
-) -> List[Path]:
-    """Recursively copy template directory and apply replacements."""
-    created_files: List[Path] = []
-
+def _resolve_template_path(template_pkg: str, template_dir: str) -> Path:
+    """Resolve the template package directory used by `openenv init`."""
     # Get the package path using importlib.resources but avoid importing the template package
     # We'll use the package's __file__ to get the directory path
     import importlib
@@ -340,6 +332,20 @@ def _copy_template_directory(
         raise FileNotFoundError(
             f"Template directory not found: {template_pkg}.{template_dir}"
         )
+
+    return template_path
+
+
+def _copy_template_directory(
+    template_pkg: str,
+    template_dir: str,
+    dest_dir: Path,
+    replacements: Dict[str, str],
+    env_name: str,
+) -> List[Path]:
+    """Recursively copy template directory and apply replacements."""
+    created_files: List[Path] = []
+    template_path = _resolve_template_path(template_pkg, template_dir)
 
     # Walk through all files in template directory using Path
     for item in template_path.rglob("*"):

--- a/tests/test_cli/test_init.py
+++ b/tests/test_cli/test_init.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from openenv.cli.__main__ import app
+from openenv.cli.commands.init import _resolve_template_path
 from typer.testing import CliRunner
 
 
@@ -227,6 +228,24 @@ def test_init_with_output_dir(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert env_dir.exists()
     assert (env_dir / "models.py").exists()
+
+
+def test_resolve_template_path_root() -> None:
+    """Test resolving the packaged init template root."""
+    template_path = _resolve_template_path("openenv.cli.templates.openenv_env", "")
+
+    assert template_path.is_dir()
+    assert (template_path / "models.py").exists()
+
+
+def test_resolve_template_path_nested_directory() -> None:
+    """Test resolving a nested init template directory."""
+    template_path = _resolve_template_path(
+        "openenv.cli.templates.openenv_env", "server"
+    )
+
+    assert template_path.is_dir()
+    assert (template_path / "Dockerfile").exists()
 
 
 def test_init_filename_templating(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extract `openenv init` template path resolution into `_resolve_template_path`
- add focused coverage for root and nested template directories

## Tests
- `PYTHONPATH=src:envs uv run python -m pytest tests/test_cli -q`
- `uv run ruff check src/openenv/cli/commands/init.py tests/test_cli/test_init.py`
- `uv run ruff format --check src/openenv/cli/commands/init.py tests/test_cli/test_init.py`
- `uv run usort check src/openenv/cli/commands/init.py tests/test_cli/test_init.py`