### PR TITLE
chore(deps): aggregate core dependabot updates

### DIFF
--- a/.github/workflows/deploy-hf-env.yml
+++ b/.github/workflows/deploy-hf-env.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/manage-hf-collection.yml
+++ b/.github/workflows/manage-hf-collection.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -62,7 +62,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Aggregates non-env Dependabot updates for maintainers.\n\nIncluded source PRs:\n- #995 chore(deps): bump actions/setup-python from 6 to 7\n\nTouched files:\n- .github/workflows/deploy-hf-env.yml\n- .github/workflows/manage-hf-collection.yml\n- .github/workflows/package-ci.yml\n- .github/workflows/publish-pypi.yml\n- .github/workflows/publish-testpypi.yml\n- .github/workflows/test.yml\n\nValidation:\n- git diff --check hf/main...HEAD\n\nNo local unit/integration suite was run because this aggregate only changes GitHub Actions workflow pins and does not touch src/ or runtime dependency files.