### PR TITLE
Retry OpenCodeSessionFactory.create() with backoff

### DIFF
--- a/envs/opencode_env/harness.py
+++ b/envs/opencode_env/harness.py
@@ -206,6 +206,8 @@ class OpenCodeSessionFactory(ResourceSessionFactory[OpenCodeSession]):
         verifier: Verifier | None = None,
         install_timeout_s: int = 240,
         setup_timeout_s: int = 300,
+        create_attempts: int = 3,
+        create_backoff_s: float = 2.0,
     ) -> None:
         if mode not in {"black_box", "transparent_proxy"}:
             raise ValueError(f"Unknown mode: {mode!r}")
@@ -215,8 +217,41 @@ class OpenCodeSessionFactory(ResourceSessionFactory[OpenCodeSession]):
         self._verifier = verifier
         self._install_timeout_s = install_timeout_s
         self._setup_timeout_s = setup_timeout_s
+        self._create_attempts = create_attempts
+        self._create_backoff_s = create_backoff_s
 
     def create(
+        self,
+        task: Any,
+        seed: int | None = None,
+        episode_id: str | None = None,
+    ) -> OpenCodeSession:
+        """Create one session, retrying with exponential backoff.
+
+        Session creation spins up a sandbox, installs opencode, and starts the
+        proxy + agent, the flakiest step in a rollout. Each failed attempt tears
+        its own sandbox down (see :meth:`_create_once`), so a retry never leaks.
+        """
+        import logging
+        import time
+
+        _log = logging.getLogger(__name__)
+        last_exc: Exception = RuntimeError("create_attempts must be >= 1")
+        for i in range(self._create_attempts):
+            try:
+                return self._create_once(task, seed=seed, episode_id=episode_id)
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if i + 1 < self._create_attempts:
+                    backoff = self._create_backoff_s * (2**i)
+                    _log.warning(
+                        "factory.create attempt %d/%d failed (%r); retrying in %.1fs",
+                        i + 1, self._create_attempts, exc, backoff,
+                    )
+                    time.sleep(backoff)
+        raise last_exc
+
+    def _create_once(
         self,
         task: Any,
         seed: int | None = None,

--- a/tests/envs/test_opencode_factory_lifecycle.py
+++ b/tests/envs/test_opencode_factory_lifecycle.py
@@ -35,16 +35,17 @@ class _FakeBackend:
         return self._sandbox
 
 
-def _factory(sandbox):
+def _factory(sandbox, **overrides):
     return OpenCodeSessionFactory(
         config=OpenCodeConfig(base_url="http://localhost:8000/v1"),
         sandbox_backend=_FakeBackend(sandbox),
+        **overrides,
     )
 
 
 def test_create_kills_sandbox_when_bootstrap_fails(monkeypatch):
     sandbox = _FakeSandbox()
-    factory = _factory(sandbox)
+    factory = _factory(sandbox, create_attempts=1)
     monkeypatch.setattr(
         factory,
         "_bootstrap_sandbox",
@@ -61,7 +62,7 @@ def test_create_preserves_root_cause_if_kill_also_fails(monkeypatch):
             raise RuntimeError("kill failed")
 
     sandbox = _KillRaises()
-    factory = _factory(sandbox)
+    factory = _factory(sandbox, create_attempts=1)
     monkeypatch.setattr(
         factory,
         "_bootstrap_sandbox",
@@ -70,3 +71,37 @@ def test_create_preserves_root_cause_if_kill_also_fails(monkeypatch):
     # The original bootstrap failure must surface, not the cleanup error.
     with pytest.raises(RuntimeError, match="boom"):
         factory.create("write a function")
+
+
+def test_create_retries_then_succeeds(monkeypatch):
+    # create() retries a flaky _create_once and returns once it succeeds.
+    sandbox = _FakeSandbox()
+    factory = _factory(sandbox, create_attempts=3, create_backoff_s=0)
+    calls = {"n": 0}
+    session = object()
+
+    def _flaky(task, seed=None, episode_id=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError("transient create failure")
+        return session
+
+    monkeypatch.setattr(factory, "_create_once", _flaky)
+    assert factory.create("write a function") is session
+    assert calls["n"] == 3
+
+
+def test_create_raises_after_exhausting_attempts(monkeypatch):
+    # A persistent failure is re-raised after create_attempts tries.
+    sandbox = _FakeSandbox()
+    factory = _factory(sandbox, create_attempts=3, create_backoff_s=0)
+    calls = {"n": 0}
+
+    def _always_fails(task, seed=None, episode_id=None):
+        calls["n"] += 1
+        raise RuntimeError("persistent create failure")
+
+    monkeypatch.setattr(factory, "_create_once", _always_fails)
+    with pytest.raises(RuntimeError, match="persistent create failure"):
+        factory.create("write a function")
+    assert calls["n"] == 3


### PR DESCRIPTION
Adds retry-with-backoff to `OpenCodeSessionFactory.create()`.

## Why

Session creation spins up a sandbox, installs opencode, and starts the proxy + agent. It is the flakiest step in a rollout (sandbox-API blips, cold install, proxy start). Today a single transient failure drops the whole rollout as unscorable, which shrinks the effective group size and silently weakens the training signal. This is one of the `TODO(@openenv)` gaps flagged in TRL's loop-owning harness work (huggingface/trl#6420).

## Change

- `create()` now retries up to `create_attempts` (default 3) with exponential backoff (`create_backoff_s * 2**i`, default base 2s), matching the existing `_exec_with_retry` style.
- The per-attempt logic moved verbatim into `_create_once`, which already tears its own sandbox down on any post-provision failure, so a retry never leaks a sandbox.

## Tests

The two existing teardown tests now pin `create_attempts=1` (they test a single attempt's cleanup). Two new tests cover the wrapper: retries-then-succeeds, and raises-after-exhausting-attempts.

`pi_env`'s `PiSessionFactory.create()` mirrors this and gets the same change on its own PR (#999).

AI-assisted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated harness resilience change with defaults preserving prior single-attempt semantics only when callers override; rollout provisioning path only, no auth or data handling.
> 
> **Overview**
> **`OpenCodeSessionFactory.create()`** now retries transient provisioning failures instead of failing the whole rollout on the first error.
> 
> The factory accepts **`create_attempts`** (default 3) and **`create_backoff_s`** (default 2s, exponential `2**i`). The previous single-shot logic lives in **`_create_once`**, which still kills the sandbox on failure so retries do not leak sandboxes. Failed attempts are logged at warning level before sleep/retry; the last exception is re-raised when attempts are exhausted.
> 
> Lifecycle tests pin **`create_attempts=1`** so teardown behavior stays single-attempt; new tests cover success after flaky failures and failure after all attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34af51abc1ae03454d7eea9cb4b1b04c6f5b7b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->