### PR TITLE
Make ResourceSessionFactory generic over its session type

### DIFF
--- a/envs/opencode_env/harness.py
+++ b/envs/opencode_env/harness.py
@@ -189,7 +189,7 @@ class OpenCodeSession(ResourceSession):
         return records
 
 
-class OpenCodeSessionFactory(ResourceSessionFactory):
+class OpenCodeSessionFactory(ResourceSessionFactory[OpenCodeSession]):
     """Produce isolated per-rollout :class:`OpenCodeSession` instances.
 
     The factory owns sandbox provisioning, opencode install, config injection,

--- a/src/openenv/core/harness/__init__.py
+++ b/src/openenv/core/harness/__init__.py
@@ -12,7 +12,7 @@ import json
 import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Callable, Protocol
+from typing import Any, Callable, Generic, Protocol, TypeVar
 
 from ..client_types import StepResult
 from ..env_server.mcp_types import JsonRpcErrorCode, JsonRpcResponse, Tool
@@ -141,8 +141,17 @@ class ResourceSession(ABC):
         """Release session resources."""
 
 
-class ResourceSessionFactory(ABC):
-    """Factory for producing isolated per-rollout sessions."""
+SessionT = TypeVar("SessionT", bound=ResourceSession)
+
+
+class ResourceSessionFactory(ABC, Generic[SessionT]):
+    """Factory for producing isolated per-rollout sessions.
+
+    Generic over the concrete session type it creates, so a subclass such as
+    ``OpenCodeSessionFactory(ResourceSessionFactory[OpenCodeSession])`` types
+    ``create`` as returning ``OpenCodeSession``. Subclassing without a type
+    argument stays valid and behaves as before.
+    """
 
     @abstractmethod
     def create(
@@ -150,7 +159,7 @@ class ResourceSessionFactory(ABC):
         task: Any,
         seed: int | None = None,
         episode_id: str | None = None,
-    ) -> ResourceSession:
+    ) -> SessionT:
         """Create one isolated resource session for a rollout."""
 
 


### PR DESCRIPTION
Makes `ResourceSessionFactory` generic over the session type it produces.

## Why

`ResourceSessionFactory.create()` is typed as returning the base `ResourceSession`, so callers lose the concrete session type and have to cast. This is one of the `TODO(@openenv)` gaps flagged in TRL's loop-owning harness rollout work (huggingface/trl#6420), where the worker does `cast(LoopOwningSession, session)` because the factory type cannot express which session subtype it returns.

## Change

- `ResourceSessionFactory(ABC, Generic[SessionT])` with `SessionT` bound to `ResourceSession`, and `create()` returns `SessionT`.
- `OpenCodeSessionFactory` is now `ResourceSessionFactory[OpenCodeSession]`, so its `create()` types as returning `OpenCodeSession`.

## Compatibility

Backward compatible: subclassing without a type argument (`class MyFactory(ResourceSessionFactory)`) stays valid and behaves exactly as before. The other envs that subclass it (browsergym, openspiel, reasoning_gym) are unaffected and import cleanly. Pure typing change, no runtime behavior difference.

AI-assisted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only change with no runtime or behavioral impact; existing factory subclasses without type arguments stay compatible.
> 
> **Overview**
> **`ResourceSessionFactory` is now generic** so `create()` can be typed to return a concrete session subtype instead of always `ResourceSession`.
> 
> In `openenv.core.harness`, the factory adds `SessionT` (bound to `ResourceSession`) and `create()` is annotated as `-> SessionT`. **`OpenCodeSessionFactory`** is updated to `ResourceSessionFactory[OpenCodeSession]`, so callers get `OpenCodeSession` from `create()` without casts—relevant for TRL loop-owning harness work that previously needed `cast(LoopOwningSession, session)`.
> 
> **No runtime behavior change.** Subclasses that omit the type parameter (e.g. browsergym, openspiel, reasoning_gym) remain valid and unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37100cc04362d42e2b7a898bc50091d75e5b2224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->