### PR TITLE
opencode_env: run setup before the agent, skip verify on non-zero agent exit

### DIFF
--- a/envs/opencode_env/harness.py
+++ b/envs/opencode_env/harness.py
@@ -225,12 +225,16 @@ class OpenCodeSessionFactory(ResourceSessionFactory[OpenCodeSession]):
         task: Any,
         seed: int | None = None,
         episode_id: str | None = None,
+        start_agent: bool = True,
     ) -> OpenCodeSession:
         """Create one session, retrying with exponential backoff.
 
         Session creation spins up a sandbox, installs opencode, and starts the
         proxy + agent, the flakiest step in a rollout. Each failed attempt tears
         its own sandbox down (see :meth:`_create_once`), so a retry never leaks.
+
+        Pass ``start_agent=False`` to return before launching the agent (for
+        example to run setup first), then call ``session.start_agent()``.
         """
         import logging
         import time
@@ -239,7 +243,9 @@ class OpenCodeSessionFactory(ResourceSessionFactory[OpenCodeSession]):
         last_exc: Exception = RuntimeError("create_attempts must be >= 1")
         for i in range(self._create_attempts):
             try:
-                return self._create_once(task, seed=seed, episode_id=episode_id)
+                return self._create_once(
+                    task, seed=seed, episode_id=episode_id, start_agent=start_agent
+                )
             except Exception as exc:  # noqa: BLE001
                 last_exc = exc
                 if i + 1 < self._create_attempts:
@@ -256,6 +262,7 @@ class OpenCodeSessionFactory(ResourceSessionFactory[OpenCodeSession]):
         task: Any,
         seed: int | None = None,
         episode_id: str | None = None,
+        start_agent: bool = True,
     ) -> OpenCodeSession:
         import logging
         _log = logging.getLogger(__name__)
@@ -318,7 +325,8 @@ class OpenCodeSessionFactory(ResourceSessionFactory[OpenCodeSession]):
                 proxy_trace_path=proxy_trace_path,
                 proxy_bg_job=proxy_bg_job,
             )
-            session.start_agent()
+            if start_agent:
+                session.start_agent()
             return session
         except Exception as exc:
             _log.error("factory.create: setup failed, killing sandbox: %r", exc)

--- a/envs/opencode_env/opencode_runtime.py
+++ b/envs/opencode_env/opencode_runtime.py
@@ -124,6 +124,7 @@ def build_run_cmd(config: OpenCodeConfig) -> str:
 
     format_flag = "--format json" if config.run_format == "json" else ""
     return (
+        "set -o pipefail && "
         'export PATH="$HOME/.opencode/bin:$PATH" && '
         f"cd {workdir_path(config)} && "
         f'opencode run {format_flag} "$(cat {instruction_path(config)})" '

--- a/envs/opencode_env/server/opencode_environment.py
+++ b/envs/opencode_env/server/opencode_environment.py
@@ -333,21 +333,15 @@ class OpenCodeEnvironment(MCPEnvironment):
                 f"creating E2B sandbox (template={template or 'default'}) — "
                 "this is the slow phase (~5–60s cold, ~5s with template)"
             )
-            session = factory.create(task=opencode_task)
+            session = factory.create(task=opencode_task, start_agent=False)
             result.sandbox_id = session.sandbox.sandbox_id
             _emit(
-                f"sandbox ready: {result.sandbox_id} — agent started "
+                f"sandbox ready: {result.sandbox_id} "
                 f"({'proxy on :7000, logprobs capturing' if mode == 'transparent_proxy' else 'direct LLM, no logprobs'})"
             )
 
-            # Run setup commands one at a time, *before* the agent starts.
-            # The factory has already started the agent in start_agent()
-            # during create(); to keep the order "setup → agent → verify"
-            # we'd need to restructure. As a pragmatic compromise we run
-            # setup IMMEDIATELY after create(), which races with the agent
-            # for ~1-2s but is fine for typical pip/git/download work
-            # because opencode itself takes >=20s to make its first model
-            # call.
+            # Run setup one command at a time, before the agent starts. create()
+            # was called with start_agent=False, so the agent has not launched yet.
             for i, cmd in enumerate(setup, 1):
                 _emit(f"setup [{i}/{len(setup)}]: {cmd[:80]}")
                 cr = self._exec_command(session.sandbox, cmd, timeout=SETUP_TIMEOUT_S)
@@ -359,8 +353,9 @@ class OpenCodeEnvironment(MCPEnvironment):
                     _emit(f"setup FAILED at [{i}]: exit={cr.exit_code}")
                     break
 
-            # Block until the agent is done (or setup already failed).
+            # Setup is done and clean, so launch the agent now (deferred from create()).
             if result.error is None:
+                session.start_agent()
                 _emit(
                     f"agent running — opencode CLI in sandbox "
                     f"(timeout {int(agent_timeout_s)}s)"
@@ -370,6 +365,9 @@ class OpenCodeEnvironment(MCPEnvironment):
                         timeout_s=agent_timeout_s
                     )
                     _emit(f"agent finished: exit_code={result.agent_exit_code}")
+                    if result.agent_exit_code != 0:
+                        result.error = f"agent exited non-zero ({result.agent_exit_code})"
+                        _emit(f"agent FAILED: exit_code={result.agent_exit_code}")
                 except TimeoutError as exc:
                     result.error = f"agent timeout: {exc}"
                     _emit(f"agent TIMEOUT: {exc}")

--- a/tests/envs/test_opencode_factory_lifecycle.py
+++ b/tests/envs/test_opencode_factory_lifecycle.py
@@ -80,7 +80,7 @@ def test_create_retries_then_succeeds(monkeypatch):
     calls = {"n": 0}
     session = object()
 
-    def _flaky(task, seed=None, episode_id=None):
+    def _flaky(task, seed=None, episode_id=None, start_agent=True):
         calls["n"] += 1
         if calls["n"] < 3:
             raise RuntimeError("transient create failure")
@@ -97,7 +97,7 @@ def test_create_raises_after_exhausting_attempts(monkeypatch):
     factory = _factory(sandbox, create_attempts=3, create_backoff_s=0)
     calls = {"n": 0}
 
-    def _always_fails(task, seed=None, episode_id=None):
+    def _always_fails(task, seed=None, episode_id=None, start_agent=True):
         calls["n"] += 1
         raise RuntimeError("persistent create failure")
 


### PR DESCRIPTION
## What does this PR do?

Two usability fixes to `opencode_env`'s `run_rollout`, from review on #999.

- **Setup no longer races the agent.** `run_rollout` ran the setup commands after `create()`, which had already started the agent, so setup and the agent raced over the workspace. `create()` now takes `start_agent` (default `True`, so the loop-owning training path that calls `create()` directly is unchanged). The server passes `start_agent=False`, runs setup, then calls `session.start_agent()`, giving the correct setup then agent then verify order.
- **A failed agent is no longer scored.** A non-zero `agent_exit_code` is now treated like a timeout (sets `result.error`), so verify and reward are skipped for a crashed agent.

The same fix for `pi_env` is on #999.

AI-assisted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout ordering and reward gating in the MCP server path; default create() behavior is preserved but agent exit handling now affects whether verify runs.
> 
> **Overview**
> **`run_rollout` now runs task setup before the OpenCode agent starts**, instead of racing setup against an agent that `create()` had already launched. `OpenCodeSessionFactory.create()` gains an optional `start_agent` flag (default **true**, so direct training/harness callers are unchanged); the MCP server passes `start_agent=False`, runs each setup command, then calls `session.start_agent()`.
> 
> **Failed agent runs are no longer scored.** A non-zero `agent_exit_code` sets `result.error` (like a timeout), so verify commands and reward computation are skipped on a crashed agent.
> 
> `build_run_cmd` adds **`set -o pipefail`** so a failing `opencode` inside the `| tee` pipeline surfaces as a non-zero exit code. Factory lifecycle tests were updated for the new `start_agent` parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 800c92272587d02e59dc4add73a91468c07c7dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->