### PR TITLE
Fix OpenCodeEnv client timeout and retry transient sandbox-API polls

### DIFF
--- a/envs/opencode_env/client.py
+++ b/envs/opencode_env/client.py
@@ -47,10 +47,27 @@ class OpenCodeEnv(MCPToolClient):
     / context-manager semantics from :class:`MCPToolClient`.
     """
 
-    def __init__(self, base_url: str, *, message_timeout_s: float = 1800.0, **kwargs):
+    def __init__(
+        self,
+        base_url: str,
+        connect_timeout_s: float = 10.0,
+        message_timeout_s: float = 1800.0,
+        websocket_ping_interval_s: float | None = 20.0,
+        websocket_ping_timeout_s: float | None = 20.0,
+        provider: Any | None = None,
+        mode: str | None = None,
+    ):
         # One rollout runs for minutes (the server caps a run at 900s); the base
         # 60s default would time out client-side mid-rollout.
-        super().__init__(base_url, message_timeout_s=message_timeout_s, **kwargs)
+        super().__init__(
+            base_url=base_url,
+            connect_timeout_s=connect_timeout_s,
+            message_timeout_s=message_timeout_s,
+            websocket_ping_interval_s=websocket_ping_interval_s,
+            websocket_ping_timeout_s=websocket_ping_timeout_s,
+            provider=provider,
+            mode=mode,
+        )
 
     def run_rollout(
         self,

--- a/envs/opencode_env/client.py
+++ b/envs/opencode_env/client.py
@@ -47,6 +47,11 @@ class OpenCodeEnv(MCPToolClient):
     / context-manager semantics from :class:`MCPToolClient`.
     """
 
+    def __init__(self, base_url: str, *, message_timeout_s: float = 1800.0, **kwargs):
+        # One rollout runs for minutes (the server caps a run at 900s); the base
+        # 60s default would time out client-side mid-rollout.
+        super().__init__(base_url, message_timeout_s=message_timeout_s, **kwargs)
+
     def run_rollout(
         self,
         *,

--- a/envs/opencode_env/sandbox/hf.py
+++ b/envs/opencode_env/sandbox/hf.py
@@ -11,12 +11,16 @@ from __future__ import annotations
 import time
 from pathlib import PurePosixPath
 
+import httpx
 from huggingface_hub import Sandbox
 
 from .base import BgJob, ExecResult, SandboxHandle
 
 
 _WAIT_POLL_INTERVAL_S = 0.5
+# The sandbox API occasionally drops a single poll; give up only after this many
+# consecutive transient failures.
+_MAX_TRANSIENT_POLL_ERRORS = 10
 
 
 class HFBgJob:
@@ -32,8 +36,20 @@ class HFBgJob:
 
     def wait(self, timeout: float | None = None) -> int:
         deadline = None if timeout is None else time.monotonic() + timeout
+        transient_errors = 0
         while True:
-            proc = next((p for p in self._sandbox.processes() if p.pid == self.pid), None)
+            try:
+                procs = self._sandbox.processes()
+            except httpx.TransportError:
+                # Transient sandbox-API disconnect (RemoteProtocolError, read
+                # timeout, ...): retry on the next poll tick.
+                transient_errors += 1
+                if transient_errors > _MAX_TRANSIENT_POLL_ERRORS:
+                    raise
+                time.sleep(_WAIT_POLL_INTERVAL_S)
+                continue
+            transient_errors = 0
+            proc = next((p for p in procs if p.pid == self.pid), None)
             # Finished processes stay listed (running=False); a vanished pid means
             # the sandbox was torn down mid-run, not a clean exit.
             if proc is None:

--- a/envs/opencode_env/sandbox/hf.py
+++ b/envs/opencode_env/sandbox/hf.py
@@ -40,22 +40,22 @@ class HFBgJob:
         while True:
             try:
                 procs = self._sandbox.processes()
+                transient_errors = 0
             except httpx.TransportError:
                 # Transient sandbox-API disconnect (RemoteProtocolError, read
-                # timeout, ...): retry on the next poll tick.
+                # timeout, ...): retry on the next poll tick, still honoring the deadline.
                 transient_errors += 1
                 if transient_errors > _MAX_TRANSIENT_POLL_ERRORS:
                     raise
-                time.sleep(_WAIT_POLL_INTERVAL_S)
-                continue
-            transient_errors = 0
-            proc = next((p for p in procs if p.pid == self.pid), None)
-            # Finished processes stay listed (running=False); a vanished pid means
-            # the sandbox was torn down mid-run, not a clean exit.
-            if proc is None:
-                raise RuntimeError(f"process {self.pid} vanished (sandbox torn down?)")
-            if not proc.running:
-                return int(proc.exit_code) if proc.exit_code is not None else 0
+                procs = None
+            if procs is not None:
+                proc = next((p for p in procs if p.pid == self.pid), None)
+                # Finished processes stay listed (running=False); a vanished pid means
+                # the sandbox was torn down mid-run, not a clean exit.
+                if proc is None:
+                    raise RuntimeError(f"process {self.pid} vanished (sandbox torn down?)")
+                if not proc.running:
+                    return int(proc.exit_code) if proc.exit_code is not None else 0
             if deadline is not None:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:

--- a/tests/envs/test_opencode_env.py
+++ b/tests/envs/test_opencode_env.py
@@ -58,6 +58,23 @@ def test_public_api_imports() -> None:
     )
 
 
+def test_new_session_client_preserves_supported_constructor_options() -> None:
+    """Session recreation filters unsupported base-client options."""
+    from opencode_env import OpenCodeEnv
+
+    env = OpenCodeEnv(
+        base_url="http://localhost:8000",
+        connect_timeout_s=12.0,
+        message_timeout_s=34.0,
+    )
+
+    session = env._create_session_client()
+
+    assert isinstance(session, OpenCodeEnv)
+    assert session._connect_timeout == 12.0
+    assert session._message_timeout == 34.0
+
+
 def test_server_modules_import() -> None:
     """Server-side modules (FastAPI app, MCP env, catalog) import cleanly."""
     from opencode_env.server.app import app  # noqa: F401

--- a/tests/envs/test_opencode_hf_sandbox.py
+++ b/tests/envs/test_opencode_hf_sandbox.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import sys
 
+import httpx
 import pytest
 
 # Make ``envs/`` importable when running from the repository root.
@@ -71,6 +72,38 @@ class _FlippingSandbox:
         return [self._proc]
 
 
+class _TransientThenExitsSandbox:
+    """Raises a transient sandbox-API error on the first ``fail_times`` polls, then reports exited."""
+
+    def __init__(self, proc: _FakeProcess, *, fail_times: int) -> None:
+        self._proc = proc
+        self._fail_times = fail_times
+        self.poll_count = 0
+
+    def processes(self) -> list:
+        self.poll_count += 1
+        if self.poll_count <= self._fail_times:
+            raise httpx.RemoteProtocolError(
+                "Server disconnected without sending a response."
+            )
+        self._proc.running = False
+        self._proc.exit_code = 0
+        return [self._proc]
+
+
+class _AlwaysTransientSandbox:
+    """Every poll raises a transient sandbox-API error."""
+
+    def __init__(self) -> None:
+        self.poll_count = 0
+
+    def processes(self) -> list:
+        self.poll_count += 1
+        raise httpx.RemoteProtocolError(
+            "Server disconnected without sending a response."
+        )
+
+
 @pytest.fixture(autouse=True)
 def _instant_poll(monkeypatch):
     # Keep the polling loop instant so timeout tests stay sub-second.
@@ -124,6 +157,23 @@ def test_wait_none_timeout_polls_without_deadline(monkeypatch):
     proc = _FakeProcess(pid=7, running=True)
     sbx = _FlippingSandbox(proc, flip_after=2, exit_code=0)
     assert HFBgJob(sbx, proc).wait(timeout=None) == 0
+
+
+def test_wait_retries_transient_processes_error():
+    # A few transient sandbox-API disconnects must not fail the wait.
+    proc = _FakeProcess(pid=7, running=True)
+    sbx = _TransientThenExitsSandbox(proc, fail_times=3)
+    assert HFBgJob(sbx, proc).wait(timeout=1.0) == 0
+    assert sbx.poll_count == 4  # 3 transient failures + 1 successful poll
+
+
+def test_wait_reraises_after_persistent_transient_errors():
+    # A persistent outage eventually gives up instead of looping forever.
+    proc = _FakeProcess(pid=7, running=True)
+    sbx = _AlwaysTransientSandbox()
+    with pytest.raises(httpx.RemoteProtocolError):
+        HFBgJob(sbx, proc).wait(timeout=1.0)
+    assert sbx.poll_count == hf_mod._MAX_TRANSIENT_POLL_ERRORS + 1
 
 
 def test_kill_calls_through():

--- a/tests/envs/test_opencode_hf_sandbox.py
+++ b/tests/envs/test_opencode_hf_sandbox.py
@@ -176,6 +176,15 @@ def test_wait_reraises_after_persistent_transient_errors():
     assert sbx.poll_count == hf_mod._MAX_TRANSIENT_POLL_ERRORS + 1
 
 
+def test_wait_transient_retries_still_honor_deadline():
+    # A finite timeout must win even while retrying transient errors: raise
+    # TimeoutError (what wait_for_completion relies on), not TransportError.
+    proc = _FakeProcess(pid=7, running=True)
+    sbx = _AlwaysTransientSandbox()
+    with pytest.raises(TimeoutError):
+        HFBgJob(sbx, proc).wait(timeout=0.0)
+
+
 def test_kill_calls_through():
     proc = _FakeProcess(pid=7)
     HFBgJob(_FakeSandbox([proc]), proc).kill()


### PR DESCRIPTION
Follow-up to #998, which landed `HFSandboxBackend`. Two small robustness fixes surfaced while validating loop-owning training on remote HF sandboxes.

## 1. OpenCodeEnv client timeout

`OpenCodeEnv` inherited `MCPToolClient`'s 60s `message_timeout_s` default, but a rollout runs up to 900s server-side (`_RUN_ROLLOUT_TIMEOUT_S`). So `run_rollout()` timed out client-side mid-rollout. Adds an `__init__` defaulting `message_timeout_s` to 1800s, matching the fix already in `PiEnv` (#999).

## 2. Retry transient sandbox-API polls

`HFBgJob.wait()` polls `Sandbox.processes()`, which occasionally drops a single poll with `httpx.TransportError` (observed `RemoteProtocolError: Server disconnected without sending a response`, also read timeouts). Before this, one blip aborted the whole rollout. Now it retries on the next poll tick and gives up only after a run of consecutive failures, so a transient disconnect no longer kills a training step. `wait()` lives in `opencode_env/sandbox/hf.py`, shared by both opencode_env and pi_env, so this covers both.

## Tests

Two new unit tests in `test_opencode_hf_sandbox.py`: retry recovers from a few transient poll errors, and a persistent outage re-raises instead of looping forever. Full suite green.

Validated end-to-end: loop-owning AsyncGRPO training on HF Jobs (h200x2, opencode on remote HF sandboxes) completes cleanly with the transient poll errors now absorbed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational robustness only—timeout defaults and retry logic on sandbox polling—with unit tests and no changes to auth, rewards, or rollout semantics.
> 
> **Overview**
> **OpenCodeEnv** now defaults **`message_timeout_s` to 1800s** (via an explicit constructor that forwards timeouts to `MCPToolClient`), so long **`run_rollout`** calls are not cut off by the previous ~60s client default while the server allows runs up to ~900s.
> 
> **`HFBgJob.wait()`** in the HF sandbox backend **retries `Sandbox.processes()`** when polls fail with **`httpx.TransportError`**, up to **10 consecutive** failures, and still **raises `TimeoutError`** when a finite deadline expires. That shared wait path applies to remote HF sandbox rollouts for both opencode and pi envs.
> 
> Tests cover **session client** timeout forwarding and **transient vs persistent** poll failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755682613db226c268d83c565c71463830f126cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->