### PR TITLE
Remove the nonexistent openenv[core] extra from example and test fixtures

### DIFF
--- a/examples/sophistry_bench_sprint_grpo.py
+++ b/examples/sophistry_bench_sprint_grpo.py
@@ -3,7 +3,10 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "openenv[core]",
+#     # Plain `openenv`: there is no `core` extra. The published extras are
+#     # daytona, aca, modal and inspect, and uv only warns before installing
+#     # the base package anyway, so the old spelling polluted every job log.
+#     "openenv",
 #     "trl",
 #     "datasets",
 #     "torch",
@@ -15,7 +18,7 @@
 
 Single-step env, so this is a plain prompt -> completion -> reward GRPO setup:
 no `environment_factory`/tool-calling needed. Uses `GenericEnvClient` so the
-script only depends on `openenv[core]` from PyPI, which also makes it runnable
+script only depends on `openenv` from PyPI, which also makes it runnable
 as a standalone `uv` script, including via Hugging Face Jobs:
 
     hf jobs uv run examples/sophistry_bench_sprint_grpo.py --flavor a10g-small \
@@ -26,7 +29,7 @@ Connects via a manually-built `UVProvider` + `GenericEnvClient` rather than
 (`SUPPORTS_CONCURRENT_SESSIONS = False`), and `from_env()` + `.sync()` can
 leave behind an orphaned first connection that occupies that single slot (see
 https://github.com/huggingface/OpenEnv/pull/854). Needs the `project_path`
-git-clone fix from that PR; until it's released, override the `openenv[core]`
+git-clone fix from that PR; until it's released, override the `openenv`
 dependency above with a git ref of it.
 
 Run locally:

--- a/tests/test_cli/test_push.py
+++ b/tests/test_cli/test_push.py
@@ -40,7 +40,7 @@ def _create_test_openenv_env(env_dir: Path, env_name: str = "test_env") -> None:
     pyproject_content = f"""[project]
 name = "{env_name}"
 version = "0.1.0"
-dependencies = ["openenv[core]>=0.2.0"]
+dependencies = ["openenv>=0.2.0"]
 """
     (env_dir / "pyproject.toml").write_text(pyproject_content)
 

--- a/tests/test_cli/test_validate.py
+++ b/tests/test_cli/test_validate.py
@@ -251,7 +251,7 @@ def test_validate_command_accepts_dockerfile_managed_openenv_runtime(
         'server = "server.app:main"\n'
     )
     (env_dir / "server" / "Dockerfile").write_text(
-        'RUN pip install --no-cache-dir --no-deps "openenv[core]>=0.2.2"\n'
+        'RUN pip install --no-cache-dir --no-deps "openenv>=0.2.2"\n'
     )
 
     result = runner.invoke(app, ["validate", str(env_dir), "--json"])


### PR DESCRIPTION
## Summary

`openenv[core]` is not a real extra (the published ones are `daytona`, `aca`, `modal` and `inspect`), so the spelling made `uv` and `pip` emit a warning before installing the base package anyway. This removes it from the sophistry GRPO example's inline dependencies and prose, and from two CLI test fixtures that modelled env projects with it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New environment
- [ ] Refactoring

## Alignment Checklist

Before submitting, verify:
- [x] I have read `.claude/docs/PRINCIPLES.md` and this PR aligns with our principles
- [x] I have checked `.claude/docs/INVARIANTS.md` and no invariants are violated
- [x] I have run `/pre-submit-pr` (or `bash .claude/hooks/lint.sh` and tests) and addressed all issues

## RFC Status
- [x] Not required (bug fix, docs, minor refactoring)
- [ ] RFC exists: #___
- [ ] RFC needed (will create before merge)

## Test Plan

- `PYTHONPATH=src:envs uv run pytest tests/test_cli/test_push.py tests/test_cli/test_validate.py tests/scripts/test_backfill_openenv_pypi.py -q` — 68 passed.
- The one remaining `openenv[core]` in the repo is deliberate: `tests/scripts/test_backfill_openenv_pypi.py` asserts name rewriting over historical `openenv-core` releases, which did declare a `core` extra.
- To see the warning this removes: `uv run --with "openenv[core]" python -c "import openenv"` warns `unknown extra`, plain `openenv` does not.

## Claude Code Review
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test fixture string changes only; no runtime or packaging logic is modified.
> 
> **Overview**
> Replaces **`openenv[core]`** with **`openenv`** everywhere this PR touches, because the published package has no `core` extra (only `daytona`, `aca`, `modal`, and `inspect`). **`uv`** / **`pip`** were emitting an “unknown extra” warning and still installing the base package.
> 
> Updates the sophistry GRPO example’s inline **`uv`** script dependencies and related doc text, and aligns CLI test fixtures in **`test_push.py`** and **`test_validate.py`** (`pyproject.toml` and Dockerfile **`pip install`** lines) with the correct dependency spelling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d37f6b0854fc0a9704ce7416158852a273b88c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->